### PR TITLE
Feature/improve config error

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ including the following components:
 
 1. [Percept-plan-execute-repeat (PPER)](https://izumi.7mind.io/v0.6.0-SNAPSHOT/doc/pper/) toolchain, allowing you to model 
    very complex domains and orchestrate deadly complex processes lot easier than you get used to,
-1. [distage](https://izumi.7mind.io/v0.6.0-SNAPSHOT/doc/distage/) – Generative and introspectable runtime DI framework, 
-2. [logstage](https://izumi.7mind.io/v0.6.0-SNAPSHOT/doc/logstage/) – Effortless structured logging framework,
+1. [distage](https://izumi.7mind.io/v0.6.0-SNAPSHOT/doc/distage/) – Staged, transparent runtime Dependency Injection framework,
+2. [logstage](https://izumi.7mind.io/v0.6.0-SNAPSHOT/doc/logstage/) – Effortless Structured Logging framework,
 3. [idealingua](https://izumi.7mind.io/v0.6.0-SNAPSHOT/doc/idealingua/) – API Definition and Data Modeling language with network RPC generator targeting multiple languages, including Go, Typescript, C# and Scala,
 4. [Opinionated SBT plugins](https://izumi.7mind.io/v0.6.0-SNAPSHOT/doc/sbt/) aimed to significantly 
    increase clarity of your builds and compactify build files.

--- a/distage/distage-config/src/main/scala/com/github/pshirshov/izumi/distage/config/ConfigProvider.scala
+++ b/distage/distage-config/src/main/scala/com/github/pshirshov/izumi/distage/config/ConfigProvider.scala
@@ -27,7 +27,7 @@ class ConfigProvider(config: AppConfig, reader: RuntimeConfigReader, injectorCon
             translate(ci.imp, requirement)
           } catch {
             case NonFatal(t) =>
-              TranslationResult.Failure(ci.imp, t)
+              TranslationResult.Failure(ci.imp, config.config.origin, t)
           }
 
         case s =>
@@ -54,10 +54,6 @@ class ConfigProvider(config: AppConfig, reader: RuntimeConfigReader, injectorCon
 
     val loaded = results.collect({ case (path, scala.util.Success(value)) => (path, value) })
 
-    if (loaded.isEmpty) {
-
-    }
-
     loaded.headOption match {
       case Some((loadedPath, loadedValue)) =>
         try {
@@ -74,12 +70,12 @@ class ConfigProvider(config: AppConfig, reader: RuntimeConfigReader, injectorCon
           TranslationResult.Success(ExecutableOp.WiringOp.ReferenceInstance(step.target, Wiring.UnaryWiring.Instance(step.target.tpe, product), op.origin))
         } catch {
           case NonFatal(t) =>
-            TranslationResult.ExtractionFailure(op, step.targetType, loadedPath.toPath, loadedValue, t)
+            TranslationResult.ExtractionFailure(op, step.targetType, loadedPath.toPath, loadedValue, config.config.origin, t)
         }
 
       case None =>
         val failures = results.collect({ case (path, scala.util.Failure(f)) => (path, f) })
-        TranslationResult.MissingConfigValue(op, failures)
+        TranslationResult.MissingConfigValue(op, failures, config.config.origin)
     }
   }
 

--- a/distage/distage-config/src/main/scala/com/github/pshirshov/izumi/distage/config/ConfigReferenceExtractor.scala
+++ b/distage/distage-config/src/main/scala/com/github/pshirshov/izumi/distage/config/ConfigReferenceExtractor.scala
@@ -9,6 +9,10 @@ import com.github.pshirshov.izumi.distage.model.reflection.ReflectionProvider
 import com.github.pshirshov.izumi.distage.model.reflection.universe.RuntimeDIUniverse._
 import com.github.pshirshov.izumi.fundamentals.reflection.AnnotationTools
 
+/**
+  * Finds parameters of bindings with @Conf, @ConfPath or @AutoConf annotations and replaces their keys with Conf IdKeys
+  * To then be processed by `ConfigProvider` plan rewriter
+  */
 class ConfigReferenceExtractor(protected val reflectionProvider: ReflectionProvider.Runtime) extends PlanningHook {
 
   import u._

--- a/distage/distage-config/src/main/scala/com/github/pshirshov/izumi/distage/config/TranslationResult.scala
+++ b/distage/distage-config/src/main/scala/com/github/pshirshov/izumi/distage/config/TranslationResult.scala
@@ -3,7 +3,7 @@ package com.github.pshirshov.izumi.distage.config
 import com.github.pshirshov.izumi.distage.model.plan.ExecutableOp
 import com.github.pshirshov.izumi.distage.model.reflection.universe.RuntimeDIUniverse
 import com.github.pshirshov.izumi.distage.model.reflection.universe.RuntimeDIUniverse.SafeType
-import com.typesafe.config.ConfigValue
+import com.typesafe.config.{ConfigOrigin, ConfigValue}
 import com.github.pshirshov.izumi.fundamentals.platform.exceptions.IzThrowable._
 
 sealed trait TranslationResult
@@ -27,7 +27,7 @@ object TranslationResult {
 
   final case class Success(op: ExecutableOp) extends TranslationResult
 
-  final case class MissingConfigValue(op: ExecutableOp, paths: Seq[(ConfigPath, Throwable)]) extends TranslationFailure {
+  final case class MissingConfigValue(op: ExecutableOp, paths: Seq[(ConfigPath, Throwable)], configOrigin: ConfigOrigin) extends TranslationFailure {
     override def toString: String = {
       import com.github.pshirshov.izumi.fundamentals.platform.strings.IzString._
       val tried = paths.map {
@@ -38,16 +38,16 @@ object TranslationResult {
       val details = s"""origin: $origin
          |tried: $tried""".stripMargin.shift(4)
 
-      s"Missing config value:\n$details"
+      s"Missing config value:\n$details\nWhen reading from ConfigOrigin: $configOrigin"
     }
   }
 
-  final case class ExtractionFailure(op: ExecutableOp, tpe: SafeType, path: String, config: ConfigValue, f: Throwable) extends TranslationFailure {
-    override def toString: String = s"$origin: cannot read $tpe out of $path ==> $config: ${f.stackTrace}"
+  final case class ExtractionFailure(op: ExecutableOp, tpe: SafeType, path: String, config: ConfigValue, configOrigin: ConfigOrigin, f: Throwable) extends TranslationFailure {
+    override def toString: String = s"$origin: cannot read $tpe out of $path ==> $config: ${f.stackTrace}\nWhen reading from ConfigOrigin: $configOrigin"
   }
 
-  final case class Failure(op: ExecutableOp, f: Throwable) extends TranslationFailure {
-    override def toString: String = s"$origin: unexpected exception: ${f.stackTrace}"
+  final case class Failure(op: ExecutableOp, configOrigin: ConfigOrigin, f: Throwable) extends TranslationFailure {
+    override def toString: String = s"$origin: unexpected exception: ${f.stackTrace}\nWhen reading from ConfigOrigin: $configOrigin"
   }
 
 }

--- a/distage/distage-core/src/test/scala/com/github/pshirshov/izumi/distage/ProviderMagnetTest.scala
+++ b/distage/distage-core/src/test/scala/com/github/pshirshov/izumi/distage/ProviderMagnetTest.scala
@@ -7,33 +7,23 @@ import distage._
 import org.scalatest.WordSpec
 
 import scala.language.higherKinds
+import com.github.pshirshov.izumi.fundamentals.platform.language.Quirks._
 
 class ProviderMagnetTest extends WordSpec {
   import ProviderCase1._
 
-  def priv(@Id("locargann") x: Int): Unit = {val _ = x}
+  def priv(@Id("locargann") x: Int): Unit = x.discard
 
   val locargannfnval: Int @Id("loctypeann") => Unit = priv
   val locargannfnvalerased = priv _
 
   "Annotation extracting WrappedFunction" should {
-    "progression test: can't handle method reference vals, they lose annotation info" in {
+    "can't handle opaque function vals, that hide underlying method reference" in {
       val fn = ProviderMagnet(locargannfnvalerased).get
       assert(fn.diKeys.collect{case i: DIKey.IdKey[_] => i}.isEmpty)
 
       val fn2 = ProviderMagnet(testVal2).get
       assert(fn2.diKeys.collect{case i: DIKey.IdKey[_] => i}.isEmpty)
-    }
-
-    "progression test: can't handle curried function values" in {
-      val fn3 = ProviderMagnet(testVal3).get
-      assert(fn3.diKeys.contains(DIKey.get[Long].named("valsbtypeann1")))
-      assert(!fn3.diKeys.contains(DIKey.get[String].named("valsbtypeann2")))
-    }
-
-    "progression test: doesn't fail on conflicting annotations" in {
-      assertCompiles("ProviderMagnet.apply(defconfannfn _)")
-      assertCompiles("ProviderMagnet.apply(defconfannfn2 _)")
     }
 
     "produce correct DI keys for anonymous inline lambda" in {
@@ -83,6 +73,14 @@ class ProviderMagnetTest extends WordSpec {
       assert(fn2.diKeys contains DIKey.get[Int].named("valsigtypeann2"))
     }
 
+    "handle references with annotated type signatures, if a function value is curried, the result is the next function" in {
+      val fn = ProviderMagnet(testVal3).get
+
+      assert(fn.diKeys.contains(DIKey.get[Long].named("valsbtypeann1")))
+      assert(!fn.diKeys.contains(DIKey.get[String].named("valsbtypeann2")))
+      assert(fn.ret == SafeType.get[String @Id("valsbtypeann2") => Long])
+    }
+
     "ProviderMagnet can work with vals" in {
       def triggerConversion[R](x: ProviderMagnet[R]): Int = {val _ = x; return 5}
 
@@ -98,6 +96,13 @@ class ProviderMagnetTest extends WordSpec {
 
     "handle opaque references with argument annotations" in {
       val fn = ProviderMagnet.apply(defargannfn _).get
+
+      assert(fn.diKeys contains DIKey.get[String].named("defargann"))
+      assert(fn.diKeys contains DIKey.get[Int].named("defargann2"))
+    }
+
+    "handle opaque references with argument annotations 2" in {
+      val fn = ProviderMagnet.apply(defargannfn(_, _)).get
 
       assert(fn.diKeys contains DIKey.get[String].named("defargann"))
       assert(fn.diKeys contains DIKey.get[Int].named("defargann2"))
@@ -161,13 +166,6 @@ class ProviderMagnetTest extends WordSpec {
       assert(fn.diKeys contains DIKey.get[Int].named("classtypeann2"))
     }
 
-    "progression test: FAILS to handle case class .apply references with argument annotations" in {
-      val fn = ProviderMagnet.apply(ClassArgAnn.apply _).get
-
-      assert(!fn.diKeys.contains(DIKey.get[String].named("classargann1")))
-      assert(!fn.diKeys.contains(DIKey.get[Int].named("classargann2")))
-    }
-
     "handle case class .apply references with type annotations" in {
       val fn = ProviderMagnet.apply(ClassTypeAnn.apply _).get
 
@@ -200,6 +198,18 @@ class ProviderMagnetTest extends WordSpec {
       assertTypeError(
         """def fn[T]  = ProviderMagnet.apply((x: T @Id("gentypeann")) => x).get"""
       )
+    }
+
+    "progression test: FAILS to handle case class .apply references with argument annotations" in {
+      val fn = ProviderMagnet.apply(ClassArgAnn.apply _).get
+
+      assert(!fn.diKeys.contains(DIKey.get[String].named("classargann1")))
+      assert(!fn.diKeys.contains(DIKey.get[Int].named("classargann2")))
+    }
+
+    "progression test: doesn't fail on multiple conflicting annotations on the same parameter" in {
+      assertCompiles("ProviderMagnet.apply(defconfannfn _)")
+      assertCompiles("ProviderMagnet.apply(defconfannfn2 _)")
     }
   }
 

--- a/distage/distage-model/src/main/scala/com/github/pshirshov/izumi/distage/model/definition/ModuleDefDSL.scala
+++ b/distage/distage-model/src/main/scala/com/github/pshirshov/izumi/distage/model/definition/ModuleDefDSL.scala
@@ -323,11 +323,7 @@ object ModuleDefDSL {
       bind(ImplDef.InstanceImpl(SafeType.get[I], instance))
 
     /**
-      * See [[com.github.pshirshov.izumi.distage.model.providers.ProviderMagnet]]
-      *
-      * A function that receives its arguments from DI context, including named instances via [[Id]] annotation.
-      *
-      * Prefer passing an inline lambda such as { x => y } or a method reference such as (method _)
+      * A function that receives its arguments from DI context, including named instances via [[com.github.pshirshov.izumi.distage.model.definition.Id]] annotation.
       *
       * The following syntaxes are supported by extractor macro:
       *
@@ -344,16 +340,46 @@ object ModuleDefDSL {
       *   def constructor(@Id("special") i: Int): Unit = ()
       *
       *   make[Unit].from(constructor _)
+      *
+      *   make[Unit].from(constructor(_))
       * }}}
       *
       * Function value with annotated signature:
       * {{{
-      *   val constructor: Int @Id("special") => Unit = _ => ()
+      *   val constructor: (Int @Id("special"), String @Id("special")) => Unit = (_, _) => ()
       *
       *   make[Unit].from(constructor)
       * }}}
       *
-      * The following **IS NOT SUPPORTED**, because annotations are lost when converting a method into a function value:
+      *
+      * Annotation processing is done by a macro and macros are rarely perfect,
+      * Prefer passing an inline lambda such as { x => y } or a method reference such as (method _) or (method(_))
+      * Annotation info may be lost ONLY in a few cases detailed below, though:
+      *  - If an annotated method has been hidden by an intermediate `val`
+      *  - If an `.apply` method of a case class is passed when case class _parameters_ are annotated, not their types
+      *
+      * As such, prefer annotating parameter types, not parameters: `class X(i: Int @Id("special")) { ... }`
+      *
+      * When binding a case class to constructor, prefer passing `new X(_)` instead of `X.apply _` because `apply` will
+      * not preserve parameter annotations from case class definitions:
+      *
+      *   {{{
+      *   case class X(@Id("special") i: Int)
+      *
+      *   make[X].from(X.apply _) // summons regular Int
+      *   make[X].from(new X(_)) // summons special Int
+      *   }}}
+      *
+      * HOWEVER, if you annotate the types of parameters instead of their names, `apply` WILL work:
+      *
+      *   {{{
+      *     case class X(i: Int @Id("special"))
+      *
+      *     make[X].from(X.apply _) // summons special Int
+      *   }}}
+      *
+      * Using intermediate vals` will lose annotations when converting a method into a function value,
+      * prefer using annotated method directly as method reference `(method _)`:
       *
       *   {{{
       *   def constructorMethod(@Id("special") i: Int): Unit = ()
@@ -363,22 +389,8 @@ object ModuleDefDSL {
       *   make[Unit].from(constructor) // Will summon regular Int, not a "special" Int from DI context
       *   }}}
       *
-      * Annotations on constructor will also be lost when passing a case classes .apply method, use `new` instead.
-      *
-      * DO:
-      *   {{{
-      *   make[Abc].from(new Abc(_, _, _))
-      *   }}}
-      *
-      * DON'T:
-      *   {{{
-      *   make[Abc].from(Abc.apply _)
-      *   }}}
-      *
-      * @see [[com.github.pshirshov.izumi.distage.model.providers.ProviderMagnet]]
-      *      [[com.github.pshirshov.izumi.distage.model.reflection.macros.ProviderMagnetMacro]]
-      *
-      * */
+      * @see [[com.github.pshirshov.izumi.distage.model.reflection.macros.ProviderMagnetMacro]]
+      **/
     final def from[I <: T : Tag](f: ProviderMagnet[I]): AfterBind =
       bind(ImplDef.ProviderImpl(SafeType.get[I], f.get))
 

--- a/distage/distage-model/src/main/scala/com/github/pshirshov/izumi/distage/model/providers/ProviderMagnet.scala
+++ b/distage/distage-model/src/main/scala/com/github/pshirshov/izumi/distage/model/providers/ProviderMagnet.scala
@@ -9,58 +9,74 @@ import scala.language.implicitConversions
 import scala.language.experimental.macros
 
 /**
-* A function that receives its arguments from DI context, including named instances via [[com.github.pshirshov.izumi.distage.model.definition.Id]] annotation.
-*
-* Prefer passing an inline lambda such as { x => y } or a method reference such as (method _)
-*
-* The following syntaxes are supported by extractor macro:
-*
-* Inline lambda:
-*
-* {{{
-*   make[Unit].from {
-*     i: Int @Id("special") => ()
-*   }
-* }}}
-*
-* Method reference:
-* {{{
-*   def constructor(@Id("special") i: Int): Unit = ()
-*
-*   make[Unit].from(constructor _)
-* }}}
-*
-* Function value with annotated signature:
-* {{{
-*   val constructor: Int @Id("special") => Unit = _ => ()
-*
-*   make[Unit].from(constructor)
-* }}}
-*
-* The following **IS NOT SUPPORTED**, because annotations are lost when converting a method into a function value:
-*
-*   {{{
-*   def constructorMethod(@Id("special") i: Int): Unit = ()
-*
-*   val constructor = constructorMethod _
-*
-*   make[Unit].from(constructor) // Will summon regular Int, not a "special" Int from DI context
-*   }}}
-*
-* Annotations on constructor will also be lost when passing a case classes .apply method, use `new` instead.
-*
-* DO:
-*   {{{
-*   make[Abc].from(new Abc(_, _, _))
-*   }}}
-*
-* DON'T:
-*   {{{
-*   make[Abc].from(Abc.apply _)
-*   }}}
-*
-* @see [[com.github.pshirshov.izumi.distage.model.reflection.macros.ProviderMagnetMacro]]
-* */
+  * A function that receives its arguments from DI context, including named instances via [[com.github.pshirshov.izumi.distage.model.definition.Id]] annotation.
+  *
+  * The following syntaxes are supported by extractor macro:
+  *
+  * Inline lambda:
+  *
+  * {{{
+  *   make[Unit].from {
+  *     i: Int @Id("special") => ()
+  *   }
+  * }}}
+  *
+  * Method reference:
+  * {{{
+  *   def constructor(@Id("special") i: Int): Unit = ()
+  *
+  *   make[Unit].from(constructor _)
+  *
+  *   make[Unit].from(constructor(_))
+  * }}}
+  *
+  * Function value with annotated signature:
+  * {{{
+  *   val constructor: (Int @Id("special"), String @Id("special")) => Unit = (_, _) => ()
+  *
+  *   make[Unit].from(constructor)
+  * }}}
+  *
+  *
+  * Annotation processing is done by a macro and macros are rarely perfect,
+  * Prefer passing an inline lambda such as { x => y } or a method reference such as (method _) or (method(_))
+  * Annotation info may be lost ONLY in a few cases detailed below, though:
+  *  - If an annotated method has been hidden by an intermediate `val`
+  *  - If an `.apply` method of a case class is passed when case class _parameters_ are annotated, not their types
+  *
+  * As such, prefer annotating parameter types, not parameters: `class X(i: Int @Id("special")) { ... }`
+  *
+  * When binding a case class to constructor, prefer passing `new X(_)` instead of `X.apply _` because `apply` will
+  * not preserve parameter annotations from case class definitions:
+  *
+  *   {{{
+  *   case class X(@Id("special") i: Int)
+  *
+  *   make[X].from(X.apply _) // summons regular Int
+  *   make[X].from(new X(_)) // summons special Int
+  *   }}}
+  *
+  * HOWEVER, if you annotate the types of parameters instead of their names, `apply` WILL work:
+  *
+  *   {{{
+  *     case class X(i: Int @Id("special"))
+  *
+  *     make[X].from(X.apply _) // summons special Int
+  *   }}}
+  *
+  * Using intermediate vals` will lose annotations when converting a method into a function value,
+  * prefer using annotated method directly as method reference `(method _)`:
+  *
+  *   {{{
+  *   def constructorMethod(@Id("special") i: Int): Unit = ()
+  *
+  *   val constructor = constructorMethod _
+  *
+  *   make[Unit].from(constructor) // Will summon regular Int, not a "special" Int from DI context
+  *   }}}
+  *
+  * @see [[com.github.pshirshov.izumi.distage.model.reflection.macros.ProviderMagnetMacro]]
+  **/
 case class ProviderMagnet[+R](get: Provider)
 
 object ProviderMagnet {

--- a/doc/paradox/izumi.md
+++ b/doc/paradox/izumi.md
@@ -30,7 +30,7 @@ addSbtPlugin("com.github.pshirshov.izumi.r2" % "sbt-idealingua" % izumi_version)
 @@@
 
 
-You can use izumi's `BOM` definitions to import (it comes with the [`sbt-izumi-deps` plugin](sbt/00_sbt.md#bills-of-materials)). BOM will insert the correct version automatically:
+You can use izumi's `BOM` definitions to import (from [`sbt-izumi-deps` plugin](sbt/00_sbt.md#bills-of-materials)). BOM will insert the correct version automatically:
 
 ```scala
 libraryDependencies ++= Seq(
@@ -59,7 +59,7 @@ libraryDependencies ++= Seq(
 )
 ```
 
-Alternatively, you can list artifact names and versions manually:
+Alternatively, you can use the following artifact names and versions:
 
 @@@vars
 ```scala
@@ -90,8 +90,6 @@ libraryDependencies ++= Seq(
 You may find ScalaDoc API docs @scaladoc[here](izumi.index)
 
 You may find Izumi on github [here](https://github.com/pshirshov/izumi-r2)
-
-@@toc { depth=2 }
 
 @@@ index
 

--- a/doc/paradox/pper/00_pper.md
+++ b/doc/paradox/pper/00_pper.md
@@ -7,3 +7,6 @@ PPER Pattern
 @@@ warning { title='TODO' }
 Sorry, this page is not ready yet
 @@@
+
+"Project Networks and Percept-Plan-Execute-Repeat loop to the rescue" slides:
+https://github.com/7mind/slides/raw/master/03-pper-basics/target/pper-base.pdf


### PR DESCRIPTION
Show what config files were read on error message in `distage-config`, eg.:

```
     - aws: No configuration setting found for key 'aws'
When reading from ConfigOrigin: 
ConfigOrigin(merge of system properties,application.conf @ jar:file:
/home/kai/.coursier/v1/https/repo1.maven.org/maven2/io/findify/s3mock_2.12/0.2.5/s3mock_2.12-0.2.5.jar!/application.conf: 1)
```