### PR TITLE
Compute hashcode only based on short type name

### DIFF
--- a/fundamentals/fundamentals-reflection/src/main/scala/izumi/fundamentals/reflection/macrortti/LightTypeTag.scala
+++ b/fundamentals/fundamentals-reflection/src/main/scala/izumi/fundamentals/reflection/macrortti/LightTypeTag.scala
@@ -140,7 +140,7 @@ abstract class LightTypeTag
   }
 
   override def hashCode(): Int = {
-    val state = Seq(ref)
+    val state = Seq(ref.shortName)
     state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
   }
 }


### PR DESCRIPTION
Because after combining higher-kinded LTTs their lambda parameter names mismatch:

`TagK[Either[Throwable, ?]]` = `%0 => Either[Throwable, 0]`
but `[F[_, _]: TagKK] => TagK[F[Throwable, ?]]` = `%1 => Either[Throwable, 1]`