### PR TITLE
#117 complex ids

### DIFF
--- a/idealingua/idealingua-core/src/main/scala/com/github/pshirshov/izumi/idealingua/il/renderer/ILRenderer.scala
+++ b/idealingua/idealingua-core/src/main/scala/com/github/pshirshov/izumi/idealingua/il/renderer/ILRenderer.scala
@@ -105,7 +105,7 @@ class ILRenderer(domain: DomainDefinition) {
       .mkString("\n")
   }
 
-  def renderPrimitiveAggregate(aggregate: PrimitiveTuple): String = {
+  def renderPrimitiveAggregate(aggregate: IdTuple): String = {
     aggregate
       .map(render)
       .mkString("\n")
@@ -125,7 +125,7 @@ class ILRenderer(domain: DomainDefinition) {
     s"${field.name}: ${render(field.typeId)}"
   }
 
-  def render(field: PrimitiveField): String = {
+  def render(field: IdField): String = {
     s"${field.name}: ${render(field.typeId)}"
   }
 

--- a/idealingua/idealingua-core/src/main/scala/com/github/pshirshov/izumi/idealingua/translator/tocsharp/CSharpImports.scala
+++ b/idealingua/idealingua-core/src/main/scala/com/github/pshirshov/izumi/idealingua/translator/tocsharp/CSharpImports.scala
@@ -1,13 +1,12 @@
 package com.github.pshirshov.izumi.idealingua.translator.tocsharp
 
-import com.github.pshirshov.izumi.idealingua.model.common.Generic.{TList, TMap, TOption, TSet}
-import com.github.pshirshov.izumi.idealingua.model.common.{Generic, Package, Primitive, TypeId}
 import com.github.pshirshov.izumi.idealingua.model.common.TypeId._
+import com.github.pshirshov.izumi.idealingua.model.common.{Generic, Package, Primitive, TypeId}
 import com.github.pshirshov.izumi.idealingua.model.exceptions.IDLException
 import com.github.pshirshov.izumi.idealingua.model.il.ast.typed.Service.DefMethod.Output.{Algebraic, Singular, Struct}
 import com.github.pshirshov.izumi.idealingua.model.il.ast.typed.Service.DefMethod.RPCMethod
-import com.github.pshirshov.izumi.idealingua.model.il.ast.typed.{Service, TypeDef}
 import com.github.pshirshov.izumi.idealingua.model.il.ast.typed.TypeDef._
+import com.github.pshirshov.izumi.idealingua.model.il.ast.typed.{Service, TypeDef}
 import com.github.pshirshov.izumi.idealingua.model.typespace.Typespace
 import com.github.pshirshov.izumi.idealingua.translator.tocsharp.types.CSharpType
 

--- a/idealingua/idealingua-core/src/main/scala/com/github/pshirshov/izumi/idealingua/translator/tocsharp/extensions/CSharpTranslatorExtension.scala
+++ b/idealingua/idealingua-core/src/main/scala/com/github/pshirshov/izumi/idealingua/translator/tocsharp/extensions/CSharpTranslatorExtension.scala
@@ -1,12 +1,11 @@
 package com.github.pshirshov.izumi.idealingua.translator.tocsharp.extensions
 
-import com.github.pshirshov.izumi.idealingua.translator.TranslatorExtension
-import com.github.pshirshov.izumi.idealingua.translator.tocsharp.{CSTContext, CSharpImports}
-import com.github.pshirshov.izumi.idealingua.translator.tocsharp.products.CogenProduct.{EnumProduct, IdentifierProduct}
 import com.github.pshirshov.izumi.idealingua.model.il.ast.typed.TypeDef._
 import com.github.pshirshov.izumi.idealingua.model.output.Module
 import com.github.pshirshov.izumi.idealingua.model.typespace.Typespace
+import com.github.pshirshov.izumi.idealingua.translator.TranslatorExtension
 import com.github.pshirshov.izumi.idealingua.translator.tocsharp.types.CSharpClass
+import com.github.pshirshov.izumi.idealingua.translator.tocsharp.{CSTContext, CSharpImports}
 
 trait CSharpTranslatorExtension extends TranslatorExtension {
     import com.github.pshirshov.izumi.fundamentals.platform.language.Quirks._

--- a/idealingua/idealingua-core/src/main/scala/com/github/pshirshov/izumi/idealingua/translator/tocsharp/types/CSharpType.scala
+++ b/idealingua/idealingua-core/src/main/scala/com/github/pshirshov/izumi/idealingua/translator/tocsharp/types/CSharpType.scala
@@ -250,8 +250,8 @@ final case class CSharpType (
           case Primitive.TInt32 => s"int.Parse($src)"
           case Primitive.TInt64 => s"long.Parse($src)"
           case Primitive.TUUID => s"new Guid($source)"
-          case e: EnumId => s"${e.name}Helpers.From(${src})"
-          case i: IdentifierId => s"${i.name}.From(${src})"
+          case e: EnumId => s"${e.name}Helpers.From($source)"
+          case i: IdentifierId => s"${i.name}.From($source)"
           case _ => throw new IDLException(s"Should never render non int, string, or Guid types to strings. Used for type ${id.name}")
       }
     }

--- a/idealingua/idealingua-core/src/main/scala/com/github/pshirshov/izumi/idealingua/translator/totypescript/TypeScriptTranslator.scala
+++ b/idealingua/idealingua-core/src/main/scala/com/github/pshirshov/izumi/idealingua/translator/totypescript/TypeScriptTranslator.scala
@@ -275,7 +275,7 @@ class TypeScriptTranslator(ts: Typespace, extensions: Seq[TypeScriptTranslatorEx
            |    getFullClassName(): string;
            |    serialize(): string;
            |
-           |${fields.all.map(f => s"${conv.toNativeTypeName(conv.safeName(f.field.name), f.field.typeId)}: ${conv.toNativeType(f.field.typeId, ts, forSerialized = true)};").mkString("\n").shift(4)}
+           |${fields.all.map(f => s"${conv.toNativeTypeName(conv.safeName(f.field.name), f.field.typeId)}: ${conv.toNativeType(f.field.typeId, ts)};").mkString("\n").shift(4)}
            |}
          """.stripMargin
 
@@ -302,7 +302,7 @@ class TypeScriptTranslator(ts: Typespace, extensions: Seq[TypeScriptTranslatorEx
            |    }
            |
            |    public toString(): string {
-           |        const suffix = ${sortedFields.map(sf => "encodeURIComponent(this." + sf.field.name + ".toString())").mkString(" + ':' + ")};
+           |        const suffix = ${sortedFields.map(sf => "encodeURIComponent(" + conv.emitTypeAsString(s"this.${sf.field.name}", sf.field.typeId) + ")").mkString(" + ':' + ")};
            |        return '$typeName#' + suffix;
            |    }
            |

--- a/idealingua/idealingua-core/src/main/scala/com/github/pshirshov/izumi/idealingua/translator/totypescript/extensions/IntrospectionExtension.scala
+++ b/idealingua/idealingua-core/src/main/scala/com/github/pshirshov/izumi/idealingua/translator/totypescript/extensions/IntrospectionExtension.scala
@@ -1,14 +1,13 @@
 package com.github.pshirshov.izumi.idealingua.translator.totypescript.extensions
 
-import com.github.pshirshov.izumi.fundamentals.platform.language.Quirks.discard
-import com.github.pshirshov.izumi.idealingua.model.il.ast.typed.TypeDef
-import com.github.pshirshov.izumi.idealingua.translator.totypescript.TSTContext
-import com.github.pshirshov.izumi.idealingua.translator.totypescript.products.CogenProduct._
 import com.github.pshirshov.izumi.fundamentals.platform.strings.IzString._
 import com.github.pshirshov.izumi.idealingua.model.common.TypeId._
 import com.github.pshirshov.izumi.idealingua.model.common.{Generic, Primitive, TypeId}
+import com.github.pshirshov.izumi.idealingua.model.il.ast.typed.TypeDef
 import com.github.pshirshov.izumi.idealingua.model.il.ast.typed.TypeDef.{DTO, Interface}
 import com.github.pshirshov.izumi.idealingua.model.typespace.Typespace
+import com.github.pshirshov.izumi.idealingua.translator.totypescript.TSTContext
+import com.github.pshirshov.izumi.idealingua.translator.totypescript.products.CogenProduct._
 import com.github.pshirshov.izumi.idealingua.translator.totypescript.types.TypeScriptTypeConverter
 
 object IntrospectionExtension extends TypeScriptTranslatorExtension {

--- a/idealingua/idealingua-core/src/main/scala/com/github/pshirshov/izumi/idealingua/translator/totypescript/types/TypeScriptTypeConverter.scala
+++ b/idealingua/idealingua-core/src/main/scala/com/github/pshirshov/izumi/idealingua/translator/totypescript/types/TypeScriptTypeConverter.scala
@@ -24,8 +24,28 @@ class TypeScriptTypeConverter() {
       case Primitive.TDate => "Date.parse(" + value + ")"
       case Primitive.TTs => "Date.parse(" + value + ")"
       case Primitive.TTsTz => "Date.parse(" + value + ")"
+      case id: IdentifierId => s"new ${id.name}($value)"
+      case en: EnumId => s"$en[$value]"
       // TODO We do nothing for other types, should probably figure something out ...
-      case _ => value
+      case _ => throw new Exception("Unsupported area in parseTypeFromString")
+    }
+  }
+
+  def emitTypeAsString(value: String, target: TypeId): String = {
+    target match {
+      case Primitive.TBool => "(" + value + " ? 'true' : 'false')'"
+      case Primitive.TString => value
+      case Primitive.TInt8 => s"$value.toString()"
+      case Primitive.TInt16 => s"$value.toString()"
+      case Primitive.TInt32 => s"$value.toString()"
+      case Primitive.TInt64 => s"$value.toString()"
+      case Primitive.TFloat => s"$value.toString()"
+      case Primitive.TDouble => s"$value.toString()"
+      case Primitive.TUUID => value
+      case id: IdentifierId => s"$value.toString()"
+      case en: EnumId => s"$en[$value]"
+      // TODO We do nothing for other types, should probably figure something out ...
+      case _ => throw new Exception("Unsupported area in emitTypeAsString")
     }
   }
 

--- a/idealingua/idealingua-core/src/test/scala/com/github/pshirshov/izumi/idealingua/IDLTestTools.scala
+++ b/idealingua/idealingua-core/src/test/scala/com/github/pshirshov/izumi/idealingua/IDLTestTools.scala
@@ -61,13 +61,6 @@ object IDLTestTools {
 
     val classpath: String = IzJvm.safeClasspath(classLoader)
 
-    val classpathParts: Seq[String] = Seq(
-      classLoaderCp,
-      Seq(System.getProperty("java.class.path"))
-    ).flatten
-
-    val classpath = classpathParts.mkString(System.getProperty("path.separator"))
-
     val cmd = Seq(
       "scalac"
       , "-deprecation"

--- a/idealingua/idealingua-core/src/test/scala/com/github/pshirshov/izumi/idealingua/IDLTestTools.scala
+++ b/idealingua/idealingua-core/src/test/scala/com/github/pshirshov/izumi/idealingua/IDLTestTools.scala
@@ -61,6 +61,13 @@ object IDLTestTools {
 
     val classpath: String = IzJvm.safeClasspath(classLoader)
 
+    val classpathParts: Seq[String] = Seq(
+      classLoaderCp,
+      Seq(System.getProperty("java.class.path"))
+    ).flatten
+
+    val classpath = classpathParts.mkString(System.getProperty("path.separator"))
+
     val cmd = Seq(
       "scalac"
       , "-deprecation"

--- a/idealingua/idealingua-model/src/main/scala/com/github/pshirshov/izumi/idealingua/model/common/TypeId.scala
+++ b/idealingua/idealingua-model/src/main/scala/com/github/pshirshov/izumi/idealingua/model/common/TypeId.scala
@@ -98,33 +98,37 @@ object Builtin {
   final val prelude: Package = Seq.empty
 }
 
-trait Primitive extends Builtin with ScalarId {
+sealed trait Primitive extends Builtin with ScalarId {
+
+}
+
+sealed trait PrimitiveId extends Primitive {
 
 }
 
 object Primitive {
 
-  case object TBool extends Primitive {
+  case object TBool extends PrimitiveId {
     override def aliases: List[TypeName] = List("bit", "bool", "boolean")
   }
 
-  case object TString extends Primitive {
+  case object TString extends PrimitiveId {
     override def aliases: List[TypeName] = List("str", "string")
   }
 
-  case object TInt8 extends Primitive {
+  case object TInt8 extends PrimitiveId {
     override def aliases: List[TypeName] = List("i08", "byte", "int8")
   }
 
-  case object TInt16 extends Primitive {
+  case object TInt16 extends PrimitiveId {
     override def aliases: List[TypeName] = List("i16", "short", "int16")
   }
 
-  case object TInt32 extends Primitive {
+  case object TInt32 extends PrimitiveId {
     override def aliases: List[TypeName] = List("i32", "int", "int32")
   }
 
-  case object TInt64 extends Primitive {
+  case object TInt64 extends PrimitiveId {
     override def aliases: List[TypeName] = List("i64", "long", "int64")
   }
 
@@ -136,14 +140,13 @@ object Primitive {
     override def aliases: List[TypeName] = List("f64", "dbl", "double")
   }
 
-  case object TUUID extends Primitive {
+  case object TUUID extends PrimitiveId {
     override def aliases: List[TypeName] = List("uid", "uuid")
   }
 
   case object TTs extends Primitive with TimeTypeId {
     override def aliases: List[TypeName] = List("tsl", "datetimel", "dtl")
   }
-
 
   case object TTsTz extends Primitive with TimeTypeId {
     override def aliases: List[TypeName] = List("tsz", "datetimez", "dtz")
@@ -157,6 +160,18 @@ object Primitive {
     override def aliases: List[TypeName] = List("date")
   }
 
+  final val mappingId = Set(
+    TBool
+    , TString
+    , TInt8
+    , TInt16
+    , TInt32
+    , TInt64
+    , TUUID
+    ,
+  )
+    .flatMap(tpe => tpe.aliases.map(a => a -> tpe))
+    .toMap
 
   final val mapping = Set(
     TBool

--- a/idealingua/idealingua-model/src/main/scala/com/github/pshirshov/izumi/idealingua/model/il/ast/DomainDefinitionTyper.scala
+++ b/idealingua/idealingua-model/src/main/scala/com/github/pshirshov/izumi/idealingua/model/il/ast/DomainDefinitionTyper.scala
@@ -44,9 +44,9 @@ class DomainDefinitionTyper(defn: DomainDefinitionParsed) {
           case f if isIdPrimitive(f.typeId) =>
             IdField.PrimitiveField(toIdPrimitive(f.typeId), f.name)
           case f if mapping.get(toIndefinite(f.typeId)).exists(_.isInstanceOf[IdentifierId]) =>
-            IdField.SubId(fixSimpleId(makeDefinite(f.typeId)): TypeId.IdentifierId, f.name)
+            IdField.SubId(fixSimpleId(makeDefinite(f.typeId).asInstanceOf[IdentifierId]), f.name)
           case f if mapping.get(toIndefinite(f.typeId)).exists(_.isInstanceOf[EnumId]) =>
-            IdField.Enum(fixSimpleId(makeDefinite(f.typeId)): TypeId.EnumId, f.name)
+            IdField.Enum(fixSimpleId(makeDefinite(f.typeId).asInstanceOf[TypeId.EnumId]), f.name)
           case f =>
             throw new IDLException(s"Unsupporeted ID field $f in $domainId. You may use primitive fields, enums or other IDs only")
 
@@ -179,7 +179,7 @@ class DomainDefinitionTyper(defn: DomainDefinitionParsed) {
     DomainId(v.init, v.last)
   }
 
-  protected def toIdPrimitive(typeId: AbstractIndefiniteId): Primitive = {
+  protected def toIdPrimitive(typeId: AbstractIndefiniteId): PrimitiveId = {
     typeId match {
       case p if isIdPrimitive(p) =>
         Primitive.mappingId(p.name)

--- a/idealingua/idealingua-model/src/main/scala/com/github/pshirshov/izumi/idealingua/model/il/ast/DomainDefinitionTyper.scala
+++ b/idealingua/idealingua-model/src/main/scala/com/github/pshirshov/izumi/idealingua/model/il/ast/DomainDefinitionTyper.scala
@@ -107,7 +107,7 @@ class DomainDefinitionTyper(defn: DomainDefinitionParsed) {
   }
 
   protected def fixPrimitiveFields(fields: raw.RawTuple): typed.PrimitiveTuple = {
-    fields.map(f => typed.PrimitiveField(name = f.name, typeId = toPrimitive(f.typeId)))
+    fields.map(f => typed.PrimitiveField(name = f.name, typeId = toIdPrimitive(f.typeId)))
   }
 
 
@@ -141,7 +141,7 @@ class DomainDefinitionTyper(defn: DomainDefinitionParsed) {
 
   protected def makeDefinite(id: AbstractIndefiniteId): TypeId = {
     id match {
-      case p if isPrimitive(p) =>
+      case p if isIdPrimitive(p) =>
         Primitive.mapping(p.name)
 
       case g: IndefiniteGeneric =>
@@ -171,13 +171,14 @@ class DomainDefinitionTyper(defn: DomainDefinitionParsed) {
     DomainId(v.init, v.last)
   }
 
-  protected def toPrimitive(typeId: AbstractIndefiniteId): Primitive = {
+  protected def toIdPrimitive(typeId: AbstractIndefiniteId): Primitive = {
     typeId match {
-      case p if isPrimitive(p) =>
-        Primitive.mapping(p.name)
+      case p if isIdPrimitive(p) =>
+        Primitive.mappingId(p.name)
 
       case o =>
-        throw new IDLException(s"Unexpected non-primitive id in $domainId: $o")
+        import com.github.pshirshov.izumi.fundamentals.platform.strings.IzString._
+        throw new IDLException(s"The $domainId: $o; Allowed types for identifier fields: ${Primitive.mappingId.values.map(_.name).niceList()}")
     }
   }
 
@@ -335,8 +336,8 @@ class DomainDefinitionTyper(defn: DomainDefinitionParsed) {
     }
   }
 
-  protected def isPrimitive(abstractTypeId: AbstractIndefiniteId): Boolean = {
-    abstractTypeId.pkg.isEmpty && Primitive.mapping.contains(abstractTypeId.name)
+  protected def isIdPrimitive(abstractTypeId: AbstractIndefiniteId): Boolean = {
+    abstractTypeId.pkg.isEmpty && Primitive.mappingId.contains(abstractTypeId.name)
   }
 
 

--- a/idealingua/idealingua-model/src/main/scala/com/github/pshirshov/izumi/idealingua/model/il/ast/typed/Structure.scala
+++ b/idealingua/idealingua-model/src/main/scala/com/github/pshirshov/izumi/idealingua/model/il/ast/typed/Structure.scala
@@ -1,15 +1,26 @@
 package com.github.pshirshov.izumi.idealingua.model.il.ast.typed
 
-import com.github.pshirshov.izumi.idealingua.model.common.TypeId.{IdentifierId, InterfaceId}
+import com.github.pshirshov.izumi.idealingua.model.common.TypeId.{EnumId, IdentifierId, InterfaceId}
 import com.github.pshirshov.izumi.idealingua.model.common.{PrimitiveId, TypeId}
 
 final case class Field(typeId: TypeId, name: String) {
   override def toString: String = s"$name:$typeId"
 }
 
-final case class PrimitiveField(typeId: PrimitiveId, name: String)
+sealed trait IdField {
+  def name: String
+  def typeId: TypeId
+}
 
-final case class IdField(typeId: IdentifierId, name: String)
+object IdField {
+  final case class PrimitiveField(typeId: PrimitiveId, name: String) extends IdField
+
+  final case class SubId(typeId: IdentifierId, name: String)  extends IdField
+
+  final case class Enum(typeId: EnumId, name: String)  extends IdField
+}
+
+
 
 final case class SimpleStructure(concepts: Structures, fields: Tuple)
 

--- a/idealingua/idealingua-model/src/main/scala/com/github/pshirshov/izumi/idealingua/model/il/ast/typed/Structure.scala
+++ b/idealingua/idealingua-model/src/main/scala/com/github/pshirshov/izumi/idealingua/model/il/ast/typed/Structure.scala
@@ -1,6 +1,6 @@
 package com.github.pshirshov.izumi.idealingua.model.il.ast.typed
 
-import com.github.pshirshov.izumi.idealingua.model.common.TypeId.InterfaceId
+import com.github.pshirshov.izumi.idealingua.model.common.TypeId.{IdentifierId, InterfaceId}
 import com.github.pshirshov.izumi.idealingua.model.common.{PrimitiveId, TypeId}
 
 final case class Field(typeId: TypeId, name: String) {
@@ -8,6 +8,8 @@ final case class Field(typeId: TypeId, name: String) {
 }
 
 final case class PrimitiveField(typeId: PrimitiveId, name: String)
+
+final case class IdField(typeId: IdentifierId, name: String)
 
 final case class SimpleStructure(concepts: Structures, fields: Tuple)
 

--- a/idealingua/idealingua-model/src/main/scala/com/github/pshirshov/izumi/idealingua/model/il/ast/typed/Structure.scala
+++ b/idealingua/idealingua-model/src/main/scala/com/github/pshirshov/izumi/idealingua/model/il/ast/typed/Structure.scala
@@ -1,13 +1,13 @@
 package com.github.pshirshov.izumi.idealingua.model.il.ast.typed
 
-import com.github.pshirshov.izumi.idealingua.model.common.{Primitive, TypeId}
 import com.github.pshirshov.izumi.idealingua.model.common.TypeId.InterfaceId
+import com.github.pshirshov.izumi.idealingua.model.common.{PrimitiveId, TypeId}
 
 final case class Field(typeId: TypeId, name: String) {
   override def toString: String = s"$name:$typeId"
 }
 
-final case class PrimitiveField(typeId: Primitive, name: String)
+final case class PrimitiveField(typeId: PrimitiveId, name: String)
 
 final case class SimpleStructure(concepts: Structures, fields: Tuple)
 

--- a/idealingua/idealingua-model/src/main/scala/com/github/pshirshov/izumi/idealingua/model/il/ast/typed/TypeDef.scala
+++ b/idealingua/idealingua-model/src/main/scala/com/github/pshirshov/izumi/idealingua/model/il/ast/typed/TypeDef.scala
@@ -17,7 +17,7 @@ object TypeDef {
 
   final case class Adt(id: AdtId, alternatives: List[AdtMember]) extends TypeDef
 
-  final case class Identifier(id: IdentifierId, fields: PrimitiveTuple) extends TypeDef
+  final case class Identifier(id: IdentifierId, fields: PrimitiveTuple, idFields: List[IdField]) extends TypeDef
 
   sealed trait WithStructure extends TypeDef {
     def id: StructureId

--- a/idealingua/idealingua-model/src/main/scala/com/github/pshirshov/izumi/idealingua/model/il/ast/typed/TypeDef.scala
+++ b/idealingua/idealingua-model/src/main/scala/com/github/pshirshov/izumi/idealingua/model/il/ast/typed/TypeDef.scala
@@ -17,7 +17,7 @@ object TypeDef {
 
   final case class Adt(id: AdtId, alternatives: List[AdtMember]) extends TypeDef
 
-  final case class Identifier(id: IdentifierId, fields: PrimitiveTuple, idFields: List[IdField]) extends TypeDef
+  final case class Identifier(id: IdentifierId, fields: IdTuple) extends TypeDef
 
   sealed trait WithStructure extends TypeDef {
     def id: StructureId

--- a/idealingua/idealingua-model/src/main/scala/com/github/pshirshov/izumi/idealingua/model/il/ast/typed/package.scala
+++ b/idealingua/idealingua-model/src/main/scala/com/github/pshirshov/izumi/idealingua/model/il/ast/typed/package.scala
@@ -7,5 +7,5 @@ package object typed {
   type Interfaces = List[InterfaceId]
   type Structures = List[StructureId]
   type Tuple = List[Field]
-  type PrimitiveTuple = List[PrimitiveField]
+  type IdTuple = List[IdField]
 }

--- a/idealingua/idealingua-model/src/main/scala/com/github/pshirshov/izumi/idealingua/model/typespace/FieldExtractor.scala
+++ b/idealingua/idealingua-model/src/main/scala/com/github/pshirshov/izumi/idealingua/model/typespace/FieldExtractor.scala
@@ -51,7 +51,7 @@ private class FieldExtractor(resolver: TypeResolver, user: TypeId) {
     }
   }
 
-  protected def toExtendedPrimitiveFields(nextDepth: Int, fields: PrimitiveTuple, id: TypeId): List[ExtendedField] = {
+  protected def toExtendedPrimitiveFields(nextDepth: Int, fields: IdTuple, id: TypeId): List[ExtendedField] = {
     fields.zipWithIndex.map {
       case (f, idx) =>
         ExtendedField(Field(f.typeId, f.name), FieldDef(id, idx, user, nextDepth - 1))

--- a/idealingua/idealingua-model/src/main/scala/com/github/pshirshov/izumi/idealingua/model/typespace/StructuralQueriesImpl.scala
+++ b/idealingua/idealingua-model/src/main/scala/com/github/pshirshov/izumi/idealingua/model/typespace/StructuralQueriesImpl.scala
@@ -239,5 +239,3 @@ protected[typespace] class StructuralQueriesImpl(types: TypeCollection, resolver
     structure(defn).all.map(_.field).sortBy(_.name)
   }
 }
-
-

--- a/idealingua/idealingua-model/src/main/scala/com/github/pshirshov/izumi/idealingua/model/typespace/TypespaceVerifier.scala
+++ b/idealingua/idealingua-model/src/main/scala/com/github/pshirshov/izumi/idealingua/model/typespace/TypespaceVerifier.scala
@@ -54,7 +54,7 @@ object MissingDependency {
     override def toString: TypeName = s"[field $definedIn::${tpe.name} :$missing]"
   }
 
-  final case class DepPrimitiveField(definedIn: TypeId, missing: TypeId, tpe: typed.PrimitiveField) extends MissingDependency {
+  final case class DepPrimitiveField(definedIn: TypeId, missing: TypeId, tpe: typed.IdField) extends MissingDependency {
     override def toString: TypeName = s"[field $definedIn::${tpe.name} :$missing]"
   }
 

--- a/idealingua/idealingua-model/src/test/scala/com/github/pshirshov/izumi/idealingua/IdTest.scala
+++ b/idealingua/idealingua-model/src/test/scala/com/github/pshirshov/izumi/idealingua/IdTest.scala
@@ -1,0 +1,95 @@
+package com.github.pshirshov.izumi.idealingua
+
+import java.util._
+
+import com.github.pshirshov.izumi.idealingua.runtime.model._
+import org.scalatest.WordSpec
+
+class IdTest extends WordSpec {
+  import IdTest._
+
+  "Identifiers" should {
+    "support complex serialization" in {
+      val id = ComplexID(
+        BucketID(UUID.randomUUID(), UUID.randomUUID(), "test")
+        , UserWithEnumId(UUID.randomUUID(), UUID.randomUUID(), DepartmentEnum.Engineering)
+        , UUID.randomUUID()
+        , "field"
+      )
+
+      val serialized = id.toString
+      val parsed = ComplexID.parse(serialized)
+      assert(parsed == id)
+    }
+  }
+}
+
+
+object IdTest {
+  sealed trait DepartmentEnum extends IDLEnumElement
+
+  object DepartmentEnum extends IDLEnum {
+    type Element = DepartmentEnum
+    override def all: Seq[DepartmentEnum] = Seq(Engineering, Sales)
+    override def parse(value: String): DepartmentEnum = value match {
+      case "Engineering" => Engineering
+      case "Sales" => Sales
+    }
+    final case object Engineering extends DepartmentEnum { override def toString: String = "Engineering" }
+    final case object Sales extends DepartmentEnum { override def toString: String = "Sales" }
+  }
+
+
+  final case class UserWithEnumId(value: UUID, company: UUID, dept: DepartmentEnum) extends IDLGeneratedType with IDLIdentifier {
+    override def toString: String = {
+      import com.github.pshirshov.izumi.idealingua.runtime.model.IDLIdentifier._
+      val suffix = Seq(this.company, this.dept, this.value).map(part => escape(part.toString)).mkString(":")
+      s"UserWithEnumId#$suffix"
+    }
+  }
+
+  object UserWithEnumId {
+    def parse(s: String): UserWithEnumId = {
+      import com.github.pshirshov.izumi.idealingua.runtime.model.IDLIdentifier._
+      val withoutPrefix = s.substring(s.indexOf("#") + 1)
+      val parts = withoutPrefix.split(":").map(part => unescape(part))
+      UserWithEnumId(company = parsePart[UUID](parts(0), classOf[UUID]), dept = DepartmentEnum.parse(parts(1)), value = parsePart[UUID](parts(2), classOf[UUID]))
+    }
+  }
+
+
+  final case class BucketID(app: UUID, user: UUID, bucket: String) extends IDLGeneratedType with IDLIdentifier {
+    override def toString: String = {
+      import com.github.pshirshov.izumi.idealingua.runtime.model.IDLIdentifier._
+      val suffix = Seq(this.app, this.bucket, this.user).map(part => escape(part.toString)).mkString(":")
+      s"BucketID#$suffix"
+    }
+  }
+
+  object BucketID {
+    def parse(s: String): BucketID = {
+      import com.github.pshirshov.izumi.idealingua.runtime.model.IDLIdentifier._
+      val withoutPrefix = s.substring(s.indexOf("#") + 1)
+      val parts = withoutPrefix.split(":").map(part => unescape(part))
+      BucketID(app = parsePart[UUID](parts(0), classOf[UUID]), bucket = parsePart[String](parts(1), classOf[String]), user = parsePart[UUID](parts(2), classOf[UUID]))
+    }
+  }
+
+
+  final case class ComplexID(bucket: BucketID, user: UserWithEnumId, uid: UUID, str: String) extends IDLGeneratedType with IDLIdentifier {
+    override def toString: String = {
+      import com.github.pshirshov.izumi.idealingua.runtime.model.IDLIdentifier._
+      val suffix = Seq(this.bucket, this.str, this.uid, this.user).map(part => escape(part.toString)).mkString(":")
+      s"ComplexID#$suffix"
+    }
+  }
+
+  object ComplexID {
+    def parse(s: String): ComplexID = {
+      import com.github.pshirshov.izumi.idealingua.runtime.model.IDLIdentifier._
+      val withoutPrefix = s.substring(s.indexOf("#") + 1)
+      val parts = withoutPrefix.split(":").map(part => unescape(part))
+      ComplexID(bucket = BucketID.parse(parts(0)), str = parsePart[String](parts(1), classOf[String]), uid = parsePart[UUID](parts(2), classOf[UUID]), user = UserWithEnumId.parse(parts(3)))
+    }
+  }
+}

--- a/idealingua/idealingua-test-defs/src/main/resources/defs/idltest/identifiers.domain
+++ b/idealingua/idealingua-test-defs/src/main/resources/defs/idltest/identifiers.domain
@@ -16,7 +16,6 @@ id BucketID {
     bucket: str
 }
 
-/*
 enum DepartmentEnum {
     Engineering
     Sales
@@ -27,7 +26,13 @@ id UserWithEnumId {
     company: uid
     dept: DepartmentEnum
 }
-*/
+
+id ComplexID {
+    bucket: BucketID
+    user: UserWithEnumId
+    _: uid
+    _: str
+}
 
 data KVIDGeneric {
   test: map[BucketID, BucketID]

--- a/idealingua/idealingua-test-defs/src/main/resources/defs/idltest/identifiers.domain
+++ b/idealingua/idealingua-test-defs/src/main/resources/defs/idltest/identifiers.domain
@@ -30,6 +30,7 @@ id UserWithEnumId {
 id ComplexID {
     bucket: BucketID
     user: UserWithEnumId
+    _: i32
     _: uid
     _: str
 }


### PR DESCRIPTION
#117 - support for complex identifiers

1. We still use `parts.map(_.toString).map(urlencode).mkString(":")` to serialize
2. We use `Type.parse` for complex parts and continuing to use `parseParts[Scalar]` for simple parts

Go, C# and TS translators needs to be updated.