### PR TITLE
Fix #374 derive higher-kinded Tags from other even-higher kinded Tags

### DIFF
--- a/distage/distage-framework/src/main/scala/izumi/distage/roles/RoleAppLauncher.scala
+++ b/distage/distage-framework/src/main/scala/izumi/distage/roles/RoleAppLauncher.scala
@@ -241,7 +241,7 @@ object RoleAppLauncher {
     override protected val shutdownStrategy: AppShutdownStrategy[F] = new CatsEffectIOShutdownStrategy(executionContext)
   }
 
-  abstract class LauncherBIO[F[+_, +_]: BIOAsync: BIOPrimitives](implicit tagK: TagK[F[Throwable, ?]]) extends RoleAppLauncherImpl[F[Throwable, ?]] {
+  abstract class LauncherBIO[F[+_, +_]: TagKK: BIOAsync: BIOPrimitives] extends RoleAppLauncherImpl[F[Throwable, ?]] {
     override protected val shutdownStrategy: AppShutdownStrategy[F[Throwable, ?]] = new BIOShutdownStrategy[F]
   }
 

--- a/distage/distage-testkit/src/main/scala/izumi/distage/testkit/DistageBioSpec.scala
+++ b/distage/distage-testkit/src/main/scala/izumi/distage/testkit/DistageBioSpec.scala
@@ -1,6 +1,6 @@
 package izumi.distage.testkit
 
-import distage.{TagK, TagKK}
+import distage.TagKK
 
 @deprecated("Use dstest", "2019/Jul/18")
-abstract class DistageBioSpec[F[_, _]](implicit val tagMonoIO: TagK[F[Throwable, ?]], implicit val tagBIO: TagKK[F]) extends DistageSpec[F[Throwable, ?]]
+abstract class DistageBioSpec[F[_, _]](implicit val tagBIO: TagKK[F]) extends DistageSpec[F[Throwable, ?]]

--- a/distage/distage-testkit/src/main/scala/izumi/distage/testkit/DistageSpec.scala
+++ b/distage/distage-testkit/src/main/scala/izumi/distage/testkit/DistageSpec.scala
@@ -5,7 +5,7 @@ import izumi.distage.testkit.services.st.adapter.DistageTestSupport
 import org.scalatest.{ScalatestSuite, WordSpecLike}
 
 @deprecated("Use dstest", "2019/Jul/18")
-abstract class DistageSpec[F[_] : TagK] extends DistageTestSupport[F] with WordSpecLike {
+abstract class DistageSpec[F[_]: TagK] extends DistageTestSupport[F] with WordSpecLike {
   override def toString: String = ScalatestSuite.suiteToString(None, this)
 }
 

--- a/distage/distage-testkit/src/main/scala/izumi/distage/testkit/services/st/dtest/DistageAbstractScalatestSpec.scala
+++ b/distage/distage-testkit/src/main/scala/izumi/distage/testkit/services/st/dtest/DistageAbstractScalatestSpec.scala
@@ -167,7 +167,6 @@ object DistageAbstractScalatestSpec {
                                                env: TestEnvironment,
                                              )(
                                                implicit override val tagBIO: TagKK[F],
-                                               val tagK: TagK[F[Throwable, *]],
                                              ) extends DISyntaxBIOBase[F] {
 
     override protected def takeAs1(fAsThrowable: ProviderMagnet[F[Throwable, _]], pos: CodePosition): Unit = {

--- a/distage/distage-testkit/src/main/scala/izumi/distage/testkit/st/adapter/specs/DistagePluginBioSpec.scala
+++ b/distage/distage-testkit/src/main/scala/izumi/distage/testkit/st/adapter/specs/DistagePluginBioSpec.scala
@@ -1,6 +1,6 @@
 package izumi.distage.testkit.st.adapter.specs
 
-import distage.{TagK, TagKK}
+import distage.TagKK
 
 @deprecated("Use dstest", "2019/Jul/18")
-abstract class DistagePluginBioSpec[F[_, _]](implicit tagMonoIO: TagK[F[Throwable, ?]], implicit val tagBIO: TagKK[F]) extends DistagePluginSpec[F[Throwable, ?]]()(tagMonoIO)
+abstract class DistagePluginBioSpec[F[_, _]](implicit val tagBIO: TagKK[F]) extends DistagePluginSpec[F[Throwable, ?]]()

--- a/distage/distage-testkit/src/main/scala/izumi/distage/testkit/st/specs/DistageBIOSpecScalatest.scala
+++ b/distage/distage-testkit/src/main/scala/izumi/distage/testkit/st/specs/DistageBIOSpecScalatest.scala
@@ -7,9 +7,11 @@ import org.scalatest.DistageScalatestTestSuiteRunner
 
 import scala.language.implicitConversions
 
-abstract class DistageBIOSpecScalatest[F[+_, +_]](implicit val tagMonoIO: TagK[F[Throwable, ?]], implicit val tagBIO: TagKK[F])
+abstract class DistageBIOSpecScalatest[F[+_, +_]](implicit val tagBIO: TagKK[F])
   extends DistageScalatestTestSuiteRunner[F[Throwable, ?]]
     with DistageAbstractScalatestSpec[F[Throwable, ?]] {
+
+  override val tagMonoIO: TagK[F[Throwable, ?]] = TagK[F[Throwable, ?]]
 
   protected implicit def convertToWordSpecStringWrapper2(s: String): DSWordSpecStringWrapper2[F] = {
     new DSWordSpecStringWrapper2(context, distageSuiteName, distageSuiteId, s, this, testEnv)

--- a/distage/distage-testkit/src/test/scala/izumi/distage/testkit/st/TestkitBIOTest.scala
+++ b/distage/distage-testkit/src/test/scala/izumi/distage/testkit/st/TestkitBIOTest.scala
@@ -6,7 +6,7 @@ import izumi.distage.testkit.services.st.adapter.DISyntaxBIO
 import izumi.distage.testkit.st.adapter.specs.DistagePluginBioSpec
 import izumi.functional.bio.{BIO, BIOError, F}
 
-abstract class TestkitBIOTest[F[+_, +_]: BIO: TagKK](implicit ev: TagK[F[Throwable, ?]]) extends DistagePluginBioSpec[F]
+abstract class TestkitBIOTest[F[+_, +_]: BIO: TagKK] extends DistagePluginBioSpec[F]
   with DISyntaxBIO[F] {
 
   override protected def pluginPackages: Seq[String] = thisPackage

--- a/fundamentals/fundamentals-reflection/src/main/scala/izumi/fundamentals/reflection/Tags.scala
+++ b/fundamentals/fundamentals-reflection/src/main/scala/izumi/fundamentals/reflection/Tags.scala
@@ -158,6 +158,10 @@ object Tags {
       override val closestClass: Class[_] = cls
     }
 
+    def appliedTagNonPos[R](tag: HKTag[_], args: List[Option[LightTypeTag]]): HKTag[R] = {
+      HKTag(tag.closestClass, tag.tag.combineNonPos(args: _*))
+    }
+
     @inline implicit final def hktagFromTagMacro[T](implicit materializer: HKTagMaterializer[T]): HKTag[T] = materializer.value
   }
 

--- a/fundamentals/fundamentals-reflection/src/main/scala/izumi/fundamentals/reflection/macrortti/RuntimeAPI.scala
+++ b/fundamentals/fundamentals-reflection/src/main/scala/izumi/fundamentals/reflection/macrortti/RuntimeAPI.scala
@@ -49,7 +49,8 @@ private[izumi] object RuntimeAPI {
       replaced
     } else {
       val out = Lambda(newParams, replaced)
-      assert(out.allArgumentsReferenced, s"bad lambda: $out, ${out.paramRefs}, ${out.referenced}")
+      //assert(out.allArgumentsReferenced, s"bad lambda: $out, ${out.paramRefs}, ${out.referenced}")
+      // such lambdas are legal: see "regression test: combine Const Lambda to TagK"
       out
     }
   }


### PR DESCRIPTION
e.g. derive TagK[F[Throwable, ?]] when TagKK[F] is in scope.