### PR TITLE
WIP try to catch IntegrationCheckException from inside F

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
 .hydra
 .idea
+.java-version
 *.jps
 /local.sbt
 .secrets*
-/config 
+/config
 
 secrets.tar
 build/project

--- a/distage/distage-roles/src/main/scala/com/github/pshirshov/izumi/distage/roles/services/IntegrationCheck.scala
+++ b/distage/distage-roles/src/main/scala/com/github/pshirshov/izumi/distage/roles/services/IntegrationCheck.scala
@@ -14,10 +14,10 @@ import scala.util.control.NonFatal
 trait IntegrationChecker {
   def check(integrationComponents: Set[DIKey], integrationLocator: Locator): Option[Seq[ResourceCheck.Failure]]
 
-  final def checkOrFail(integrationComponents: Set[DIKey], integrationLocator: Locator): Unit = {
-    check(integrationComponents, integrationLocator).fold(()) {
+  final def checkOrException(integrationComponents: Set[DIKey], integrationLocator: Locator): Option[IntegrationCheckException] = {
+    check(integrationComponents, integrationLocator).map {
       failures =>
-        throw new IntegrationCheckException(s"Integration check failed, failures were: ${failures.niceList()}", failures)
+        new IntegrationCheckException(s"Integration check failed, failures were: ${failures.niceList()}", failures)
     }
   }
 }

--- a/distage/distage-roles/src/main/scala/com/github/pshirshov/izumi/distage/roles/services/StartupPlanExecutor.scala
+++ b/distage/distage-roles/src/main/scala/com/github/pshirshov/izumi/distage/roles/services/StartupPlanExecutor.scala
@@ -2,13 +2,14 @@ package com.github.pshirshov.izumi.distage.roles.services
 
 import com.github.pshirshov.izumi.distage.model.monadic.DIEffect
 import com.github.pshirshov.izumi.distage.model.provisioning.PlanInterpreter.FinalizersFilter
+import com.github.pshirshov.izumi.distage.roles.services.IntegrationChecker.IntegrationCheckException
 import com.github.pshirshov.izumi.distage.roles.services.RoleAppPlanner.AppStartupPlans
 import com.github.pshirshov.izumi.fundamentals.platform.functional.Identity
 import com.github.pshirshov.izumi.logstage.api.IzLogger
 import distage.{Injector, Locator, TagK}
 
 trait StartupPlanExecutor {
-  def execute[F[_] : TagK](appPlan: AppStartupPlans, filters: StartupPlanExecutor.Filters[F])(doRun: (Locator, DIEffect[F]) => F[Unit]): Unit
+  def execute[F[_]: TagK, A](appPlan: AppStartupPlans, filters: StartupPlanExecutor.Filters[F])(doRun: (Locator, Option[IntegrationCheckException], DIEffect[F]) => F[A]): A
 }
 
 object StartupPlanExecutor {

--- a/distage/distage-roles/src/main/scala/com/github/pshirshov/izumi/distage/roles/services/StartupPlanExecutorImpl.scala
+++ b/distage/distage-roles/src/main/scala/com/github/pshirshov/izumi/distage/roles/services/StartupPlanExecutorImpl.scala
@@ -2,6 +2,8 @@ package com.github.pshirshov.izumi.distage.roles.services
 
 import com.github.pshirshov.izumi.distage.model.Locator
 import com.github.pshirshov.izumi.distage.model.monadic.{DIEffect, DIEffectRunner}
+import com.github.pshirshov.izumi.distage.model.monadic.DIEffect.syntax._
+import com.github.pshirshov.izumi.distage.roles.services.IntegrationChecker.IntegrationCheckException
 import com.github.pshirshov.izumi.distage.roles.services.RoleAppPlanner.AppStartupPlans
 import com.github.pshirshov.izumi.fundamentals.platform.functional.Identity
 import distage.{Injector, TagK}
@@ -10,25 +12,27 @@ class StartupPlanExecutorImpl(
                                injector: Injector,
                                integrationChecker: IntegrationChecker
                              ) extends StartupPlanExecutor {
-  final def execute[F[_] : TagK](appPlan: AppStartupPlans, filters: StartupPlanExecutor.Filters[F])(doRun: (Locator, DIEffect[F]) => F[Unit]): Unit = {
+  final def execute[F[_]: TagK, A](appPlan: AppStartupPlans, filters: StartupPlanExecutor.Filters[F])(doRun: (Locator, Option[IntegrationCheckException], DIEffect[F]) => F[A]): A = {
 
     injector.produceFX[Identity](appPlan.runtime, filters.filterId)
       .use {
         runtimeLocator =>
           val runner = runtimeLocator.get[DIEffectRunner[F]]
-          implicit val effect: DIEffect[F] = runtimeLocator.get[DIEffect[F]]
+          implicit val F: DIEffect[F] = runtimeLocator.get[DIEffect[F]]
 
           runner.run {
             Injector.inherit(runtimeLocator)
               .produceFX[F](appPlan.integration, filters.filterF)
               .use {
                 integrationLocator =>
-                  integrationChecker.checkOrFail(appPlan.integrationKeys, integrationLocator)
-
-
-                  Injector.inherit(integrationLocator)
-                    .produceFX[F](appPlan.app, filters.filterF)
-                    .use(doRun(_, effect))
+                  F.maybeSuspend {
+                    integrationChecker.checkOrException(appPlan.integrationKeys, integrationLocator)
+                  }.flatMap {
+                    integrationCheckResult =>
+                      Injector.inherit(integrationLocator)
+                        .produceFX[F](appPlan.app, filters.filterF)
+                        .use(doRun(_, integrationCheckResult, F))
+                  }
               }
           }
       }


### PR DESCRIPTION
to allow DIEffectRunner/BIORunner to return a decorated exception instead of original

not finished (have to expose `IO.halt` to recover original trace after `.sandbox` ._.)