### PR TITLE
Fix IzManifest version retrieving from an artifact 

### DIFF
--- a/fundamentals/fundamentals-platform/src/main/scala/com/github/pshirshov/izumi/fundamentals/platform/resources/IzManifest.scala
+++ b/fundamentals/fundamentals-platform/src/main/scala/com/github/pshirshov/izumi/fundamentals/platform/resources/IzManifest.scala
@@ -19,6 +19,7 @@ trait IzManifest {
   val BuildSbt = "X-Build-SBT"
 
   val Version = "X-Version"
+  val ImplementationVersion = "Implementation-Version"
   val VersionJava = "Version"
   val VersionBundle = "Bundle-Version"
 
@@ -100,7 +101,7 @@ trait IzManifest {
   }
 
   protected def appVersion(mf: jar.Manifest): ArtifactVersion = {
-    getFirst(mf)(Seq(Version, VersionJava, VersionBundle)) match {
+    getFirst(mf)(Seq(Version, ImplementationVersion, VersionJava, VersionBundle)) match {
       case Some(version) =>
         ArtifactVersion(version)
       case _ =>


### PR DESCRIPTION
#536 
Some artifacts does not have 'X-Version' attribute,
so as a fallback option we search for 'Implementation-Version'.
