### PR TITLE
Fixed cogen for empty services

### DIFF
--- a/idealingua/idealingua-transpilers/src/main/scala/com/github/pshirshov/izumi/idealingua/translator/toscala/ServiceRenderer.scala
+++ b/idealingua/idealingua-transpilers/src/main/scala/com/github/pshirshov/izumi/idealingua/translator/toscala/ServiceRenderer.scala
@@ -61,7 +61,7 @@ class ServiceRenderer(ctx: STContext) {
             final val serviceId: ${rt.IRTServiceId.typeName} = ${c.svcMethods.termName}.serviceId
 
             val allMethods: Map[${rt.IRTMethodId.typeName}, IRTMethodWrapper[${c.F.t}, ${c.Ctx.t}]] = {
-              Seq(..${decls.map(_.defnMethodRegistration)})
+              Seq[IRTMethodWrapper[${c.F.t}, ${c.Ctx.t}]](..${decls.map(_.defnMethodRegistration)})
                 .map(m => m.signature.id -> m)
                 .toMap
             }


### PR DESCRIPTION
If you will define service with no methods you will get follow compilation error while generating code:
for instance :

```
service YourService {
}
```
The error is:
```
 value signature is not a member of Nothing [error]     Seq().map(m => m.signature.id -> m).toMap
```
The reason is that expicit type for Seq is missed out.
![image](https://user-images.githubusercontent.com/11776895/50454932-54229980-0953-11e9-92e0-7c881a14a194.png)

Just adding follow resolves issue

![image](https://user-images.githubusercontent.com/11776895/50454968-a06dd980-0953-11e9-9a38-22d46e74d50b.png)