### PR TITLE
ESNext target

### DIFF
--- a/idealingua/idealingua-runtime-rpc-typescript/src/npmjs/tsconfig.json
+++ b/idealingua/idealingua-runtime-rpc-typescript/src/npmjs/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions" : {
     "module" : "commonjs",
-    "target" : "es5",
-    "lib" : [
-      "es6",
-      "dom"
-    ],
+    "target" : "esnext",
     "sourceMap" : true,
     "allowJs" : false,
     "moduleResolution" : "node",


### PR DESCRIPTION
According to spec, "lib" field automatically injected if not specified.
https://www.typescriptlang.org/docs/handbook/compiler-options.html