### PR TITLE
Implicit conversions from BIOAsync/BIOFork to cats-effect Async/Concurrent

### DIFF
--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/BIOFiber.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/BIOFiber.scala
@@ -1,7 +1,7 @@
 package izumi.functional.bio
 
 import izumi.functional.bio.BIOExit.ZIOExit
-import zio.{Fiber, IO}
+import zio.{Fiber, ZIO}
 
 trait BIOFiber[F[+_, +_], +E, +A] {
   def join: F[E, A]
@@ -10,10 +10,17 @@ trait BIOFiber[F[+_, +_], +E, +A] {
 }
 
 object BIOFiber {
-  def fromZIO[E, A](f: Fiber[E, A]): BIOFiber[IO, E, A] =
-    new BIOFiber[IO, E, A] {
-      override val join: IO[E, A] = f.join
-      override val observe: IO[Nothing, BIOExit[E, A]] = f.await.map(ZIOExit.toBIOExit[E, A])
-      override def interrupt: IO[Nothing, BIOExit[E, A]] = f.interrupt.map(ZIOExit.toBIOExit[E, A])
+  def fromZIO[R, E, A](f: Fiber[E, A]): BIOFiber[ZIO[R, +?, +?], E, A] =
+    new BIOFiber[ZIO[R, +?, +?], E, A] {
+      override val join: ZIO[R, E, A] = f.join
+      override val observe: ZIO[R, Nothing, BIOExit[E, A]] = f.await.map(ZIOExit.toBIOExit[E, A])
+      override def interrupt: ZIO[R, Nothing, BIOExit[E, A]] = f.interrupt.map(ZIOExit.toBIOExit[E, A])
     }
+
+  implicit final class ToCats[F[+_, +_], A](private val bioFiber: BIOFiber[F, Throwable, A]) extends AnyVal {
+    def toCats(implicit F: BIOFunctor[F]): cats.effect.Fiber[F[Throwable, ?], A] = new cats.effect.Fiber[F[Throwable, ?], A] {
+      override def cancel: F[Throwable, Unit] = F.void(bioFiber.interrupt)
+      override def join: F[Throwable, A] = bioFiber.join
+    }
+  }
 }


### PR DESCRIPTION
* added BIOFiber.toCats
* added BIOAsync.asyncF, BIOAsync.racePair, BIOAsync.race semantic changed to first-to-terminate-is-winner
* added BIOMonad.tap, BIOMonadError.tapBoth, BIOFunctor.as,