### PR TITLE
distage-testkit: Restrict overloading in `in` for non-effectful tests to `Unit` & `Assertion`

### DIFF
--- a/distage/distage-testkit-scalatest/src/main/scala/izumi/distage/testkit/services/scalatest/dstest/DistageAbstractScalatestSpec.scala
+++ b/distage/distage-testkit-scalatest/src/main/scala/izumi/distage/testkit/services/scalatest/dstest/DistageAbstractScalatestSpec.scala
@@ -11,7 +11,7 @@ import izumi.distage.testkit.services.{DISyntaxBIOBase, DISyntaxBase}
 import izumi.fundamentals.platform.language.{CodePosition, CodePositionMaterializer, Quirks, unused}
 import izumi.logstage.api.{IzLogger, Log}
 import org.scalactic.source
-import org.scalatest.TestCancellation
+import org.scalatest.{Assertion, TestCancellation}
 
 import scala.language.implicitConversions
 
@@ -94,19 +94,15 @@ object DistageAbstractScalatestSpec {
       takeAny(function, pos.get)
     }
 
-    def in[T: Tag](function: T => F[_])(implicit pos: CodePositionMaterializer): Unit = {
-      takeFunIO(function, pos.get)
-    }
-
-    def in[T: Tag](function: T => _)(implicit pos: CodePositionMaterializer, dummyImplicit: DummyImplicit): Unit = {
-      takeFunAny(function, pos.get)
-    }
-
     def in(value: => F[_])(implicit pos: CodePositionMaterializer): Unit = {
       takeIO(() => value, pos.get)
     }
 
-    def in(value: => Any)(implicit pos: CodePositionMaterializer, dummyImplicit: DummyImplicit): Unit = {
+    def in(value: => Unit)(implicit pos: CodePositionMaterializer, dummyImplicit: DummyImplicit): Unit = {
+      takeAny(() => value, pos.get)
+    }
+
+    def in(value: => Assertion)(implicit pos: CodePositionMaterializer, dummyImplicit: DummyImplicit, dummyImplicit2: DummyImplicit): Unit = {
       takeAny(() => value, pos.get)
     }
 
@@ -130,7 +126,11 @@ object DistageAbstractScalatestSpec {
       takeFunIO(cancel, pos.get)
     }
 
-    def skip(@unused value: => Any)(implicit pos: CodePositionMaterializer, dummyImplicit: DummyImplicit): Unit = {
+    def skip(@unused value: => Unit)(implicit pos: CodePositionMaterializer, dummyImplicit: DummyImplicit): Unit = {
+      takeFunIO(cancel, pos.get)
+    }
+
+    def skip(@unused value: => Assertion)(implicit pos: CodePositionMaterializer, dummyImplicit: DummyImplicit, dummyImplicit2: DummyImplicit): Unit = {
       takeFunIO(cancel, pos.get)
     }
 
@@ -173,19 +173,15 @@ object DistageAbstractScalatestSpec {
       takeAny(function, pos.get)
     }
 
-    def in[T: Tag](function: T => F[_, _])(implicit pos: CodePositionMaterializer): Unit = {
-      takeFunBIO(function, pos.get)
-    }
-
-    def in[T: Tag](function: T => _)(implicit pos: CodePositionMaterializer, dummyImplicit: DummyImplicit): Unit = {
-      takeFunAny(function, pos.get)
-    }
-
     def in(value: => F[_, _])(implicit pos: CodePositionMaterializer): Unit = {
       takeBIO(() => value, pos.get)
     }
 
-    def in(value: => Any)(implicit pos: CodePositionMaterializer, dummyImplicit: DummyImplicit): Unit = {
+    def in(value: => Unit)(implicit pos: CodePositionMaterializer, dummyImplicit: DummyImplicit): Unit = {
+      takeAny(() => value, pos.get)
+    }
+
+    def in(value: => Assertion)(implicit pos: CodePositionMaterializer, dummyImplicit: DummyImplicit, dummyImplicit2: DummyImplicit): Unit = {
       takeAny(() => value, pos.get)
     }
 
@@ -209,7 +205,11 @@ object DistageAbstractScalatestSpec {
       takeFunIO(cancel, pos.get)
     }
 
-    def skip(@unused value: => Any)(implicit pos: CodePositionMaterializer, dummyImplicit: DummyImplicit): Unit = {
+    def skip(@unused value: => Unit)(implicit pos: CodePositionMaterializer, dummyImplicit: DummyImplicit): Unit = {
+      takeFunIO(cancel, pos.get)
+    }
+
+    def skip(@unused value: => Assertion)(implicit pos: CodePositionMaterializer, dummyImplicit: DummyImplicit, dummyImplicit2: DummyImplicit): Unit = {
       takeFunIO(cancel, pos.get)
     }
 

--- a/doc/microsite/src/main/tut/distage/distage-testkit.md
+++ b/doc/microsite/src/main/tut/distage/distage-testkit.md
@@ -15,24 +15,18 @@ Some example code from [distage-example](https://github.com/7mind/distage-exampl
 ```scala
 package leaderboard
 
-import com.typesafe.config.ConfigFactory
-import distage.{DIKey, Injector, ModuleDef}
-import izumi.distage.config.AppConfigModule
+import distage.{DIKey, ModuleDef}
 import izumi.distage.framework.model.PluginSource
 import izumi.distage.model.definition.Activation
 import izumi.distage.model.definition.StandardAxis.Repo
-import izumi.distage.model.plan.GCMode
 import izumi.distage.plugins.PluginConfig
 import izumi.distage.testkit.TestConfig
 import izumi.distage.testkit.scalatest.DistageBIOSpecScalatest
 import izumi.distage.testkit.services.DISyntaxZIOEnv
-import izumi.logstage.api.logger.LogRouter
 import leaderboard.model.{QueryFailure, Score, UserId, UserProfile}
-import leaderboard.plugins.{LeaderboardPlugin, ZIOPlugin}
 import leaderboard.repo.{Ladder, Profiles}
 import leaderboard.zioenv._
-import logstage.di.LogstageModule
-import zio.{IO, Task, ZIO}
+import zio.{IO, ZIO}
 
 abstract class LeaderboardTest extends DistageBIOSpecScalatest[IO] with DISyntaxZIOEnv {
   override def config = TestConfig(


### PR DESCRIPTION
And remove single-parameter function overload for `in` (an artefact, not necessary due to ProviderMagnet)