### PR TITLE
Erroneous filter out of empty set binding in PluginMergeStrategy

### DIFF
--- a/distage/distage-plugins/src/test/scala/com/github/pshirshov/plugins/PluginMergeStrategyTest.scala
+++ b/distage/distage-plugins/src/test/scala/com/github/pshirshov/plugins/PluginMergeStrategyTest.scala
@@ -1,0 +1,36 @@
+package com.github.pshirshov.plugins
+
+import distage.plugins.{ConfigurablePluginMergeStrategy, PluginDef}
+import com.github.pshirshov.izumi.distage.fixtures.BasicCases._
+import com.github.pshirshov.izumi.distage.plugins.merge.ConfigurablePluginMergeStrategy.PluginMergeConfig
+import com.github.pshirshov.izumi.fundamentals.tags.TagExpr
+import distage.Injector
+import org.scalatest.WordSpec
+
+class PluginMergeStrategyTest extends WordSpec {
+
+  "Plugin merge strategy" should {
+    "Preserve empty set binding with multiple conflicting tags" in {
+      import BasicCase5._
+
+      val plugin1 = new PluginDef {
+        many[TestDependency]
+        make[TestImpl1]
+      }
+
+      val plugin2 = new PluginDef {
+        tag("bad")
+        many[TestDependency]
+          .add[TestDependency]
+      }
+
+      val mergeStrategy = new ConfigurablePluginMergeStrategy(PluginMergeConfig(
+        TagExpr.Strings.Has("bad")
+      ))
+
+      val definition = mergeStrategy.merge(Seq(plugin1, plugin2)).definition
+
+      assert(Injector().produce(definition).get[TestImpl1].justASet == Set.empty)
+    }
+  }
+}


### PR DESCRIPTION
```
Provisioner stopped after 1 instances, 1/2 operations failed: 
 - scala.collection.immutable.Set[com.github.pshirshov.izumi.distage.fixtures.BasicCases.BasicCase5.TestDependency] (PluginMergeStrategyTest.scala:18), com.github.pshirshov.izumi.distage.model.exceptions.MissingInstanceException: Instance is not available in the context: scala.collection.immutable.Set[com.github.pshirshov.izumi.distage.fixtures.BasicCases.BasicCase5.TestDependency]. required by refs: Set(com.github.pshirshov.izumi.distage.fixtures.BasicCases.BasicCase5.TestImpl1)
com.github.pshirshov.izumi.distage.model.exceptions.ProvisioningException: Provisioner stopped after 1 instances, 1/2 operations failed: 
 - scala.collection.immutable.Set[com.github.pshirshov.izumi.distage.fixtures.BasicCases.BasicCase5.TestDependency] (PluginMergeStrategyTest.scala:18), com.github.pshirshov.izumi.distage.model.exceptions.MissingInstanceException: Instance is not available in the context: scala.collection.immutable.Set[com.github.pshirshov.izumi.distage.fixtures.BasicCases.BasicCase5.TestDependency]. required by refs: Set(com.github.pshirshov.izumi.distage.fixtures.BasicCases.BasicCase5.TestImpl1)
```