### PR TITLE
Fix #551, in ConfigWriter include other plans in minimized config

### DIFF
--- a/distage/distage-model/src/main/scala/com/github/pshirshov/izumi/distage/model/plan/ExecutableOp.scala
+++ b/distage/distage-model/src/main/scala/com/github/pshirshov/izumi/distage/model/plan/ExecutableOp.scala
@@ -1,19 +1,17 @@
 package com.github.pshirshov.izumi.distage.model.plan
 
 import com.github.pshirshov.izumi.distage.model.definition.Binding
-import com.github.pshirshov.izumi.distage.model.plan
 import com.github.pshirshov.izumi.distage.model.plan.ExecutableOp.ProxyOp.MakeProxy
 import com.github.pshirshov.izumi.distage.model.reflection.universe.RuntimeDIUniverse
 import com.github.pshirshov.izumi.distage.model.reflection.universe.RuntimeDIUniverse.Wiring._
 import com.github.pshirshov.izumi.distage.model.reflection.universe.RuntimeDIUniverse._
-
 
 sealed trait ExecutableOp {
   def target: DIKey
 
   def origin: Option[Binding]
 
-  override def toString: String = new plan.OpFormatter.Impl(KeyFormatter.Full, TypeFormatter.Full).format(this)
+  override def toString: String = new OpFormatter.Impl(KeyFormatter.Full, TypeFormatter.Full).format(this)
 }
 
 object ExecutableOp {

--- a/distage/distage-model/src/main/scala/com/github/pshirshov/izumi/distage/model/plan/OpFormatter.scala
+++ b/distage/distage-model/src/main/scala/com/github/pshirshov/izumi/distage/model/plan/OpFormatter.scala
@@ -62,14 +62,14 @@ object OpFormatter {
                 case ReferenceInstance(target, wiring, origin) =>
                   val pos = formatBindingPosition(origin)
                   if (wiring.instance!=null) {
-                    s"${formatKey(target)} $pos := ${wiring.instance.getClass}#${wiring.instance.hashCode()}"
+                    s"${formatKey(target)} $pos := value ${wiring.instance.getClass.getName}#${wiring.instance.hashCode()}"
                   } else {
                     s"${formatKey(target)} $pos := null"
                   }
 
                 case ReferenceKey(target, wiring, origin) =>
                   val pos = formatBindingPosition(origin)
-                  s"${formatKey(target)} $pos := ${formatKey(wiring.key)}"
+                  s"${formatKey(target)} $pos := ref ${formatKey(wiring.key)}"
               }
           }
 

--- a/distage/distage-roles/src/test/resources/testrole00-reference.conf
+++ b/distage/distage-roles/src/test/resources/testrole00-reference.conf
@@ -6,3 +6,7 @@ testservice {
   systemPropInt: 222
   systemPropList: [1, 2, 3]
 }
+
+integrationOnlyCfg {
+  flag: false
+}

--- a/distage/distage-roles/src/test/scala/com/github/pshirshov/izumi/distage/roles/test/RoleAppTest.scala
+++ b/distage/distage-roles/src/test/scala/com/github/pshirshov/izumi/distage/roles/test/RoleAppTest.scala
@@ -1,14 +1,15 @@
 package com.github.pshirshov.izumi.distage.roles.test
 
-import java.nio.file.Paths
+import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.{Files, Paths}
 import java.util.UUID
 
 import com.github.pshirshov.izumi.distage.roles.test.fixtures.TestPlugin
 import com.github.pshirshov.izumi.fundamentals.platform.resources.ArtifactVersion
 import org.scalatest.WordSpec
 
-
-class RoleAppTest extends WordSpec with WithProperties {
+class RoleAppTest extends WordSpec
+  with WithProperties {
 
   "Role Launcher" should {
     "produce config dumps and support minimization" in {
@@ -20,10 +21,13 @@ class RoleAppTest extends WordSpec with WithProperties {
 
       val cfg1 = cfg("configwriter", version)
       val cfg2 = cfg("configwriter-minimized", version)
+      val cfg3 = cfg("testrole00-minimized", version)
 
       assert(cfg1.exists())
       assert(cfg2.exists())
+      assert(cfg3.exists())
       assert(cfg1.length() > cfg2.length())
+      assert(new String(Files.readAllBytes(cfg3.toPath), UTF_8).contains("integrationOnlyCfg"))
     }
   }
 

--- a/distage/distage-roles/src/test/scala/com/github/pshirshov/izumi/distage/roles/test/fixtures/TestPlugin.scala
+++ b/distage/distage-roles/src/test/scala/com/github/pshirshov/izumi/distage/roles/test/fixtures/TestPlugin.scala
@@ -6,6 +6,7 @@ import com.github.pshirshov.izumi.distage.model.monadic.{DIEffect, DIEffectRunne
 import com.github.pshirshov.izumi.distage.plugins.PluginDef
 import com.github.pshirshov.izumi.distage.roles.internal.{ConfigWriter, Help}
 import com.github.pshirshov.izumi.distage.roles.test.fixtures.Junk._
+import com.github.pshirshov.izumi.distage.roles.test.fixtures.TestRole00.{TestRole00Resource, TestRole00ResourceIntegrationCheck}
 import com.github.pshirshov.izumi.fundamentals.platform.resources.ArtifactVersion
 
 
@@ -31,6 +32,8 @@ class TestPlugin extends PluginDef {
   make[TestRole01[IO]]
   make[TestRole02[IO]]
 
+  make[TestRole00Resource[IO]]
+  make[TestRole00ResourceIntegrationCheck]
 
   make[NotCloseable].from[InheritedCloseable]
   make[ConfigWriter[IO]]

--- a/distage/distage-testkit/src/main/scala/com/github/pshirshov/izumi/distage/testkit/services/ExternalResourceProvider.scala
+++ b/distage/distage-testkit/src/main/scala/com/github/pshirshov/izumi/distage/testkit/services/ExternalResourceProvider.scala
@@ -128,6 +128,15 @@ object ExternalResourceProvider {
       runtimes.putIfNotExist(SafeType.getK[F], rt)
     }
 
+    /**
+     * Fake HKT to use in-place of (unknown at compile-time) user effect type
+     *
+     * NOTE: DO NOT move this into an `object` or inside `stop()`, since then
+     * scala-reflect will start generating TypeTags for it and break it. Whether or not
+     * scala-reflect generates a TypeTag for an abstract member type is inconsistent
+     * and depends on the type's placement
+     * @see TagTest "Handle abstract types instead of parameters"
+     * */
     private[Singleton] type FakeF[T]
 
     private def stop(): Unit = {
@@ -151,6 +160,7 @@ object ExternalResourceProvider {
 
           implicit val effectTagK: TagK[FakeF] = rt.fTag.asInstanceOf[TagK[FakeF]]
           Quirks.discard(effectTagK)
+          assert(!effectTagK.toString.contains("FakeF"))
 
           val effectTag = SafeType.get[DIEffect[FakeF]]
           val runnerTag = SafeType.get[DIEffectRunner[FakeF]]


### PR DESCRIPTION
* Move SemiPlan collection methods up into AbstractPlan
* add `value`, `ref` prefixes to ops in pretty printer, remove `class ` prefix in instance ops