### PR TITLE
Kind-inference macro for Tags

### DIFF
--- a/distage/distage-app/src/main/scala/com/github/pshirshov/izumi/distage/app/plugin/macros/StaticPluginCheckerMacro.scala
+++ b/distage/distage-app/src/main/scala/com/github/pshirshov/izumi/distage/app/plugin/macros/StaticPluginCheckerMacro.scala
@@ -206,6 +206,8 @@ object StaticPluginCheckerMacro {
       */
     def unresolvedImports: Either[Seq[ImportDependency], OrderedPlan] = {
       val nonMagicImports = plan.getImports.filter {
+        // a hack to not account for distage-config *bootstrap module*
+        // fixme: better scheme
         case ImportDependency(DIKey.IdKey(_, _: AbstractConfId), _, _) => false
         case i if i.target == DIKey.get[FactoryExecutor] => false
         case i if i.target == DIKey.get[LocatorRef] => false

--- a/distage/distage-core/src/test/scala/com/github/pshirshov/izumi/distage/ProviderMagnetTest.scala
+++ b/distage/distage-core/src/test/scala/com/github/pshirshov/izumi/distage/ProviderMagnetTest.scala
@@ -13,7 +13,7 @@ import scala.language.higherKinds
 class ProviderMagnetTest extends WordSpec {
   import ProviderCase1._
 
-  def priv(@Id("locargann") x: Int): Unit = x.discard
+  def priv(@Id("locargann") x: Int): Unit = x.discard()
 
   val locargannfnval: Int @Id("loctypeann") => Unit = priv
   val locargannfnvalerased = priv _

--- a/distage/distage-core/src/test/scala/com/github/pshirshov/izumi/distage/TagTest.scala
+++ b/distage/distage-core/src/test/scala/com/github/pshirshov/izumi/distage/TagTest.scala
@@ -87,13 +87,13 @@ class TagTest extends WordSpec with X[String] {
       assert(Tag[zy.y.type].tpe weak_<:< safe[zy.y.type])
     }
 
-    "Work for a concrete type with available TypeTag" in {
+    "Use TypeTag instance when available" in {
       val t_ = typeTag[Unit]
 
       {
         implicit val t: TypeTag[Unit] =  t_
 
-        assert(Tag[Unit].tpe == safe[Unit])
+        assert(Tag[Unit].tag eq t)
       }
     }
 
@@ -138,13 +138,6 @@ class TagTest extends WordSpec with X[String] {
       }
 
       assert(testTagK[Set, Int].tpe == safe[Set[Int]])
-    }
-
-    "scalac bug: can't find HKTag when obscured by type lambda" in {
-      assertCompiles("HKTag.unsafeFromTypeTag[{ type Arg[C] = Option[C] }]")
-      assertTypeError("HKTag.unsafeFromTypeTag[({ type l[F[_]] = HKTag[{ type Arg[C] = F[C] }] })#l[Option]]")
-//      Error:(177, 32) No TypeTag available for com.github.pshirshov.izumi.distage.model.reflection.universe.RuntimeDIUniverse.HKTag[Object{type Arg[C] = Option[C]}]
-//        HKTag.unsafeFromTypeTag[({ type l[F[_]] = HKTag[{ type Arg[C] = F[C] }] })#l[Option]]
     }
 
     "Tag.auto.T kind inference macro works for known cases" in {
@@ -256,6 +249,13 @@ class TagTest extends WordSpec with X[String] {
       type `TagK<:Dep`[K[_ <: Dep]] = HKTag[ { type Arg[A <: Dep] = K[A] } ]
 
       implicitly[`TagK<:Dep`[Trait3]].tag.tpe =:= typeOf[Trait3[Nothing]].typeConstructor
+    }
+
+    "scalac bug: can't find HKTag when obscured by type lambda" in {
+      assertCompiles("HKTag.unsafeFromTypeTag[{ type Arg[C] = Option[C] }]")
+      assertTypeError("HKTag.unsafeFromTypeTag[({ type l[F[_]] = HKTag[{ type Arg[C] = F[C] }] })#l[Option]]")
+//      Error:(177, 32) No TypeTag available for com.github.pshirshov.izumi.distage.model.reflection.universe.RuntimeDIUniverse.HKTag[Object{type Arg[C] = Option[C]}]
+//        HKTag.unsafeFromTypeTag[({ type l[F[_]] = HKTag[{ type Arg[C] = F[C] }] })#l[Option]]
     }
 
     "progression test: type tags with bounds are not currently requested by the macro" in {

--- a/distage/distage-core/src/test/scala/com/github/pshirshov/izumi/distage/TagTest.scala
+++ b/distage/distage-core/src/test/scala/com/github/pshirshov/izumi/distage/TagTest.scala
@@ -133,7 +133,7 @@ class TagTest extends WordSpec with X[String] {
 
     "Work for an abstract type with available TagK when TagK is requested through an explicit implicit" in {
       def testTagK[F[_], T: Tag](implicit ev: HKTag[{ type Arg[C] = F[C] }]) = {
-        ev.discard
+        ev.discard()
         Tag[F[T {}] {}]
       }
 
@@ -235,7 +235,7 @@ class TagTest extends WordSpec with X[String] {
 
         final val x: Tag[F[G, Either[A, B]]] = {
           implicit val g0: TagK[G] = g
-          g0.discard
+          g0.discard()
           Tag[F[G, C[A, B]]]
         }
       }

--- a/distage/distage-core/src/test/scala/com/github/pshirshov/izumi/distage/TagTest.scala
+++ b/distage/distage-core/src/test/scala/com/github/pshirshov/izumi/distage/TagTest.scala
@@ -43,6 +43,11 @@ class TagTest extends WordSpec with X[String] {
   "Tag" should {
 
     "Work for any concrete type" in {
+
+      def x[T: Tag.abc.Arg]: Option[T] = implicitly[Option[T]]
+      assert(x(Some(5)) == Some(5))
+//      assert(Tag[Tag.`asdgasdfg`.Arg[Int]].tpe == safe[Option[Int]])
+
       assert(Tag[Int].tpe == safe[Int])
       assert(Tag[Set[String]].tpe == safe[Set[String]])
       assert(Tag[Map[Boolean, Double]].tpe == safe[Map[Boolean, Double]])

--- a/distage/distage-core/src/test/scala/com/github/pshirshov/izumi/distage/TagTest.scala
+++ b/distage/distage-core/src/test/scala/com/github/pshirshov/izumi/distage/TagTest.scala
@@ -44,7 +44,7 @@ class TagTest extends WordSpec with X[String] {
 
     "Work for any concrete type" in {
 
-      def x[T: Tag.abc.Arg]: Option[T] = implicitly[Option[T]]
+      def x[T: Tag.auto.Arg]: Option[T] = implicitly[Option[T]]
       assert(x(Some(5)) == Some(5))
 //      assert(Tag[Tag.`asdgasdfg`.Arg[Int]].tpe == safe[Option[Int]])
 

--- a/distage/distage-model/src/main/scala/com/github/pshirshov/izumi/distage/model/definition/dsl/AbstractBindingDefDSL.scala
+++ b/distage/distage-model/src/main/scala/com/github/pshirshov/izumi/distage/model/definition/dsl/AbstractBindingDefDSL.scala
@@ -94,12 +94,12 @@ trait AbstractBindingDefDSL[BindDSL[_], SetDSL[_]] {
 
   /** Same as `make[T].from(implicitly[T])` **/
   final protected def addImplicit[T: Tag](implicit instance: T, pos: CodePositionMaterializer): Unit = {
-    registered(new SingletonRef(Bindings.binding(instance))).discard
+    registered(new SingletonRef(Bindings.binding(instance))).discard()
   }
 
   /** Same as `make[T].named(name).from(implicitly[T])` **/
   final protected def addImplicit[T: Tag](name: String)(implicit instance: T, pos: CodePositionMaterializer): Unit = {
-    registered(new SingletonRef(Bindings.binding(instance), mutable.Queue(SingletonInstruction.SetId(name)))).discard
+    registered(new SingletonRef(Bindings.binding(instance), mutable.Queue(SingletonInstruction.SetId(name)))).discard()
   }
 
 }

--- a/distage/distage-model/src/main/scala/com/github/pshirshov/izumi/distage/model/providers/ProviderMagnet.scala
+++ b/distage/distage-model/src/main/scala/com/github/pshirshov/izumi/distage/model/providers/ProviderMagnet.scala
@@ -1,7 +1,7 @@
 package com.github.pshirshov.izumi.distage.model.providers
 
 import com.github.pshirshov.izumi.distage.model.exceptions.TODOBindingException
-import com.github.pshirshov.izumi.distage.model.reflection.universe.RuntimeDIUniverse.{DIKey, Provider}
+import com.github.pshirshov.izumi.distage.model.reflection.universe.RuntimeDIUniverse.{DIKey, Provider, Tag, SafeType}
 import com.github.pshirshov.izumi.distage.model.reflection.macros.{ProviderMagnetMacro, ProviderMagnetMacroGenerateUnsafeWeakSafeTypes}
 import com.github.pshirshov.izumi.fundamentals.reflection.CodePositionMaterializer
 
@@ -77,7 +77,11 @@ import scala.language.experimental.macros
   *
   * @see [[com.github.pshirshov.izumi.distage.model.reflection.macros.ProviderMagnetMacro]]
   **/
-case class ProviderMagnet[+R](get: Provider)
+case class ProviderMagnet[+R](get: Provider) {
+  def map[B: Tag](f: R => B): ProviderMagnet[B] = {
+    copy[B](get.unsafeMap(SafeType.get[B], (any: Any) => f(any.asInstanceOf[R])))
+  }
+}
 
 object ProviderMagnet {
   implicit def apply[R](fun: () => R): ProviderMagnet[R] = macro ProviderMagnetMacro.impl[R]

--- a/distage/distage-model/src/main/scala/com/github/pshirshov/izumi/distage/model/reflection/universe/WithDICallable.scala
+++ b/distage/distage-model/src/main/scala/com/github/pshirshov/izumi/distage/model/reflection/universe/WithDICallable.scala
@@ -57,6 +57,7 @@ trait WithDICallable {
     def associations: Seq[Association.Parameter]
     def diKeys: Seq[DIKey] = associations.map(_.wireWith)
     def fun: Seq[Any] => Any
+    def unsafeMap(newRet: SafeType, f: Any => _): Provider
 
     override val argTypes: Seq[SafeType] = associations.map(_.wireWith.tpe)
 
@@ -75,6 +76,9 @@ trait WithDICallable {
 
       override def unsafeApply(refs: TypedRef[_]*): R =
         super.unsafeApply(refs: _*).asInstanceOf[R]
+
+      override def unsafeMap(newRet: SafeType, f: Any => _): ProviderImpl[_] =
+        copy(ret = newRet, fun = xs => f.apply(fun(xs)))
     }
 
     object ProviderImpl {
@@ -91,6 +95,9 @@ trait WithDICallable {
         override def associations: Seq[Association.Parameter] = provider.associations
         override def ret: SafeType = provider.ret
         override def fun: Seq[Any] => Any = provider.fun
+
+        override def unsafeMap(newRet: SafeType, f: Any => _): FactoryProviderImpl =
+          copy(provider = provider.unsafeMap(newRet, f))
       }
     }
 

--- a/distage/distage-roles/src/main/scala/com/github/pshirshov/izumi/distage/roles/launcher/RoleAppBootstrapStrategy.scala
+++ b/distage/distage-roles/src/main/scala/com/github/pshirshov/izumi/distage/roles/launcher/RoleAppBootstrapStrategy.scala
@@ -128,7 +128,7 @@ class RoleAppBootstrapStrategy[CommandlineConfig](
   }
 
   override def bootstrapModules(bs: LoadedPlugins, app: LoadedPlugins): Seq[BootstrapModuleDef] = {
-    bs.discard
+    bs.discard()
 
     logger.info(s"Loaded ${app.definition.bindings.size -> "app bindings"} and ${bs.definition.bindings.size -> "bootstrap bindings"}...")
 
@@ -184,8 +184,8 @@ class RoleAppBootstrapStrategy[CommandlineConfig](
   }
 
   override def appModules(bs: LoadedPlugins, app: LoadedPlugins): Seq[ModuleBase] = {
-    bs.discard
-    app.discard
+    bs.discard()
+    app.discard()
 
     val baseMod = new ModuleDef {
       make[CustomContext].from(CustomContext.empty)

--- a/distage/distage-roles/src/test/scala/com/github/pshirshov/izumi/distage/roles/launcher/test/TestService.scala
+++ b/distage/distage-roles/src/test/scala/com/github/pshirshov/izumi/distage/roles/launcher/test/TestService.scala
@@ -28,7 +28,7 @@ class TestService(
                    , notCloseable: NotCloseable
                    , val resources: Set[Resource]
                  ) extends RoleService with RoleTask {
-  notCloseable.discard
+  notCloseable.discard()
 
   override def start(): Unit = {
     logger.info(s"Test service started; $dummies, $closeables")

--- a/doc/microsite/src/main/tut/distage/00_distage.md
+++ b/doc/microsite/src/main/tut/distage/00_distage.md
@@ -329,14 +329,21 @@ Modules can abstract over arbitrary kinds - use `TagKK` to abstract over bifunct
 class BIOModule[F[_, _]: TagKK] extends ModuleDef 
 ```
 
-`TagTK` over monad transformers:
+Use `Tag.auto.T` to abstract polymorphically over any kind:
 
 ```scala
-class TransModule[F[_[_], _]: TagTK] extends ModuleDef
+class MonadTransModule[F[_[_], _]: Tag.auto.T] extends ModuleDef
 ```
 
-Adding a `Tag` for more exotic type shapes is as easy as defining a type synonym,
-consult @scaladoc[HKTag](com.github.pshirshov.izumi.fundamentals.reflection.WithTags.HKTag) docs for description
+```scala
+class TrifunctorModule[F[_, _, _]: Tag.auto.T] extends ModuleDef
+```
+
+```scala
+class EldritchModule[F[_, _[_, _], _[_[_, _], _], _, _[_[_[_]]], _, _]: Tag.auto.T] extends ModuleDef
+```
+
+consult @scaladoc[HKTag](com.github.pshirshov.izumi.fundamentals.reflection.WithTags.HKTag) docs for more details
 
 ### Plugins
 

--- a/doc/microsite/src/main/tut/distage/00_distage.md
+++ b/doc/microsite/src/main/tut/distage/00_distage.md
@@ -228,8 +228,9 @@ and make it safer and more flexible by replacing fragile wiring `import ._`'s wi
 First, the program we want to write:
 
 ```scala
-import cats.Monad
-import scala.util.Try
+import cats._
+import cats.implicits._
+import cats.tagless._
 
 import distage._
 
@@ -239,11 +240,26 @@ class Program[F[_]: TagK: Monad] extends ModuleDef {
   addImplicit[Monad[F]]
 }
 
-class TaglessProgram[F[_]: Monad](validation: Validation[F], interaction: Interaction[F]) {
-  def program = for {
-      userInput <- interaction.ask("Give me something with at least 3 chars and a number on it")
-      valid     <- (validation.minSize(userInput, 3), validation.hasNumber(userInput)).mapN(_ && _)
-      _         <- if (valid) interaction.tell("awesomesauce!") else interaction.tell(s"$userInput is not valid")
+@finalAlg
+trait Validation[F[_]] {
+  def minSize(s: String, n: Int): F[Boolean]
+  def hasNumber(s: String): F[Boolean]
+}
+
+@finalAlg
+trait Interaction[F[_]] {
+  def tell(msg: String): F[Unit]
+  def ask(prompt: String): F[String]
+}
+
+class TaglessProgram[F[_]: Monad: Validation: Interaction] {
+  def program: F[Unit] = for {
+    userInput <- Interaction[F].ask("Give me something with at least 3 chars and a number on it")
+    valid     <- (Validation[F].minSize(userInput, 3), Validation[F].hasNumber(userInput)).mapN(_ && _)
+    _         <- if (valid) 
+                    Interaction[F].tell("awesomesauce!")
+                 else 
+                    Interaction[F].tell(s"$userInput is not valid")
   } yield ()
 }
 ```
@@ -256,6 +272,8 @@ Use @scaladoc[Tag](com.github.pshirshov.izumi.fundamentals.reflection.WithTags#T
 Interpreters:
 
 ```scala
+import scala.util.Try
+
 object TryInterpreters extends ModuleDef {
   make[Validation.Handler[Try]].from(tryValidationHandler)
   make[Interaction.Handler[Try]].from(tryInteractionHandler)

--- a/fundamentals/fundamentals-reflection/src/main/scala/com/github/pshirshov/izumi/fundamentals/reflection/HKTagMaterializer.scala
+++ b/fundamentals/fundamentals-reflection/src/main/scala/com/github/pshirshov/izumi/fundamentals/reflection/HKTagMaterializer.scala
@@ -1,0 +1,11 @@
+package com.github.pshirshov.izumi.fundamentals.reflection
+
+import scala.language.experimental.macros
+
+final case class HKTagMaterializer[DIU <: WithTags with Singleton, T](value: DIU#HKTag[T]) extends AnyVal
+
+object HKTagMaterializer {
+
+  implicit def materialize[DIU <: WithTags with Singleton, T]: HKTagMaterializer[DIU, T] = macro TagMacro.fixupHKTagArgStruct[DIU, T]
+
+}

--- a/fundamentals/fundamentals-reflection/src/main/scala/com/github/pshirshov/izumi/fundamentals/reflection/SafeType0.scala
+++ b/fundamentals/fundamentals-reflection/src/main/scala/com/github/pshirshov/izumi/fundamentals/reflection/SafeType0.scala
@@ -53,8 +53,14 @@ class SafeType0[U <: SingletonUniverse](
   }
 
   // Criteria for heuristic:
-  // Is a UniqueSingleType & .sym is FreeType
+  // Is a UniqueSingleType & .sym is FreeTerm
   //  Or the same for .prefix
+  // Purpose of heuristic:
+  //  unify two different singleton values with the same name and type
+  //  and unify their children, even if they are local variables, not static objects.
+  //  We have to stoop down to string checks because scalac's `TypeTag` is not being
+  //  useful about local variable singleton's – it contains only the name of the variable
+  //  and considers it a "FreeTerm", even though it's not!
   override final def equals(obj: Any): Boolean = {
     obj match {
       case that: SafeType0[U] @unchecked =>

--- a/fundamentals/fundamentals-reflection/src/main/scala/com/github/pshirshov/izumi/fundamentals/reflection/TagMacro.scala
+++ b/fundamentals/fundamentals-reflection/src/main/scala/com/github/pshirshov/izumi/fundamentals/reflection/TagMacro.scala
@@ -312,7 +312,7 @@ class TagLambdaMacro(override val c: whitebox.Context) extends TagMacro(c) {
     val prefixTpe = c.prefix.actualType
 
     if (!(prefixTpe <:< typeOf[WithTags#TagObject])) {
-      c.abort(c.enclosingPosition, s"Tag lambda should be called only as a member of WithTags#Tag companion object")
+      c.abort(c.enclosingPosition, "Tag lambda should be called only as a member of WithTags#Tag companion object")
     }
 
     auto.tree match {

--- a/fundamentals/fundamentals-reflection/src/main/scala/com/github/pshirshov/izumi/fundamentals/reflection/TagMacro.scala
+++ b/fundamentals/fundamentals-reflection/src/main/scala/com/github/pshirshov/izumi/fundamentals/reflection/TagMacro.scala
@@ -325,8 +325,9 @@ class TagLambdaMacro(override val c: whitebox.Context) extends TagMacro(c) {
     val pos = c.macroApplication.pos
 
     val targetTpe = c.enclosingUnit.body.collect {
-      case AppliedTypeTree(t, a) if t.exists(_.pos == pos) =>
-        c.typecheck(a.head, c.TYPEmode, c.universe.definitions.NothingTpe, false, true, true).tpe
+      case AppliedTypeTree(t, arg :: _) if t.exists(_.pos == pos) =>
+        c.typecheck(arg, c.TYPEmode, c.universe.definitions.NothingTpe, silent = false, withImplicitViewsDisabled = true, withMacrosDisabled = true)
+          .tpe
     }.headOption match {
       case None =>
         c.abort(c.enclosingPosition, "Couldn't find an the type that `Tag.auto.T` macro was applied to, please make sure you use the correct syntax, as in `def tagk[F[_]: Tag.auto.T]: TagK[T] = implicitly[Tag.auto.T[F]]`")

--- a/fundamentals/fundamentals-reflection/src/main/scala/com/github/pshirshov/izumi/fundamentals/reflection/TagMacro.scala
+++ b/fundamentals/fundamentals-reflection/src/main/scala/com/github/pshirshov/izumi/fundamentals/reflection/TagMacro.scala
@@ -147,8 +147,27 @@ class TagMacro(val c: blackbox.Context) {
     tpeSymbol
   }
 
+  // TODO
   @inline
-  protected[this] def mkRefinementWithInnerType
+  protected[this] def mkRefinementWithInnerType = {
+//    val staticOwner = c.prefix.tree.symbol.owner
+//
+//    logger.log(s"staticOwner: $staticOwner")
+//
+//    val parents = List(definitions.AnyRefTpe)
+//    val mutRefinementSymbol: Symbol = newNestedSymbol(staticOwner, TypeName("<refinement>"), NoPosition, FlagsRepr(0L), isClass = true)
+//
+//    val mutArg: Symbol = newNestedSymbol(mutRefinementSymbol, TypeName("Arg"), NoPosition, FlagsRepr(0L), isClass = false)
+//    val params = kind.args.map(mkTypeParameter(mutArg, _))
+//    setInfo(mutArg, mkPolyType(tpe, params))
+//
+//    val scope = newScopeWith(mutArg)
+//
+//    setInfo[Symbol](mutRefinementSymbol, RefinedType(parents, scope, mutRefinementSymbol))
+//
+//    RefinedType(parents, scope, mutRefinementSymbol)
+  }
+
 
   @inline
   protected[this] def mkHKTagArg(tpe: c.Type, kind: Kind): Type = {
@@ -291,6 +310,12 @@ class TagLambdaMacro(override val c: whitebox.Context) extends TagMacro(c) {
     if (!(prefixTpe <:< typeOf[WithTags#TagObject])) {
       c.abort(c.enclosingPosition, s"Tag lambda should be called only as a member of WithTags#Tag companion object")
     }
+
+    val application = c.macroApplication
+    // get c.enclosingUnit + find c.macroApplication ?
+    // TODO: FIND subtree with same .pos ?
+
+    c.info(c.enclosingPosition, showCode(application), true)
 
     val q"${sigStr: String}" = kindSig.tree
 

--- a/fundamentals/fundamentals-reflection/src/main/scala/com/github/pshirshov/izumi/fundamentals/reflection/TagMaterializer.scala
+++ b/fundamentals/fundamentals-reflection/src/main/scala/com/github/pshirshov/izumi/fundamentals/reflection/TagMaterializer.scala
@@ -6,6 +6,6 @@ final case class TagMaterializer[DIU <: WithTags with Singleton, T](value: DIU#T
 
 object TagMaterializer {
 
-  implicit def materialize[DIU <: WithTags with Singleton, T]: TagMaterializer[DIU, T] = macro TagMacroImpl.impl[DIU, T]
+  implicit def materialize[DIU <: WithTags with Singleton, T]: TagMaterializer[DIU, T] = macro TagMacro.impl[DIU, T]
 
 }

--- a/fundamentals/fundamentals-reflection/src/main/scala/com/github/pshirshov/izumi/fundamentals/reflection/WithTags.scala
+++ b/fundamentals/fundamentals-reflection/src/main/scala/com/github/pshirshov/izumi/fundamentals/reflection/WithTags.scala
@@ -4,7 +4,8 @@ import com.github.pshirshov.izumi.fundamentals.reflection.ReflectionUtil.{Kind, 
 import com.github.pshirshov.izumi.fundamentals.reflection.WithTags.hktagFormat
 
 import scala.annotation.implicitNotFound
-import scala.language.higherKinds
+import scala.language.experimental.macros
+import scala.language.{dynamics, higherKinds}
 import scala.reflect.api
 import scala.reflect.api.{TypeCreator, Universe}
 
@@ -43,7 +44,10 @@ trait WithTags extends UniverseGeneric { self =>
     override def toString: String = s"Tag[${tag.tpe}]"
   }
 
-  object Tag extends LowPriorityTagInstances {
+  object Tag extends Dynamic with LowPriorityTagInstances {
+
+    def selectDynamic(kindSig: String): Any = macro TagLambdaMacro.lambdaImpl
+
     def apply[T: Tag]: Tag[T] = implicitly
 
     def apply[T](t: TypeTag[T]): Tag[T] =
@@ -245,6 +249,8 @@ trait WithTags extends UniverseGeneric { self =>
   type ScalaReflectTypeTag[T] = u.TypeTag[T]
   type ScalaReflectWeakTypeTag[T] = u.WeakTypeTag[T]
 
+  // workaround for being unable to refer to Tag object's type from a type projection (?)
+  type TagObject = Tag.type
 }
 
 object WithTags {

--- a/logstage/logstage-config-di/src/main/scala/com.github.pshirshov.izumi.logstage.distage/LogstageCodecsModule.scala
+++ b/logstage/logstage-config-di/src/main/scala/com.github.pshirshov.izumi.logstage.distage/LogstageCodecsModule.scala
@@ -55,7 +55,7 @@ trait LogstageCodecsModule extends BootstrapModuleDef {
             SafeType0.get[RenderingPolicy] -> policyCodec
           )
         }
-    }.discard
+    }.discard()
   }
 
   def bindRenderingPolicyMapper[T <: RenderingPolicy : ru.TypeTag, C: ru.TypeTag](f: C => T): Unit = {
@@ -65,7 +65,7 @@ trait LogstageCodecsModule extends BootstrapModuleDef {
           f(props)
         }
       }
-    }.discard
+    }.discard()
   }
 
 }


### PR DESCRIPTION
This makes Tags truly kind-polymorphic (template-style)

Also highlights a bug in scalac at least wrt losing real types of structural refinements when applying a type lambda.