### PR TITLE
Add a convenient dependent summoner for BIO* hierarchy.

### DIFF
--- a/fundamentals/fundamentals-bio/.jvm/src/main/scala/com/github/pshirshov/izumi/functional/bio/BIORunner.scala
+++ b/fundamentals/fundamentals-bio/.jvm/src/main/scala/com/github/pshirshov/izumi/functional/bio/BIORunner.scala
@@ -53,7 +53,7 @@ object BIORunner {
         case BIOExit.Success(value) =>
           value
 
-        case BIOExit.Error(error, trace) =>
+        case BIOExit.Error(error, _) =>
           error match {
             case t: Throwable =>
               throw t
@@ -61,7 +61,7 @@ object BIORunner {
               throw FiberFailure(Cause.fail(o))
           }
 
-        case BIOExit.Termination(compoundException, _, trace) =>
+        case BIOExit.Termination(compoundException, _, _) =>
           throw compoundException
       }
     }

--- a/fundamentals/fundamentals-bio/src/main/scala/com/github/pshirshov/izumi/functional/bio/BIO.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/com/github/pshirshov/izumi/functional/bio/BIO.scala
@@ -10,7 +10,7 @@ trait BIOFunctor[F[_, +_]] {
 }
 
 object BIOFunctor {
-  def apply[F[_, +_]: BIOFunctor]: BIOFunctor[F] = implicitly
+  @inline final def apply[F[_, +_]: BIOFunctor]: BIOFunctor[F] = implicitly
 
   // place ZIO instance at the root of hierarchy, so that it's visible when summoning any class in hierarchy
   @inline implicit final def BIOZIO[R]: BIOZio[R] = BIOZio.asInstanceOf[BIOZio[R]]
@@ -22,7 +22,7 @@ trait BIOBifunctor[F[+_, +_]] extends BIOFunctor[F] {
 }
 
 object BIOBifunctor {
-  def apply[F[+_, +_]: BIOBifunctor]: BIOBifunctor[F] = implicitly
+  @inline final def apply[F[+_, +_]: BIOBifunctor]: BIOBifunctor[F] = implicitly
 }
 
 trait BIOApplicative[F[+_, +_]] extends BIOBifunctor[F] {
@@ -49,7 +49,7 @@ trait BIOApplicative[F[+_, +_]] extends BIOBifunctor[F] {
 }
 
 object BIOApplicative {
-  def apply[F[+_, +_]: BIOApplicative]: BIOApplicative[F] = implicitly
+  @inline final def apply[F[+_, +_]: BIOApplicative]: BIOApplicative[F] = implicitly
 }
 
 trait BIOGuarantee[F[+_, +_]] extends BIOApplicative[F]  {
@@ -57,7 +57,7 @@ trait BIOGuarantee[F[+_, +_]] extends BIOApplicative[F]  {
 }
 
 object BIOGuarantee {
-  def apply[F[+_, +_]: BIOGuarantee]: BIOGuarantee[F] = implicitly
+  @inline final def apply[F[+_, +_]: BIOGuarantee]: BIOGuarantee[F] = implicitly
 }
 
 trait BIOError[F[+_ ,+_]] extends BIOGuarantee[F] {
@@ -80,7 +80,7 @@ trait BIOError[F[+_ ,+_]] extends BIOGuarantee[F] {
 }
 
 object BIOError {
-  def apply[F[+_, +_]: BIOError]: BIOError[F] = implicitly
+  @inline final def apply[F[+_, +_]: BIOError]: BIOError[F] = implicitly
 }
 
 trait BIOMonad[F[+_, +_]] extends BIOApplicative[F] {
@@ -110,7 +110,7 @@ trait BIOMonad[F[+_, +_]] extends BIOApplicative[F] {
 }
 
 object BIOMonad {
-  def apply[F[+_, +_]: BIOMonad]: BIOMonad[F] = implicitly
+  @inline final def apply[F[+_, +_]: BIOMonad]: BIOMonad[F] = implicitly
 }
 
 trait BIOBracket[F[+_, +_]] extends BIOError[F] with BIOMonad[F] {
@@ -131,7 +131,7 @@ trait BIOBracket[F[+_, +_]] extends BIOError[F] with BIOMonad[F] {
 }
 
 object BIOBracket {
-  def apply[F[+_, +_]: BIOBracket]: BIOBracket[F] = implicitly
+  @inline final def apply[F[+_, +_]: BIOBracket]: BIOBracket[F] = implicitly
 }
 
 trait BIOPanic[F[+_, +_]] extends BIOBracket[F] {
@@ -142,7 +142,7 @@ trait BIOPanic[F[+_, +_]] extends BIOBracket[F] {
 }
 
 object BIOPanic {
-  def apply[F[+_, +_]: BIOPanic]: BIOPanic[F] = implicitly
+  @inline final def apply[F[+_, +_]: BIOPanic]: BIOPanic[F] = implicitly
 }
 
 trait BIO[F[+_, +_]] extends BIOPanic[F] {
@@ -175,8 +175,8 @@ trait BIO[F[+_, +_]] extends BIOPanic[F] {
 
 object BIO
   extends BIOSyntax {
-  @inline def apply[F[+_, +_] : BIO]: BIO[F] = implicitly
+  @inline final def apply[F[+_, +_]: BIO]: BIO[F] = implicitly
 
-  @inline def apply[F[+_, +_], A](effect: => A)(implicit BIO: BIO[F]): F[Throwable, A] = BIO.syncThrowable(effect)
+  @inline final def apply[F[+_, +_], A](effect: => A)(implicit BIO: BIO[F]): F[Throwable, A] = BIO.syncThrowable(effect)
 }
 

--- a/fundamentals/fundamentals-bio/src/main/scala/com/github/pshirshov/izumi/functional/bio/BIOSyntax.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/com/github/pshirshov/izumi/functional/bio/BIOSyntax.scala
@@ -5,6 +5,19 @@ import scala.language.implicitConversions
 
 trait BIOSyntax {
 
+  /**
+   * A convenient dependent summoner for BIO* hierarchy.
+   * Auto-narrows to the most powerful available class:
+   *
+   * {{{
+   *   def y[F[+_, +_]: BIOAsync] = {
+   *     F.timeout(5.seconds)(F.forever(F.unit))
+   *   }
+   * }}}
+   *
+   * */
+  @inline final def F[F[+_, +_]](implicit F: BIOFunctor[F]): F.type = F
+
   @inline implicit final def ToFunctorOps[F[_, + _] : BIOFunctor, E, A](self: F[E, A]): BIOSyntax.BIOFunctorOps[F, E, A] = new BIOSyntax.BIOFunctorOps[F, E, A](self)
   @inline implicit final def ToBifunctorOps[F[+ _, + _] : BIOBifunctor, E, A](self: F[E, A]): BIOSyntax.BIOBifunctorOps[F, E, A] = new BIOSyntax.BIOBifunctorOps[F, E, A](self)
   @inline implicit final def ToApplicativeOps[F[+ _, + _] : BIOApplicative, E, A](self: F[E, A]): BIOSyntax.BIOApplicativeOps[F, E, A] = new BIOSyntax.BIOApplicativeOps[F, E, A](self)

--- a/fundamentals/fundamentals-bio/src/test/scala/com/github/pshirshov/izumi/fundamentals/bio/BIOSyntaxTest.scala
+++ b/fundamentals/fundamentals-bio/src/test/scala/com/github/pshirshov/izumi/fundamentals/bio/BIOSyntaxTest.scala
@@ -1,8 +1,10 @@
 package com.github.pshirshov.izumi.fundamentals.bio
 
-import com.github.pshirshov.izumi.functional.bio.BIO
 import com.github.pshirshov.izumi.functional.bio.BIO._
+import com.github.pshirshov.izumi.functional.bio.{BIO, BIOAsync, BIOFunctor, BIOMonad}
 import org.scalatest.WordSpec
+
+import scala.concurrent.duration._
 
 class BIOSyntaxTest extends WordSpec {
 
@@ -28,6 +30,22 @@ class BIOSyntaxTest extends WordSpec {
     }
 
     x[zio.IO]
+  }
+
+  "F summoner examples" in {
+    def x[F[+_, +_]: BIOMonad] = {
+      F.when(false)(F.unit)
+    }
+    def y[F[+_, +_]: BIOAsync] = {
+      F.timeout(F.forever(F.unit))(5.seconds)
+    }
+    def z[F[+_, +_]: BIOFunctor]: F[Nothing, Unit] = {
+      F.map(z[F])(_ => ())
+    }
+    lazy val a = x
+    lazy val b = y[zio.IO](_: BIOAsync[zio.IO])
+    lazy val c = z
+    lazy val _ = (a, b, c)
   }
 
 }


### PR DESCRIPTION
Auto-narrows to the most powerful available class:

```scala
def x[F[+_, +_]: BIOAsync] = {
  F.timeout(F.forever(F.unit))(5.seconds)
}
```