### PR TITLE
Fix japanese typo in docs + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 What is it?
 ===========
 
-Izumi (*jap. 泉水, spring*) is a set of independent libraries and frameworks allowing you to significantly increase productivity of your Scala development.
+Izumi (*jp. 泉, spring*) is a set of independent libraries and frameworks allowing you to significantly increase productivity of your Scala development.
 
 including the following components:
 

--- a/doc/microsite/src/main/tut/izumi.md
+++ b/doc/microsite/src/main/tut/izumi.md
@@ -4,7 +4,7 @@ out: index.html
 Izumi Project
 =============
 
-Izumi *(jap. 泉水, spring)* is a set of independent libraries and frameworks allowing you to significantly increase productivity of your Scala development.
+Izumi *(jp. 泉, spring)* is a set of independent libraries and frameworks allowing you to significantly increase productivity of your Scala development.
 
 including the following components:
 


### PR DESCRIPTION
The female name 泉水 was used instead of the noun 泉 which means "spring" (both are pronounced "izumi").
See https://jisho.org/search/%E6%B3%89%E6%B0%B4 for more info.

(I also replaced "jap." with "jp." as an abbreviation of "japanese", "jap" is considered a racial slur)