### PR TITLE
Move scalacOptions out of globalSettings since they can end up in the meta build

### DIFF
--- a/sbt/sbt-izumi/src/main/scala/com/github/pshirshov/izumi/sbt/plugins/optional/IzumiCompilerOptionsPlugin.scala
+++ b/sbt/sbt-izumi/src/main/scala/com/github/pshirshov/izumi/sbt/plugins/optional/IzumiCompilerOptionsPlugin.scala
@@ -5,38 +5,37 @@ import sbt.Keys.{isSnapshot, scalaOrganization, _}
 import sbt.{Def, _}
 
 object IzumiCompilerOptionsPlugin extends AutoPlugin {
-  override lazy val globalSettings: Seq[Def.Setting[_]] = Seq(
-    scalacOptions := Seq(
-      "-encoding", "UTF-8",
-      "-target:jvm-1.8",
-
-      "-language:higherKinds",
-
-      "-feature",
-      "-unchecked",
-      "-deprecation",
-      "-Xlint:_",
-    )
-
-    , javacOptions ++= Seq(
-      "-encoding", "UTF-8",
-      "-source", "1.8",
-      "-target", "1.8",
-      "-deprecation",
-      "-parameters",
-      "-Xlint:all",
-      "-XDignore.symbol.file"
-      //, "-Xdoclint:all" // causes hard to track NPEs
-    )
-  )
 
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
-    scalacOptions ++= dynamicSettings(scalaOrganization.value, scalaVersion.value, isSnapshot.value)
+    scalacOptions ++=
+      generalScalaSettings ++
+      dynamicSettings(scalaOrganization.value, scalaVersion.value, isSnapshot.value),
+    javacOptions ++= generalJavaSettings,
   )
 
   protected def dynamicSettings(scalaOrganization: String, scalaVersion: String, isSnapshot: Boolean): Seq[String] = {
     scalacOptionsVersion(scalaOrganization, scalaVersion) ++ releaseSettings(scalaVersion, isSnapshot)
   }
+
+  def generalScalaSettings: Seq[String] = Seq(
+    "-encoding", "UTF-8",
+    "-target:jvm-1.8",
+    "-language:higherKinds",
+    "-feature",
+    "-unchecked",
+    "-deprecation",
+  )
+
+  def generalJavaSettings: Seq[String] = Seq(
+    "-encoding", "UTF-8",
+    "-source", "1.8",
+    "-target", "1.8",
+    "-deprecation",
+    "-parameters",
+    "-Xlint:all",
+    "-XDignore.symbol.file"
+    //, "-Xdoclint:all" // causes hard to track NPEs
+  )
 
   protected def releaseSettings(scalaVersion: String, isSnapshot: Boolean): Seq[String] = {
     CrossVersion.partialVersion(scalaVersion) match {


### PR DESCRIPTION
When a meta build source depends on an auto-plugin project that import IzumiCompilerSettings; these settings then end up in sbt's own meta-build and cause warnings for sbt's own auto-generated imports...

```sbt
// project/plugins.sbt
dependsOn("../sdk/sdk-plugin")
```

```sbt
// sdk/sdk-plugin/build.sbt

addSbtPlugin("io.7mind.izumi" % "sbt-izumi" % "0.8.7")
```

```
./plugins.sbt:0: warning: Unused import
import _root_.sbt.plugins.IvyPlugin, _root_.sbt.plugins.JvmPlugin, _root_.sbt.plugins.CorePlugin, _root_.sbt.ScriptedPlugin, _root_.sbt.plugins.SbtPlugin, _root_.sbt.plugins.SemanticdbPlugin, _root_.sbt.plugins.JUnitXmlReportPlugin, _root_.sbt.plugins.Giter8TemplatePlugin, _root_.laughedelic.sbt.PublishMore, _root_.com.timushev.sbt.updates.UpdatesPlugin, _root_.com.typesafe.sbt.GitBranchPrompt, _root_.com.typesafe.sbt.GitPlugin, _root_.com.typesafe.sbt.GitVersioning, _root_.sbtcrossproject.CrossPlugin, _root_.com.orrsella.sbtstats.StatsPlugin, _root_.coursier.CoursierPlugin, _root_.sbtrelease.ReleasePlugin, _root_.com.github.pshirshov.izumi.sbt.plugins.IzumiBuildManifestPlugin, _root_.com.github.pshirshov.izumi.sbt.plugins.IzumiConvenienceTasksPlugin, _root_.com.github.pshirshov.izumi.sbt.plugins.IzumiDslPlugin, _root_.com.github.pshirshov.izumi.sbt.plugins.IzumiGitStampPlugin, _root_.com.github.pshirshov.izumi.sbt.plugins.IzumiInheritedTestScopesPlugin, _root_.com.github.pshirshov.izumi.sbt.plugins.IzumiPropertiesPlugin, _root_.com.github.pshirshov.izumi.sbt.plugins.IzumiResolverPlugin, _root_.com.github.pshirshov.izumi.sbt.plugins.global.IzumiImportsPlugin, _root_.com.github.pshirshov.izumi.sbt.plugins.optional.IzumiCompilerOptionsPlugin, _root_.com.github.pshirshov.izumi.sbt.plugins.optional.IzumiExposedTestScopesPlugin, _root_.com.github.pshirshov.izumi.sbt.plugins.optional.IzumiFetchPlugin, _root_.com.github.pshirshov.izumi.sbt.plugins.optional.IzumiPublishingPlugin, _root_.com.github.pshirshov.izumi.sbt.plugins.optional.IzumiTestPublishingPlugin, _root_.com.github.pshirshov.izumi.sbt.plugins.presets.IzumiEnvironmentPlugin, _root_.com.github.pshirshov.izumi.sbt.plugins.presets.IzumiGitEnvironmentPlugin, _root_.com.github.pshirshov.izumi.sbt.deps.IzumiBuildInfoPlugin, _root_.com.github.pshirshov.izumi.sbt.deps.IzumiDepsPlugin, _root_.com.github.pshirshov.izumi.sbt.deps.IzumiPlugin, _root_.org.scalastyle.sbt.ScalastylePlugin, _root_.com.typesafe.sbt.duplicates.DuplicatesFinderPlugin, _root_.scoverage.ScoverageSbtPlugin, _root_.com.typesafe.sbt.SbtPgp, _root_.sbtdirtymoney.DirtyMoneyPlugin, _root_.org.portablescala.sbtplatformdeps.PlatformDepsPlugin
```