### PR TITLE
Deprecate `Injector#produceUnsafe`

### DIFF
--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/Injector.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/Injector.scala
@@ -33,8 +33,8 @@ trait Injector extends Planner with Producer {
   final def produceF[F[_]: TagK: DIEffect](input: PlannerInput): DIResourceBase[F, Locator] = {
     produceF[F](plan(input))
   }
-  final def produceF[F[_]: TagK: DIEffect](module: ModuleBase, mode: GCMode): DIResourceBase[F, Locator] = {
-    produceF[F](plan(PlannerInput(module, mode)))
+  final def produceF[F[_]: TagK: DIEffect](bindings: ModuleBase, mode: GCMode): DIResourceBase[F, Locator] = {
+    produceF[F](plan(PlannerInput(bindings, mode)))
   }
 
   /**
@@ -52,11 +52,11 @@ trait Injector extends Planner with Producer {
     *     .map(_.get[A])
     * }}}
     * */
-  final def produceGetF[F[_]: TagK: DIEffect, A: Tag](module: ModuleBase): DIResourceBase[F, A] = {
-    produceF[F](plan(PlannerInput(module, DIKey.get[A]))).map(_.get[A])
+  final def produceGetF[F[_]: TagK: DIEffect, A: Tag](bindings: ModuleBase): DIResourceBase[F, A] = {
+    produceF[F](plan(PlannerInput(bindings, DIKey.get[A]))).map(_.get[A])
   }
-  final def produceGetF[F[_]: TagK: DIEffect, A: Tag](name: String)(module: ModuleBase): DIResourceBase[F, A] = {
-    produceF[F](plan(PlannerInput(module, DIKey.get[A].named(name)))).map(_.get[A](name))
+  final def produceGetF[F[_]: TagK: DIEffect, A: Tag](name: String)(bindings: ModuleBase): DIResourceBase[F, A] = {
+    produceF[F](plan(PlannerInput(bindings, DIKey.get[A].named(name)))).map(_.get[A](name))
   }
 
   @deprecated("Use .produce(_).unsafeGet() instead", "wll be removed in 0.10.2")
@@ -65,19 +65,19 @@ trait Injector extends Planner with Producer {
   }
 
   @deprecated("Use .produce(_).unsafeGet() instead", "wll be removed in 0.10.2")
-  final def produceUnsafeF[F[_]: TagK: DIEffect](module: ModuleBase, mode: GCMode): F[Locator] = {
-    produceUnsafeF[F](plan(PlannerInput(module, mode)))
+  final def produceUnsafeF[F[_]: TagK: DIEffect](bindings: ModuleBase, mode: GCMode): F[Locator] = {
+    produceUnsafeF[F](plan(PlannerInput(bindings, mode)))
   }
 
   final def produce(input: PlannerInput): DIResourceBase[Identity, Locator] = produceF[Identity](input)
-  final def produce(module: ModuleBase, mode: GCMode): DIResourceBase[Identity, Locator] = produceF[Identity](module, mode)
+  final def produce(bindings: ModuleBase, mode: GCMode): DIResourceBase[Identity, Locator] = produceF[Identity](bindings, mode)
 
-  final def produceGet[A: Tag](module: ModuleBase): DIResourceBase[Identity, A] = produceGetF[Identity, A](module)
-  final def produceGet[A: Tag](name: String)(module: ModuleBase): DIResourceBase[Identity, A] = produceGetF[Identity, A](name)(module)
+  final def produceGet[A: Tag](bindings: ModuleBase): DIResourceBase[Identity, A] = produceGetF[Identity, A](bindings)
+  final def produceGet[A: Tag](name: String)(bindings: ModuleBase): DIResourceBase[Identity, A] = produceGetF[Identity, A](name)(bindings)
 
   @deprecated("Use .produce(_).unsafeGet() instead", "wll be removed in 0.10.2")
   final def produceUnsafe(input: PlannerInput): Locator = produceUnsafeF[Identity](input)
 
   @deprecated("Use .produce(_).unsafeGet() instead", "wll be removed in 0.10.2")
-  final def produceUnsafe(module: ModuleBase, mode: GCMode): Locator = produceUnsafeF[Identity](module, mode)
+  final def produceUnsafe(bindings: ModuleBase, mode: GCMode): Locator = produceUnsafeF[Identity](bindings, mode)
 }

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/Injector.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/Injector.scala
@@ -59,9 +59,12 @@ trait Injector extends Planner with Producer {
     produceF[F](plan(PlannerInput(module, DIKey.get[A].named(name)))).map(_.get[A](name))
   }
 
+  @deprecated("Use .produce(_).unsafeGet() instead", "wll be removed in 0.10.2")
   final def produceUnsafeF[F[_]: TagK: DIEffect](input: PlannerInput): F[Locator] = {
     produceUnsafeF[F](plan(input))
   }
+
+  @deprecated("Use .produce(_).unsafeGet() instead", "wll be removed in 0.10.2")
   final def produceUnsafeF[F[_]: TagK: DIEffect](module: ModuleBase, mode: GCMode): F[Locator] = {
     produceUnsafeF[F](plan(PlannerInput(module, mode)))
   }
@@ -72,6 +75,9 @@ trait Injector extends Planner with Producer {
   final def produceGet[A: Tag](module: ModuleBase): DIResourceBase[Identity, A] = produceGetF[Identity, A](module)
   final def produceGet[A: Tag](name: String)(module: ModuleBase): DIResourceBase[Identity, A] = produceGetF[Identity, A](name)(module)
 
+  @deprecated("Use .produce(_).unsafeGet() instead", "wll be removed in 0.10.2")
   final def produceUnsafe(input: PlannerInput): Locator = produceUnsafeF[Identity](input)
+
+  @deprecated("Use .produce(_).unsafeGet() instead", "wll be removed in 0.10.2")
   final def produceUnsafe(module: ModuleBase, mode: GCMode): Locator = produceUnsafeF[Identity](module, mode)
 }

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/Planner.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/Planner.scala
@@ -10,14 +10,14 @@ import izumi.distage.model.reflection.universe.RuntimeDIUniverse._
 trait Planner extends PlanSplittingOps {
   def plan(input: PlannerInput): OrderedPlan
 
-  final def plan(module: ModuleBase, gcMode: GCMode): OrderedPlan = {
-    plan(PlannerInput(module, gcMode))
+  final def plan(bindings: ModuleBase, gcMode: GCMode): OrderedPlan = {
+    plan(PlannerInput(bindings, gcMode))
   }
 
   // plan lifecycle
   def planNoRewrite(input: PlannerInput): OrderedPlan
 
-  def rewrite(module: ModuleBase): ModuleBase
+  def rewrite(bindings: ModuleBase): ModuleBase
 
   def prepare(input: PlannerInput): PrePlan
 

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/Producer.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/Producer.scala
@@ -21,12 +21,14 @@ trait Producer {
     produceDetailedFX[F](plan, FinalizerFilter.all[F])
   }
 
+  final def produce(plan: OrderedPlan): DIResourceBase[Identity, Locator] = produceF[Identity](plan)
+  final def produceDetailed(plan: OrderedPlan): DIResourceBase[Identity, Either[FailedProvision[Identity], Locator]] = produceDetailedF[Identity](plan)
+
+  @deprecated("Use .produce(_).unsafeGet() instead", "wll be removed in 0.10.2")
   final def produceUnsafeF[F[_]: TagK: DIEffect](plan: OrderedPlan): F[Locator] = {
     val resource = produceF[F](plan)
     resource.acquire.map(resource.extract)
   }
-
-  final def produce(plan: OrderedPlan): DIResourceBase[Identity, Locator] = produceF[Identity](plan)
-  final def produceDetailed(plan: OrderedPlan): DIResourceBase[Identity, Either[FailedProvision[Identity], Locator]] = produceDetailedF[Identity](plan)
+  @deprecated("Use .produce(_).unsafeGet() instead", "wll be removed in 0.10.2")
   final def produceUnsafe(plan: OrderedPlan): Locator = produceUnsafeF[Identity](plan)
 }

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/DIResource.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/DIResource.scala
@@ -249,6 +249,16 @@ object DIResource {
     }
   }
 
+  implicit final class DIResourceUnsafeGet[F[_], A](private val resource: DIResourceBase[F, A]) extends AnyVal {
+    /** Unsafely acquire the resource and throw away the finalizer,
+      * this will leak the resource and cause it to never be cleaned up.
+      *
+      * This function only makes sense in code examples or at top-level,
+      * please use [[DIResourceUse#use]] instead!
+      */
+    def unsafeGet()(implicit F: DIEffect[F]): F[A] = F.map(resource.acquire)(resource.extract)
+  }
+
   trait Simple[A] extends DIResource[Identity, A]
 
   trait Mutable[+A] extends DIResource.Self[Identity, A] { this: A => }

--- a/distage/distage-core/.jvm/src/test/scala/izumi/distage/gc/GcBasicTestsJvm.scala
+++ b/distage/distage-core/.jvm/src/test/scala/izumi/distage/gc/GcBasicTestsJvm.scala
@@ -22,7 +22,7 @@ class GcBasicTestsJvm extends AnyWordSpec with MkGcInjector {
         make[Trash]
       }, GCMode(DIKey.get[Circular2])))
 
-      val result = injector.produceUnsafe(plan)
+      val result = injector.produce(plan).unsafeGet()
       assert(result.find[Trash].isEmpty)
       assert(result.get[Circular1].c2 != null)
       assert(result.get[Circular2].c1 != null)
@@ -40,7 +40,7 @@ class GcBasicTestsJvm extends AnyWordSpec with MkGcInjector {
         make[App]
       }, GCMode(DIKey.get[App])))
 
-      val result = injector.produceUnsafe(plan)
+      val result = injector.produce(plan).unsafeGet()
       assert(result.get[App] != null)
     }
 
@@ -57,7 +57,7 @@ class GcBasicTestsJvm extends AnyWordSpec with MkGcInjector {
         make[S3Component]
       }, GCMode(DIKey.get[Ctx])))
 
-      val result = injector.produceUnsafe(plan)
+      val result = injector.produce(plan).unsafeGet()
       assert(result.get[Ctx].upload.client != null)
       val c1 = result.get[MkS3Client]
       val c2 = result.get[Ctx].upload.client
@@ -77,7 +77,7 @@ class GcBasicTestsJvm extends AnyWordSpec with MkGcInjector {
         make[Initiator]
       }, GCMode(DIKey.get[Ctx], DIKey.get[Initiator])))
 
-      val result = injector.produceUnsafe(plan)
+      val result = injector.produce(plan).unsafeGet()
       assert(result.get[Ctx] != null)
     }
 
@@ -93,7 +93,7 @@ class GcBasicTestsJvm extends AnyWordSpec with MkGcInjector {
         make[T2].using[Circular2]
       }, GCMode(DIKey.get[Circular2])))
 
-      val result = injector.produceUnsafe(plan)
+      val result = injector.produce(plan).unsafeGet()
       assert(result.get[Circular1].c2 != null)
       assert(result.get[Circular2].c1 != null)
       assert(result.get[Circular1].c2.isInstanceOf[Circular2])
@@ -109,7 +109,7 @@ class GcBasicTestsJvm extends AnyWordSpec with MkGcInjector {
         make[T2].from[Circular2]
       }, GCMode(DIKey.get[T1])))
 
-      val result = injector.produceUnsafe(plan)
+      val result = injector.produce(plan).unsafeGet()
       assert(result.get[T1] != null)
       assert(result.get[T2] != null)
     }
@@ -141,7 +141,7 @@ class GcBasicTestsJvm extends AnyWordSpec with MkGcInjector {
             }
         }
       }, GCMode(DIKey.get[Circular2])))
-      val result = injector.produceUnsafe(plan)
+      val result = injector.produce(plan).unsafeGet()
       assert(result.get[Circular1].nothing == 1)
       assert(result.get[Circular2].nothing == 2)
       assert(result.get[Circular1].c2.nothing == 2)
@@ -157,7 +157,7 @@ class GcBasicTestsJvm extends AnyWordSpec with MkGcInjector {
         make[Circular2]
       }, GCMode(DIKey.get[Circular2])))
 
-      val result = injector.produceUnsafe(plan)
+      val result = injector.produce(plan).unsafeGet()
 
       assert(result.get[Circular1].c2 != null)
       assert(result.get[Circular1].c2 != null)
@@ -173,7 +173,7 @@ class GcBasicTestsJvm extends AnyWordSpec with MkGcInjector {
         make[Circular2]
       }, GCMode(DIKey.get[Circular2])))
 
-      val result = injector.produceUnsafe(plan)
+      val result = injector.produce(plan).unsafeGet()
 
       assert(result.get[Circular1].c2 != null)
       assert(result.get[Circular1].c2.isInstanceOf[Circular2])
@@ -188,7 +188,7 @@ class GcBasicTestsJvm extends AnyWordSpec with MkGcInjector {
         make[Circular2]
       }, GCMode(DIKey.get[Circular2], DIKey.get[Set[AutoCloseable]])))
 
-      val result = injector.produceUnsafe(plan)
+      val result = injector.produce(plan).unsafeGet()
 
       assert(result.get[Circular1] != null)
       assert(result.get[Circular2] != null)
@@ -208,7 +208,7 @@ class GcBasicTestsJvm extends AnyWordSpec with MkGcInjector {
           .ref[Circular2]
       }, GCMode(DIKey.get[Circular4], DIKey.get[immutable.Set[T1]], DIKey.get[Circular3])))
 
-      val result = injector.produceUnsafe(plan)
+      val result = injector.produce(plan).unsafeGet()
 
       assert(result.get[Circular1] != null)
       assert(result.get[Circular2] != null)

--- a/distage/distage-core/.jvm/src/test/scala/izumi/distage/injector/AnimalModel.scala
+++ b/distage/distage-core/.jvm/src/test/scala/izumi/distage/injector/AnimalModel.scala
@@ -39,7 +39,7 @@ class AnimalModel extends AnyWordSpec with MkInjector {
         println(plan.renderAllDeps())
         println()
       }
-      val context = injector.produceUnsafe(plan)
+      val context = injector.produce(plan).unsafeGet()
       assert(context.find[App].nonEmpty)
     }
   }

--- a/distage/distage-core/.jvm/src/test/scala/izumi/distage/injector/CglibProxiesTest.scala
+++ b/distage/distage-core/.jvm/src/test/scala/izumi/distage/injector/CglibProxiesTest.scala
@@ -27,7 +27,7 @@ class CglibProxiesTest extends AnyWordSpec with MkInjector {
 
       val injector = mkInjector()
       val plan = injector.plan(definition)
-      val context = injector.produceUnsafe(plan)
+      val context = injector.produce(plan).unsafeGet()
 
       assert(context.get[Circular1] != null)
       assert(context.get[Circular2] != null)
@@ -44,7 +44,7 @@ class CglibProxiesTest extends AnyWordSpec with MkInjector {
 
       val injector = mkInjector()
       val plan = injector.plan(definition)
-      val context = injector.produceUnsafe(plan)
+      val context = injector.produce(plan).unsafeGet()
 
       assert(context.get[Circular1] != null)
       assert(context.get[Circular2] != null)
@@ -66,7 +66,7 @@ class CglibProxiesTest extends AnyWordSpec with MkInjector {
 
       val injector = mkInjector()
       val plan = injector.plan(definition)
-      val context = injector.produceUnsafe(plan)
+      val context = injector.produce(plan).unsafeGet()
 
       assert(context.get[Circular1] != null)
       assert(context.get[Circular2] != null)
@@ -82,7 +82,7 @@ class CglibProxiesTest extends AnyWordSpec with MkInjector {
 
       val injector = mkInjector()
       val plan = injector.plan(definition)
-      val context = injector.produceUnsafe(plan)
+      val context = injector.produce(plan).unsafeGet()
 
       val instance = context.get[SelfReference]
 
@@ -101,7 +101,7 @@ class CglibProxiesTest extends AnyWordSpec with MkInjector {
 
       val injector = mkInjector()
       val plan = injector.plan(definition)
-      val context = injector.produceUnsafe(plan)
+      val context = injector.produce(plan).unsafeGet()
 
       val instance = context.get[SelfReference]
 
@@ -119,7 +119,7 @@ class CglibProxiesTest extends AnyWordSpec with MkInjector {
 
       val injector = mkInjector()
       val plan = injector.plan(definition)
-      val context = injector.produceUnsafe(plan)
+      val context = injector.produce(plan).unsafeGet()
 
       assert(context.get[Circular1] != null)
       assert(context.get[Circular2] != null)
@@ -143,7 +143,7 @@ class CglibProxiesTest extends AnyWordSpec with MkInjector {
 
       val injector = mkInjector()
       val plan = injector.plan(definition)
-      val context = injector.produceUnsafe(plan)
+      val context = injector.produce(plan).unsafeGet()
 
       assert(context.get[Circular1] != null)
       assert(context.get[Circular2] != null)
@@ -166,7 +166,7 @@ class CglibProxiesTest extends AnyWordSpec with MkInjector {
       })
 
       val injector = mkInjector()
-      val context = injector.produceUnsafe(definition)
+      val context = injector.produce(definition).unsafeGet()
 
       assert(context.get[Dependency] != null)
       assert(context.get[GenericCircular[Dependency]] != null)
@@ -187,7 +187,7 @@ class CglibProxiesTest extends AnyWordSpec with MkInjector {
 
       val injector = mkInjector()
       val plan = injector.plan(definition)
-      val context = injector.produceUnsafe(plan)
+      val context = injector.produce(plan).unsafeGet()
 
       assert(context.get[IdTypeCircular] != null)
       assert(context.get[IdParamCircular] != null)
@@ -205,7 +205,7 @@ class CglibProxiesTest extends AnyWordSpec with MkInjector {
       })
 
       val injector = mkInjector()
-      val context = injector.produceUnsafe(definition)
+      val context = injector.produce(definition).unsafeGet()
 
       assert(context.get[Dependency {def dep: RefinedCircular}] != null)
       assert(context.get[RefinedCircular] != null)
@@ -226,7 +226,7 @@ class CglibProxiesTest extends AnyWordSpec with MkInjector {
       }, GCMode(DIKey.get[Root]))
 
       val injector = mkInjector()
-      val context = injector.produceUnsafe(definition)
+      val context = injector.produce(definition).unsafeGet()
 
       assert(context.get[ComponentHolder].componentFwdRef eq context.get[ComponentWithByNameFwdRef])
       assert(context.get[ComponentWithByNameFwdRef].get eq context.get[ComponentHolder])
@@ -274,7 +274,7 @@ class CglibProxiesTest extends AnyWordSpec with MkInjector {
       )
 
       val plan = injector.plan(definition)
-      injector.produceUnsafe(plan)
+      injector.produce(plan).unsafeGet()
     }
   }
 
@@ -290,7 +290,7 @@ class CglibProxiesTest extends AnyWordSpec with MkInjector {
           make[Circular2]
         })
 
-        val context = mkInjector().produceUnsafe(definition)
+        val context = mkInjector().produce(definition).unsafeGet()
 
         assert(context.get[Circular1] != null)
         assert(context.get[Circular1].circular2 != context.get[Circular2])
@@ -310,7 +310,7 @@ class CglibProxiesTest extends AnyWordSpec with MkInjector {
           make[testProviderModule.Circular2]
         })
 
-        val context = mkInjector().produceUnsafe(definition)
+        val context = mkInjector().produce(definition).unsafeGet()
 
         assert(context.get[testProviderModule.TestFactory].mk(testProviderModule.TestDependency()) == testProviderModule.TestClass(testProviderModule.TestDependency()))
       }
@@ -336,7 +336,7 @@ class CglibProxiesTest extends AnyWordSpec with MkInjector {
 
       val injector = mkInjector()
       val plan = injector.plan(definition)
-      val context = injector.produceUnsafeF[Suspend2[Throwable, ?]](plan).unsafeRun()
+      val context = injector.produceF[Suspend2[Throwable, ?]](plan).unsafeGet().unsafeRun()
 
       val instance = context.get[SelfReference]
 

--- a/distage/distage-core/src/test/scala/izumi/distage/dsl/DSLTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/dsl/DSLTest.scala
@@ -450,7 +450,7 @@ class DSLTest extends AnyWordSpec with MkInjector {
       val plan4 = injector.plan(defWithTagsWithoutSugar)
       assert(plan3.definition == plan4.definition)
 
-      val context = injector.produceUnsafe(plan1)
+      val context = injector.produce(plan1).unsafeGet()
       val xInstance = context.get[TraitX]
       val yInstance = context.get[TraitY]("Y")
       val implInstance = context.get[ImplXYZ]("my-impl")

--- a/distage/distage-core/src/test/scala/izumi/distage/gc/GcBasicTests.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/gc/GcBasicTests.scala
@@ -33,7 +33,7 @@ class GcBasicTests extends AnyWordSpec with MkGcInjector {
         make[Box[T1]].from(new Box(new T1))
       }, GCMode(DIKey.get[Circular1], DIKey.get[Circular2])))
 
-      val result = injector.produceUnsafe(plan)
+      val result = injector.produce(plan).unsafeGet()
 
       assert(result.get[Circular1] != null)
       assert(result.get[Circular2] != null)

--- a/distage/distage-core/src/test/scala/izumi/distage/gc/GcIdempotenceTests.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/gc/GcIdempotenceTests.scala
@@ -21,7 +21,7 @@ class GcIdempotenceTests extends AnyWordSpec with MkGcInjector {
         }, GCMode(DIKey.get[App])))
 
         val updated = injector.finish(plan.toSemi)
-        val result = injector.produceUnsafe(updated)
+        val result = injector.produce(updated).unsafeGet()
         assert(updated.steps.size == plan.steps.size)
 
         assert(result.get[App].components.size == 1)

--- a/distage/distage-core/src/test/scala/izumi/distage/gc/MkGcInjector.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/gc/MkGcInjector.scala
@@ -13,7 +13,7 @@ trait MkGcInjector {
   implicit class InjectorExt(injector: Injector) {
     def finishProduce(plan: OrderedPlan): Locator = {
       val updated = injector.finish(plan.toSemi)
-      injector.produceUnsafe(updated)
+      injector.produce(updated).unsafeGet()
     }
   }
 }

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/AdvancedBindingsTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/AdvancedBindingsTest.scala
@@ -30,9 +30,9 @@ class AdvancedBindingsTest extends AnyWordSpec with MkInjector {
     val plan2 = injector.plan(def2)
     val plan3 = injector.plan(def3)
 
-    assert(Try(injector.produceUnsafe(plan1)).toEither.left.exists(_.getSuppressed.head.isInstanceOf[TODOBindingException]))
-    assert(Try(injector.produceUnsafe(plan2)).toEither.left.exists(_.getSuppressed.head.isInstanceOf[TODOBindingException]))
-    assert(Try(injector.produceUnsafe(plan3)).toEither.left.exists(_.getSuppressed.head.isInstanceOf[TODOBindingException]))
+    assert(Try(injector.produce(plan1).unsafeGet()).toEither.left.exists(_.getSuppressed.head.isInstanceOf[TODOBindingException]))
+    assert(Try(injector.produce(plan2).unsafeGet()).toEither.left.exists(_.getSuppressed.head.isInstanceOf[TODOBindingException]))
+    assert(Try(injector.produce(plan3).unsafeGet()).toEither.left.exists(_.getSuppressed.head.isInstanceOf[TODOBindingException]))
   }
 
   "Set element references are the same as their referees" in {
@@ -48,7 +48,7 @@ class AdvancedBindingsTest extends AnyWordSpec with MkInjector {
     val injector = mkInjector()
     val plan = injector.plan(definition)
 
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
     val svc = context.get[Service1]
     val set = context.get[Set[Service]]
     assert(set.head eq svc)

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/AdvancedTypesTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/AdvancedTypesTest.scala
@@ -26,7 +26,7 @@ class AdvancedTypesTest extends AnyWordSpec with MkInjector {
 
     val injector = mkInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     assert(context.get[List[Dep]]("As").forall(_.isInstanceOf[DepA]))
     assert(context.get[List[DepA]].forall(_.isInstanceOf[DepA]))
@@ -44,7 +44,7 @@ class AdvancedTypesTest extends AnyWordSpec with MkInjector {
 
     val injector = mkInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     assert(context.get[TestClass2[TypeAliasDepA]].inner.isInstanceOf[TypeAliasDepA])
   }
@@ -59,7 +59,7 @@ class AdvancedTypesTest extends AnyWordSpec with MkInjector {
 
     val injector = mkInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     assert(context.get[TestTrait].dep.isInstanceOf[TypeAliasDepA])
   }
@@ -74,7 +74,7 @@ class AdvancedTypesTest extends AnyWordSpec with MkInjector {
 
     val injector = mkInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     val instantiated = context.get[Dependency1]
     val instantiated1 = context.get[Dependency1@Id("special")]
@@ -93,7 +93,7 @@ class AdvancedTypesTest extends AnyWordSpec with MkInjector {
 
     val injector = mkInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     val instantiated = context.get[Trait2 with Trait1]
 
@@ -113,7 +113,7 @@ class AdvancedTypesTest extends AnyWordSpec with MkInjector {
 
     val injector = mkInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     val instantiated1 = context.get[Trait1 {def dep: Dep2}]
     val instantiated2 = context.get[ {def dep: Dep}]
@@ -138,7 +138,7 @@ class AdvancedTypesTest extends AnyWordSpec with MkInjector {
 
     val injector = mkInjector()
     val plan = injector.plan(PlannerInput.noGc(new Definition[Dep2]))
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     val instantiated = context.get[Trait1[Dep, Dep2]]
 
@@ -159,7 +159,7 @@ class AdvancedTypesTest extends AnyWordSpec with MkInjector {
 
     val injector = mkInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     val instantiated = context.get[Trait1 {def dep: Dep}]
 
@@ -180,7 +180,7 @@ class AdvancedTypesTest extends AnyWordSpec with MkInjector {
 
     val injector = mkInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     val instantiated = context.get[Trait3[Dep] with Trait1]
     val instantiated2 = context.get[Trait3[Dep] with Trait4]
@@ -207,7 +207,7 @@ class AdvancedTypesTest extends AnyWordSpec with MkInjector {
 
     val injector = mkInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
     val instantiated = context.get[Trait3[Dep] with Trait4]
 
     assert(instantiated.dep == context.get[Dep])
@@ -222,7 +222,7 @@ class AdvancedTypesTest extends AnyWordSpec with MkInjector {
     })
 
     val injector = mkInjector()
-    val context = injector.produceUnsafe(definition)
+    val context = injector.produce(definition).unsafeGet()
 
     val instantiated1 = context.get[Dep]
     val instantiated2 = context.get[WidgetId]
@@ -236,7 +236,7 @@ class AdvancedTypesTest extends AnyWordSpec with MkInjector {
     })
 
     val injector = mkInjector()
-    val context = injector.produceUnsafe(definition)
+    val context = injector.produce(definition).unsafeGet()
 
     val instantiated = context.get[ {def a: Int}]
     assert(instantiated.a == context.get[Int])
@@ -250,7 +250,7 @@ class AdvancedTypesTest extends AnyWordSpec with MkInjector {
     })
 
     val injector = mkInjector()
-    val context = injector.produceUnsafe(definition)
+    val context = injector.produce(definition).unsafeGet()
 
     assert(context.get[Dep {}] != null)
   }

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/AutoSetTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/AutoSetTest.scala
@@ -24,7 +24,7 @@ class AutoSetTest extends AnyWordSpec with MkInjector {
         .add(new AutoSetHook[Ordered, Ordered](identity))
     })
 
-    val autoset = injector.produceUnsafe(PlannerInput.noGc(definition)).get[Set[Ordered]]
+    val autoset = injector.produce(PlannerInput.noGc(definition)).unsafeGet().get[Set[Ordered]]
 
     assert(autoset.toSeq == autoset.toSeq.sortBy(_.order))
   }
@@ -44,7 +44,7 @@ class AutoSetTest extends AnyWordSpec with MkInjector {
         .add(new AutoSetHook[Int, Int](identity))
     })
 
-    val autoset = injector.produceUnsafe(PlannerInput.noGc(definition)).get[Set[Int]]
+    val autoset = injector.produce(PlannerInput.noGc(definition)).unsafeGet().get[Set[Int]]
 
     assert(autoset == Set(1, 2, 3, 4, 5))
   }

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/AutoTraitsTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/AutoTraitsTest.scala
@@ -18,7 +18,7 @@ class AutoTraitsTest extends AnyWordSpec with MkInjector {
     val injector = mkInjector()
     val plan = injector.plan(definition)
 
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
     assert(context.get[ATraitWithAField].field == 1)
   }
 
@@ -35,7 +35,7 @@ class AutoTraitsTest extends AnyWordSpec with MkInjector {
     val injector = mkInjector()
     val plan = injector.plan(definition)
 
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
     val instantiated = context.get[Trait]
     val instantiated1 = context.get[Trait1]
 
@@ -57,7 +57,7 @@ class AutoTraitsTest extends AnyWordSpec with MkInjector {
     val injector = mkInjector()
     val plan = injector.plan(definition)
 
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
     val instantiated = context.get[TestTrait]
 
     assert(instantiated.rd == Dep().toString)
@@ -73,7 +73,7 @@ class AutoTraitsTest extends AnyWordSpec with MkInjector {
 
     val injector = mkInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
     val instantiated = context.get[TestTraitAny {def dep: Dep}]
 
     assert(instantiated.dep eq context.get[Dep])
@@ -90,7 +90,7 @@ class AutoTraitsTest extends AnyWordSpec with MkInjector {
 
     val injector = mkInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     val instantiated = context.get[Trait2 with Trait1]
 
@@ -109,7 +109,7 @@ class AutoTraitsTest extends AnyWordSpec with MkInjector {
 
     val injector = mkInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     assert(context.get[TestTrait].anyValDep != null)
     assert(context.get[TestTrait].anyValDep ne context.get[AnyValDep].asInstanceOf[AnyRef])
@@ -127,7 +127,7 @@ class AutoTraitsTest extends AnyWordSpec with MkInjector {
 
     val injector = mkInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     val dependency1 = context.get[Dependency1]
     val dependency2 = context.get[Dependency2]

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/AxisTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/AxisTest.scala
@@ -17,13 +17,13 @@ class AxisTest extends AnyWordSpec with MkInjector {
     }
 
     val injector1 = Injector(Activation(Repo -> Repo.Prod))
-    val context1 = injector1.produceUnsafe(PlannerInput(definition, GCMode(DIKey.get[JustTrait])))
+    val context1 = injector1.produce(PlannerInput(definition, GCMode(DIKey.get[JustTrait]))).unsafeGet()
 
     assert(context1.get[JustTrait].isInstanceOf[Impl1])
     assert(!context1.get[JustTrait].isInstanceOf[Impl0])
 
     val injector2 = Injector(Activation(Repo -> Repo.Dummy))
-    val context2 = injector2.produceUnsafe(PlannerInput(definition, GCMode(DIKey.get[JustTrait])))
+    val context2 = injector2.produce(PlannerInput(definition, GCMode(DIKey.get[JustTrait]))).unsafeGet()
 
     assert(context2.get[JustTrait].isInstanceOf[Impl0])
     assert(!context2.get[JustTrait].isInstanceOf[Impl1])

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/BasicTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/BasicTest.scala
@@ -30,7 +30,7 @@ class BasicTest extends AnyWordSpec with MkInjector {
     assert(plan.steps.exists(_.isInstanceOf[ImportDependency]))
 
     val exc = intercept[ProvisioningException] {
-      injector.produceUnsafe(plan)
+      injector.produce(plan).unsafeGet()
     }
 
     assert(exc.getMessage.startsWith("Provisioner stopped after 1 instances, 1/13 operations failed"))
@@ -38,7 +38,7 @@ class BasicTest extends AnyWordSpec with MkInjector {
     val fixedPlan = plan.resolveImports {
       case i if i.target == DIKey.get[NotInContext] => new NotInContext {}
     }
-    val locator = injector.produceUnsafe(fixedPlan)
+    val locator = injector.produce(fixedPlan).unsafeGet()
     assert(locator.get[LocatorDependent].ref.get == locator)
   }
 
@@ -52,7 +52,7 @@ class BasicTest extends AnyWordSpec with MkInjector {
 
     val injector = mkInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     val s = context.get[TypedService[Int]]
     val ss = context.get[Set[ExampleTypedCaseClass[Int]]]
@@ -71,7 +71,7 @@ class BasicTest extends AnyWordSpec with MkInjector {
         })
 
         val injector = mkInjector()
-        injector.produceUnsafe(injector.plan(definition)).get[TestClass]
+        injector.produce(injector.plan(definition)).unsafeGet().get[TestClass]
         """)
     }
     assert(res.getMessage.contains("BadIdAnnotationException"))
@@ -85,7 +85,7 @@ class BasicTest extends AnyWordSpec with MkInjector {
     val injector = mkInjector()
 
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     assert(context.get[MyClass].a eq context.get[String]("a"))
     assert(context.get[MyClass].b eq context.get[String]("b"))
@@ -109,7 +109,7 @@ class BasicTest extends AnyWordSpec with MkInjector {
 
     val injector = mkInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     assert(context.get[Set[JustTrait]].size == 2)
     assert(context.get[Set[JustTrait]]("named.empty.set").isEmpty)
@@ -127,11 +127,11 @@ class BasicTest extends AnyWordSpec with MkInjector {
 
     val injector = mkInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     val sub = Injector.inherit(context)
     val subplan = sub.plan(definition)
-    val subcontext = injector.produceUnsafe(subplan)
+    val subcontext = injector.produce(subplan).unsafeGet()
 
     assert(context.get[Set[JustTrait]].size == 1)
     assert(subcontext.get[Set[JustTrait]].size == 1)
@@ -154,7 +154,7 @@ class BasicTest extends AnyWordSpec with MkInjector {
 
     val injector = mkInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     assert(context.get[TestClass]("named.test.class").correctWired())
   }
@@ -184,7 +184,7 @@ class BasicTest extends AnyWordSpec with MkInjector {
 
     val injector = mkInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
     val instantiated = context.get[TestCaseClass2]
 
     assert(instantiated.a.z.nonEmpty)
@@ -223,7 +223,7 @@ class BasicTest extends AnyWordSpec with MkInjector {
     val injector = mkInjector()
     val plan = injector.plan(definition)
 
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     assert(context.get[Service0].set.size == 3)
     assert(context.get[Service1].set.size == 3)
@@ -250,7 +250,7 @@ class BasicTest extends AnyWordSpec with MkInjector {
         | Take two of these feel like Goku""".stripMargin
     }
 
-    val context = injector.produceUnsafe(plan3)
+    val context = injector.produce(plan3).unsafeGet()
 
     assert(context.get[TestCaseClass2].a.z == context.get[String]("verse"))
   }
@@ -266,7 +266,7 @@ class BasicTest extends AnyWordSpec with MkInjector {
     val injector = mkInjector()
 
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     assert(context.get[TestClass] != null)
   }
@@ -284,7 +284,7 @@ class BasicTest extends AnyWordSpec with MkInjector {
       many[Option[Int]].refSet[Set[Some[Int]]]
     })
 
-    val context = Injector.Standard().produceUnsafe(definition)
+    val context = Injector.Standard().produce(definition).unsafeGet()
 
     assert(context.get[Set[Int]] == Set(1, 2, 3, 4, 5, 6))
     assert(context.get[Set[Option[Int]]] == Set(None, Some(7)))
@@ -305,7 +305,7 @@ class BasicTest extends AnyWordSpec with MkInjector {
       }
     })
 
-    val context = Injector.Standard().produceUnsafe(definition)
+    val context = Injector.Standard().produce(definition).unsafeGet()
     assert(context.get[Set[Int]].toList.sorted == List(0, 1, 2, 3, 5, 6, 7, 8, 9))
   }
 
@@ -316,7 +316,7 @@ class BasicTest extends AnyWordSpec with MkInjector {
       make[TestImpl1]
     })
 
-    val context = Injector.Standard().produceUnsafe(definition)
+    val context = Injector.Standard().produce(definition).unsafeGet()
 
     assert(context.get[TestImpl1].justASet == Set.empty)
   }
@@ -344,7 +344,7 @@ class BasicTest extends AnyWordSpec with MkInjector {
       make[ServerConfig].from(ServerConfig)
     })
 
-    val context = Injector.Standard().produceUnsafe(definition)
+    val context = Injector.Standard().produce(definition).unsafeGet()
 
     assert(context.get[ServerConfig].port == context.get[Int]("port"))
     assert(context.get[ServerConfig].address == context.get[String]("address"))

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/CircularDependenciesTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/CircularDependenciesTest.scala
@@ -25,7 +25,7 @@ class CircularDependenciesTest extends AnyWordSpec with MkInjector {
     val plan = injector.plan(definition)
 
     val exc = intercept[ProvisioningException] {
-      injector.produceUnsafe(plan)
+      injector.produce(plan).unsafeGet()
     }
 
     assert(exc.getSuppressed.head.isInstanceOf[TraitInitializationFailedException])
@@ -48,7 +48,7 @@ class CircularDependenciesTest extends AnyWordSpec with MkInjector {
     assert(plan.topology.dependencies.tree(DIKey.get[Circular1], Some(3)).children.size == 1)
     assert(plan.topology.dependees.tree(DIKey.get[Circular1], Some(3)).children.size == 2)
 
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
     val c3 = context.get[Circular3]
     val traitArg = c3.arg
 
@@ -68,7 +68,7 @@ class CircularDependenciesTest extends AnyWordSpec with MkInjector {
 
     val injector = mkNoCglibInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     val instance = context.get[ByNameSelfReference]
 
@@ -84,7 +84,7 @@ class CircularDependenciesTest extends AnyWordSpec with MkInjector {
 
     val injector = mkNoCglibInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     val instance = context.get[TraitSelfReference]
 
@@ -103,7 +103,7 @@ class CircularDependenciesTest extends AnyWordSpec with MkInjector {
 
     val injector = mkNoCglibInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     val instance = context.get[FactorySelfReference]
 
@@ -137,7 +137,7 @@ class CircularDependenciesTest extends AnyWordSpec with MkInjector {
 
     val injector = mkInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     val planTypes: Seq[SafeType] = plan.steps
       .collect {
@@ -166,7 +166,7 @@ class CircularDependenciesTest extends AnyWordSpec with MkInjector {
 
     val injector = mkNoCglibInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     assert(context.get[Circular1] != null)
     assert(context.get[Circular2] != null)
@@ -188,7 +188,7 @@ class CircularDependenciesTest extends AnyWordSpec with MkInjector {
     })
 
     val injector = mkInjector()
-    val context = injector.produceUnsafe(definition)
+    val context = injector.produce(definition).unsafeGet()
 
     assert(context.get[ErasedCircular[Dependency]] != null)
     assert(context.get[PhantomDependency[Dependency]] != null)

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/FactoriesTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/FactoriesTest.scala
@@ -25,7 +25,7 @@ class FactoriesTest extends AnyWordSpec with MkInjector {
 
     val injector = mkInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     val factory = context.get[Factory]
     assert(factory.wiringTargetForDependency != null)
@@ -62,7 +62,7 @@ class FactoriesTest extends AnyWordSpec with MkInjector {
 
     val injector = mkInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     val instantiated = context.get[GenericAssistedFactory]
     val product = instantiated.x(List(SpecialDep()), List(5))
@@ -83,7 +83,7 @@ class FactoriesTest extends AnyWordSpec with MkInjector {
 
     val injector = mkInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     assert(!context.get[Dependency].isSpecial)
     assert(context.get[Dependency]("special").isSpecial)
@@ -105,7 +105,7 @@ class FactoriesTest extends AnyWordSpec with MkInjector {
 
     val injector = mkInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     val dep = context.get[Dependency]
     val instantiated = context.get[MixedAssistendNonAssisted]
@@ -126,7 +126,7 @@ class FactoriesTest extends AnyWordSpec with MkInjector {
 
     val injector = mkInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     val dep = context.get[Dependency]
     val instantiated = context.get[AssistedAbstractFactory]
@@ -147,7 +147,7 @@ class FactoriesTest extends AnyWordSpec with MkInjector {
 
     val injector = mkInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     val dep = context.get[Dependency]
     val instantiated = context.get[AssistedAbstractFactoryF[Identity]]
@@ -173,7 +173,7 @@ class FactoriesTest extends AnyWordSpec with MkInjector {
 
     val injector = mkNoCyclesInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     val instantiated = context.get[{ def makeConcreteDep(): Dependency @With[ConcreteDep] }]
 
@@ -194,7 +194,7 @@ class FactoriesTest extends AnyWordSpec with MkInjector {
 
         val injector = mkInjector()
         val plan = injector.plan(definition)
-        val context = injector.produceUnsafe(plan)
+        val context = injector.produce(plan).unsafeGet()
 
         val instantiated = context.get[FactoryProducingFactory]
 
@@ -215,7 +215,7 @@ class FactoriesTest extends AnyWordSpec with MkInjector {
 
     val injector = mkInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     val instantiated = context.get[Factory]
 

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/HigherKindsTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/HigherKindsTest.scala
@@ -33,7 +33,7 @@ class HigherKindsTest extends AnyWordSpec with MkInjector {
 
     val listInjector = mkInjector()
     val listPlan = listInjector.plan(PlannerInput.noGc(Definition[List](5)))
-    val listContext = listInjector.produceUnsafe(listPlan)
+    val listContext = listInjector.produce(listPlan).unsafeGet()
 
     assert(listContext.get[TestTrait].get == List(5))
     assert(listContext.get[TestServiceClass[List]].get == List(5))
@@ -46,7 +46,7 @@ class HigherKindsTest extends AnyWordSpec with MkInjector {
 
     val optionTInjector = mkInjector()
     val optionTPlan = optionTInjector.plan(PlannerInput.noGc(Definition[OptionT[List, ?]](5)))
-    val optionTContext = optionTInjector.produceUnsafe(optionTPlan)
+    val optionTContext = optionTInjector.produce(optionTPlan).unsafeGet()
 
     assert(optionTContext.get[TestTrait].get == OptionT(List(Option(5))))
     assert(optionTContext.get[TestServiceClass[OptionT[List, ?]]].get == OptionT(List(Option(5))))
@@ -56,7 +56,7 @@ class HigherKindsTest extends AnyWordSpec with MkInjector {
     val eitherInjector = mkInjector()
     val eitherPlan = eitherInjector.plan(PlannerInput.noGc(Definition[Either[String, ?]](5)))
 
-    val eitherContext = eitherInjector.produceUnsafe(eitherPlan)
+    val eitherContext = eitherInjector.produce(eitherPlan).unsafeGet()
 
     assert(eitherContext.get[TestTrait].get == Right(5))
     assert(eitherContext.get[TestServiceClass[Either[String, ?]]].get == Right(5))
@@ -67,7 +67,7 @@ class HigherKindsTest extends AnyWordSpec with MkInjector {
 
     val idInjector = mkInjector()
     val idPlan = idInjector.plan(PlannerInput.noGc(Definition[id](5)))
-    val idContext = idInjector.produceUnsafe(idPlan)
+    val idContext = idInjector.produce(idPlan).unsafeGet()
 
     assert(idContext.get[TestTrait].get == 5)
     assert(idContext.get[TestServiceClass[id]].get == 5)
@@ -151,7 +151,7 @@ class HigherKindsTest extends AnyWordSpec with MkInjector {
     val value: Either[String, Int] = Right(5)
     val definition = new Definition[Either, Option, Int](value)
 
-    val context = Injector.Standard().produceUnsafe(PlannerInput.noGc(definition))
+    val context = Injector.Standard().produce(PlannerInput.noGc(definition)).unsafeGet()
     assert(context != null)
 
     assert(definition.t0.tag =:= LTag[TestCovariantTC[Either]].tag)

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/ImplicitInjectionTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/ImplicitInjectionTest.scala
@@ -20,7 +20,7 @@ class ImplicitInjectionTest extends AnyWordSpec with MkInjector {
 
     val injector = mkInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     assert(context.get[TestClass].a != null)
     assert(context.get[TestClass].b != null)
@@ -40,7 +40,7 @@ class ImplicitInjectionTest extends AnyWordSpec with MkInjector {
     val injector = mkInjector()
     val plan = injector.plan(definition)
 
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
     val instantiated = context.get[TestClass]
 
     assert(instantiated.dummyImplicit.isInstanceOf[MyDummyImplicit])
@@ -62,7 +62,7 @@ class ImplicitInjectionTest extends AnyWordSpec with MkInjector {
 
     val injector = mkInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     assert(context.get[TestClass].b == context.get[TestClass].d)
   }

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/InnerClassesTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/InnerClassesTest.scala
@@ -15,7 +15,7 @@ class InnerClassesTest extends AnyWordSpec with MkInjector {
       make[StableObjectInheritingTrait1.TestDependency]
     })
 
-    val context = mkInjector().produceUnsafe(definition)
+    val context = mkInjector().produce(definition).unsafeGet()
 
     assert(context.get[StableObjectInheritingTrait.TestDependency] == StableObjectInheritingTrait.TestDependency())
     assert(context.get[StableObjectInheritingTrait1.TestDependency] == StableObjectInheritingTrait1.TestDependency())
@@ -31,7 +31,7 @@ class InnerClassesTest extends AnyWordSpec with MkInjector {
       make[TestClass]
     })
 
-    val context = mkInjector().produceUnsafe(definition)
+    val context = mkInjector().produce(definition).unsafeGet()
 
     assert(context.get[TestClass] == TestClass(TestDependency()))
   }
@@ -49,7 +49,7 @@ class InnerClassesTest extends AnyWordSpec with MkInjector {
 
     val injector = mkInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     assert(context.get[testProviderModule.TestClass].a.isInstanceOf[testProviderModule.TestDependency])
   }
@@ -69,7 +69,7 @@ class InnerClassesTest extends AnyWordSpec with MkInjector {
       val injector = mkInjector()
       val plan = injector.plan(definition)
 
-      val context = injector.produceUnsafe(plan)
+      val context = injector.produce(plan).unsafeGet()
 
       assert(context.get[testProviderModule.TestClass].a.isInstanceOf[testProviderModule.TestDependency])
     }
@@ -91,7 +91,7 @@ class InnerClassesTest extends AnyWordSpec with MkInjector {
       val injector = mkInjector()
       val plan = injector.plan(definition)
 
-      val context = injector.produceUnsafe(plan)
+      val context = injector.produce(plan).unsafeGet()
 
       assert(context.get[TestModule#TestClass].a.isInstanceOf[TestModule#TestDependency])
       """)
@@ -110,7 +110,7 @@ class InnerClassesTest extends AnyWordSpec with MkInjector {
 
     val injector = mkInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     assert(context.get[testProviderModule.TestClass].aValue.isInstanceOf[testProviderModule.TestDependency])
   }
@@ -129,7 +129,7 @@ class InnerClassesTest extends AnyWordSpec with MkInjector {
     val injector = mkInjector()
     val plan = injector.plan(definition)
 
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     assert(context.get[TopLevelPathDepTest.TestClass].a != null)
   }
@@ -141,7 +141,7 @@ class InnerClassesTest extends AnyWordSpec with MkInjector {
       make[TestFactory]
     })
 
-    val context = mkInjector().produceUnsafe(definition)
+    val context = mkInjector().produce(definition).unsafeGet()
 
     assert(context.get[TestFactory].mk(TestDependency()) == TestClass(TestDependency()))
   }
@@ -155,7 +155,7 @@ class InnerClassesTest extends AnyWordSpec with MkInjector {
       make[ByNameCircular2]
     })
 
-    val context = mkNoCglibInjector().produceUnsafe(definition)
+    val context = mkNoCglibInjector().produce(definition).unsafeGet()
 
     assert(context.get[ByNameCircular1] != null)
     assert(context.get[ByNameCircular1].circular2 eq context.get[ByNameCircular2])
@@ -172,7 +172,7 @@ class InnerClassesTest extends AnyWordSpec with MkInjector {
       make[testProviderModule.TestFactory]
     })
 
-    val context = mkInjector().produceUnsafe(definition)
+    val context = mkInjector().produce(definition).unsafeGet()
     assert(context.instances.size == 2 + 5)
 
     assert(context.get[testProviderModule.TestFactory].mk(testProviderModule.TestDependency()) == testProviderModule.TestClass(testProviderModule.TestDependency()))
@@ -188,7 +188,7 @@ class InnerClassesTest extends AnyWordSpec with MkInjector {
     def testCase = {
       val injector = mkInjector()
       val plan = injector.plan(definition)
-      val context = injector.produceUnsafe(plan)
+      val context = injector.produce(plan).unsafeGet()
 
       assert(context.get[TestClass].a != null)
     }

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/ProvidersTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/ProvidersTest.scala
@@ -18,7 +18,7 @@ class ProvidersTest extends AnyWordSpec with MkInjector {
     val injector = mkInjector()
     val plan = injector.plan(definition)
 
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
     assert(context.parent.exists(_.plan.steps.nonEmpty))
     val instantiated = context.get[TestClass]
     assert(instantiated.b == null)
@@ -34,7 +34,7 @@ class ProvidersTest extends AnyWordSpec with MkInjector {
 
     val injector = mkInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     val dependency = context.get[TestDependency]("classdeftypeann1")
     val instantiated = context.get[TestClass]
@@ -51,7 +51,7 @@ class ProvidersTest extends AnyWordSpec with MkInjector {
     })
 
     val injector = mkInjector()
-    val context = injector.produceUnsafe(injector.plan(definition))
+    val context = injector.produce(injector.plan(definition)).unsafeGet()
 
     val dependency = context.get[TestDependency]("classdeftypeann1")
     val instantiated = context.get[TestClass]

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/ResourceEffectBindingsTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/ResourceEffectBindingsTest.scala
@@ -32,7 +32,7 @@ class ResourceEffectBindingsTest extends AnyWordSpec with MkInjector {
 
       val injector = mkInjector()
       val plan = injector.plan(definition)
-      val context = injector.produceUnsafe(plan)
+      val context = injector.produce(plan).unsafeGet()
 
       assert(context.get[Int] == 12)
     }
@@ -46,7 +46,7 @@ class ResourceEffectBindingsTest extends AnyWordSpec with MkInjector {
       val injector = mkInjector()
       val plan = injector.plan(definition)
 
-      val context = injector.produceUnsafeF[Suspend2[Throwable, ?]](plan).unsafeRun()
+      val context = injector.produceF[Suspend2[Throwable, ?]](plan).unsafeGet().unsafeRun()
 
       assert(context.get[Int] == 12)
     }
@@ -66,7 +66,7 @@ class ResourceEffectBindingsTest extends AnyWordSpec with MkInjector {
       val injector = mkInjector()
       val plan = injector.plan(definition)
 
-      val context = injector.produceUnsafeF[Suspend2[Nothing, ?]](plan).unsafeRun()
+      val context = injector.produceF[Suspend2[Nothing, ?]](plan).unsafeGet().unsafeRun()
 
       assert(context.get[Int]("1") != context.get[Int]("2"))
       assert(Set(context.get[Int]("1"), context.get[Int]("2")) == Set(1,2))
@@ -81,7 +81,7 @@ class ResourceEffectBindingsTest extends AnyWordSpec with MkInjector {
 
       val injector = mkInjector()
       val plan = injector.plan(definition)
-      val context = injector.produceUnsafeF[Suspend2[Throwable, ?]](plan).unsafeRun()
+      val context = injector.produceF[Suspend2[Throwable, ?]](plan).unsafeGet().unsafeRun()
 
       assert(context.get[Int] == 12)
     }
@@ -110,7 +110,7 @@ class ResourceEffectBindingsTest extends AnyWordSpec with MkInjector {
 
       val injector = mkInjector()
       val plan = injector.plan(definition)
-      val context = injector.produceUnsafeF[Suspend2[Throwable, ?]](plan).unsafeRun()
+      val context = injector.produceF[Suspend2[Throwable, ?]](plan).unsafeGet().unsafeRun()
 
       assert(context.get[Set[Char]] == "ab".toSet)
       assert(context.get[Ref[Fn, Set[Char]]].get.unsafeRun() == "ABZ".toSet)

--- a/distage/distage-core/src/test/scala/izumi/distage/staticinjector/MacroAutoFactoriesTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/staticinjector/MacroAutoFactoriesTest.scala
@@ -21,7 +21,7 @@ class MacroAutoFactoriesTest extends AnyWordSpec with MkInjector {
 
     val injector = mkNoCyclesInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     val factory = context.get[Factory]
     assert(factory.wiringTargetForDependency != null)
@@ -55,7 +55,7 @@ class MacroAutoFactoriesTest extends AnyWordSpec with MkInjector {
 
     val injector = mkNoCyclesInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     val instantiated = context.get[GenericAssistedFactory]
     val product = instantiated.x(List(SpecialDep()), List(5))
@@ -74,7 +74,7 @@ class MacroAutoFactoriesTest extends AnyWordSpec with MkInjector {
 
     val injector = mkNoCyclesInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     val instantiated = context.get[AssistedFactory]
 
@@ -93,7 +93,7 @@ class MacroAutoFactoriesTest extends AnyWordSpec with MkInjector {
 
     val injector = mkNoCyclesInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     val instantiated = context.get[NamedAssistedFactory]
 
@@ -133,7 +133,7 @@ class MacroAutoFactoriesTest extends AnyWordSpec with MkInjector {
 
     val injector = mkNoCyclesInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     val instantiated = context.get[Factory]
 

--- a/distage/distage-core/src/test/scala/izumi/distage/staticinjector/MacroAutoTraitsTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/staticinjector/MacroAutoTraitsTest.scala
@@ -31,7 +31,7 @@ class MacroAutoTraitsTest extends AnyWordSpec with MkInjector {
     val injector = mkNoCyclesInjector()
     val plan = injector.plan(PlannerInput.noGc(definition))
 
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
     val instantiated = context.get[TestTrait]
     assert(instantiated.isInstanceOf[TestTrait])
     assert(instantiated.dep != null)
@@ -48,7 +48,7 @@ class MacroAutoTraitsTest extends AnyWordSpec with MkInjector {
     val injector = mkNoCyclesInjector()
     val plan = injector.plan(PlannerInput.noGc(definition))
 
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
     val instantiated = context.get[TestTrait]("named-trait")
     assert(instantiated.isInstanceOf[TestTrait])
     assert(instantiated.dep != null)
@@ -69,7 +69,7 @@ class MacroAutoTraitsTest extends AnyWordSpec with MkInjector {
     val injector = mkNoCyclesInjector()
     val plan = injector.plan(PlannerInput.noGc(definition))
 
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
     val instantiated1 = context.get[Trait1]
     assert(instantiated1.isInstanceOf[Trait1])
 
@@ -95,7 +95,7 @@ class MacroAutoTraitsTest extends AnyWordSpec with MkInjector {
     val injector = mkNoCyclesInjector()
     val plan = injector.plan(PlannerInput.noGc(definition))
 
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
     val instantiated3 = context.get[Trait2]
     assert(instantiated3.isInstanceOf[Trait2])
     assert(instantiated3.asInstanceOf[Trait3].prr() == "Hello World")
@@ -111,7 +111,7 @@ class MacroAutoTraitsTest extends AnyWordSpec with MkInjector {
 
     val injector = mkNoCyclesInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
     val instantiated = context.get[TestTraitAny {def dep: Dep}]
 
     assert(instantiated.dep eq context.get[Dep])
@@ -128,7 +128,7 @@ class MacroAutoTraitsTest extends AnyWordSpec with MkInjector {
 
     val injector = mkNoCyclesInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     val instantiated = context.get[Trait2 with (Trait2 with (Trait2 with Trait1))]
 
@@ -149,7 +149,7 @@ class MacroAutoTraitsTest extends AnyWordSpec with MkInjector {
     val injector = mkNoCyclesInjector()
     val plan = injector.plan(PlannerInput.noGc(definition))
 
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
     val instantiated = context.get[Trait]
 
     assert(instantiated.depA.isA)
@@ -172,7 +172,7 @@ class MacroAutoTraitsTest extends AnyWordSpec with MkInjector {
     val injector = mkNoCyclesInjector()
     val plan = injector.plan(PlannerInput.noGc(definition))
 
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
     val instantiated = context.get[TestTrait]
 
     assert(instantiated.rd == Dep().toString)
@@ -189,7 +189,7 @@ class MacroAutoTraitsTest extends AnyWordSpec with MkInjector {
 
     val injector = mkNoCyclesInjector()
     val plan = injector.plan(definition)
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     assert(context.get[TestTrait].anyValDep != null)
 

--- a/distage/distage-core/src/test/scala/izumi/distage/staticinjector/StaticHigherKindsTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/staticinjector/StaticHigherKindsTest.scala
@@ -33,7 +33,7 @@ class StaticHigherKindsTest extends AnyWordSpec with MkInjector {
 
     val listInjector = mkNoCyclesInjector()
     val listPlan = listInjector.plan(PlannerInput.noGc(Definition[List](5)))
-    val listContext = listInjector.produceUnsafe(listPlan)
+    val listContext = listInjector.produce(listPlan).unsafeGet()
 
     assert(listContext.get[TestTrait].get == List(5))
     assert(listContext.get[TestServiceClass[List]].get == List(5))
@@ -46,7 +46,7 @@ class StaticHigherKindsTest extends AnyWordSpec with MkInjector {
 
     val optionTInjector = mkNoCyclesInjector()
     val optionTPlan = optionTInjector.plan(PlannerInput.noGc(Definition[OptionT[List, ?]](5)))
-    val optionTContext = optionTInjector.produceUnsafe(optionTPlan)
+    val optionTContext = optionTInjector.produce(optionTPlan).unsafeGet()
 
     assert(optionTContext.get[TestTrait].get == OptionT(List(Option(5))))
     assert(optionTContext.get[TestServiceClass[OptionT[List, ?]]].get == OptionT(List(Option(5))))
@@ -55,7 +55,7 @@ class StaticHigherKindsTest extends AnyWordSpec with MkInjector {
 
     val idInjector = mkNoCyclesInjector()
     val idPlan = idInjector.plan(PlannerInput.noGc(Definition[id](5)))
-    val idContext = idInjector.produceUnsafe(idPlan)
+    val idContext = idInjector.produce(idPlan).unsafeGet()
 
     assert(idContext.get[TestTrait].get == 5)
     assert(idContext.get[TestServiceClass[id]].get == 5)

--- a/distage/distage-core/src/test/scala/izumi/distage/staticinjector/StaticImplicitInjectionTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/staticinjector/StaticImplicitInjectionTest.scala
@@ -20,7 +20,7 @@ class StaticImplicitInjectionTest extends AnyWordSpec with MkInjector {
       make[TestClass]
     }
     val plan = injector.plan(PlannerInput.noGc(definition))
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     assert(context.get[TestClass].a != null)
     assert(context.get[TestClass].b != null)
@@ -42,7 +42,7 @@ class StaticImplicitInjectionTest extends AnyWordSpec with MkInjector {
       make[TestClass]
     }
     val plan = injector.plan(PlannerInput.noGc(definition))
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     assert(context.get[TestClass].b == context.get[TestClass].d)
   }

--- a/distage/distage-core/src/test/scala/izumi/distage/staticinjector/StaticInnerClassesTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/staticinjector/StaticInnerClassesTest.scala
@@ -17,7 +17,7 @@ class StaticInnerClassesTest extends AnyWordSpec with MkInjector {
     val injector = mkNoCyclesInjector()
     val plan = injector.plan(PlannerInput.noGc(definition))
 
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     assert(context.get[TopLevelPathDepTest.TestClass].a != null)
   }
@@ -39,7 +39,7 @@ class StaticInnerClassesTest extends AnyWordSpec with MkInjector {
     val injector = mkNoCyclesInjector()
     val plan = injector.plan(PlannerInput.noGc(definition))
 
-    val context = injector.produceUnsafe(plan)
+    val context = injector.produce(plan).unsafeGet()
 
     assert(context.get[testModule.TestClass].a != null)
   }
@@ -52,7 +52,7 @@ class StaticInnerClassesTest extends AnyWordSpec with MkInjector {
       make[TestDependency]
     }
 
-    val context = mkNoCyclesInjector().produceUnsafe(PlannerInput.noGc(definition))
+    val context = mkNoCyclesInjector().produce(PlannerInput.noGc(definition)).unsafeGet()
 
     assert(context.get[TestDependency] == TestDependency())
   }
@@ -66,7 +66,7 @@ class StaticInnerClassesTest extends AnyWordSpec with MkInjector {
       make[TestClass]
     }
 
-    val context = mkNoCyclesInjector().produceUnsafe(PlannerInput.noGc(definition))
+    val context = mkNoCyclesInjector().produce(PlannerInput.noGc(definition)).unsafeGet()
 
     assert(context.get[TestClass] == TestClass(TestDependency()))
   }
@@ -96,7 +96,7 @@ class StaticInnerClassesTest extends AnyWordSpec with MkInjector {
       val injector = mkNoCyclesInjector()
       val plan = injector.plan(PlannerInput.noGc(definition))
 
-      val context = injector.produceUnsafe(plan)
+      val context = injector.produce(plan).unsafeGet()
 
       assert(context.get[TestClass].a != null)
     }

--- a/distage/distage-extension-config/src/test/scala/izumi/distage/config/ConfigTest.scala
+++ b/distage/distage-extension-config/src/test/scala/izumi/distage/config/ConfigTest.scala
@@ -27,7 +27,7 @@
 //      val injector = Injector.Standard(mkConfigModule("distage-config-test.conf"))
 //      val plan = injector.plan(TestConfigApp.definition)
 //
-//      val context = injector.produceUnsafe(plan)
+//      val context = injector.produce(plan).unsafeGet()
 //
 //      assert(context.get[HttpServer1].listenOn.port == 8081)
 //      assert(context.get[HttpServer2].listenOn.port == 8082)
@@ -70,7 +70,7 @@
 //      val injector = Injector.Standard(mkConfigModule("distage-config-test.conf"))
 //      val plan = injector.plan(TestConfigApp.setDefinition)
 //
-//      val context = injector.produceUnsafe(plan)
+//      val context = injector.produce(plan).unsafeGet()
 //
 //      assert(context.get[Set[TestAppService]].head.asInstanceOf[DataPuller1].target.port == 9001)
 //    }
@@ -79,7 +79,7 @@
 //      val injector = Injector.Standard(mkConfigModule("map-test.conf"))
 //      val plan = injector.plan(TestConfigReaders.mapDefinition)
 //
-//      val context = injector.produceUnsafe(plan)
+//      val context = injector.produce(plan).unsafeGet()
 //
 //      assert(context.get[Service[MapCaseClass]].conf.mymap.isInstanceOf[mutable.LinkedHashMap[_, _]])
 //      assert(context.get[Service[MapCaseClass]].conf.mymap.keySet == Set("service1", "service2", "service3", "service4", "service5", "service6"))
@@ -97,7 +97,7 @@
 //      val injector = Injector.Standard(mkConfigModule("list-test.conf"))
 //      val plan = injector.plan(TestConfigReaders.listDefinition)
 //
-//      val context = injector.produceUnsafe(plan)
+//      val context = injector.produce(plan).unsafeGet()
 //
 //      assert(context.get[Service[ListCaseClass]].conf.mylist.isInstanceOf[IndexedSeq[_]])
 //      assert(context.get[Service[ListCaseClass]].conf.mylist.head.isInstanceOf[ListSet[_]])
@@ -114,7 +114,7 @@
 //      val injector = Injector.Standard(mkConfigModule("opt-test.conf"))
 //      val plan = injector.plan(TestConfigReaders.optDefinition)
 //
-//      val context = injector.produceUnsafe(plan)
+//      val context = injector.produce(plan).unsafeGet()
 //
 //      assert(context.get[Service[OptionCaseClass]].conf == OptionCaseClass(optInt = None))
 //    }
@@ -130,7 +130,7 @@
 //      val injector = Injector.Standard(mkConfigModule("opt-test-missing.conf"))
 //      val plan = injector.plan(TestConfigReaders.optDefinition)
 //
-//      val context = injector.produceUnsafe(plan)
+//      val context = injector.produce(plan).unsafeGet()
 //
 //      assert(context.get[Service[OptionCaseClass]].conf == OptionCaseClass(optInt = None))
 //    }
@@ -167,7 +167,7 @@
 //        make[TestTrait]
 //      })
 //      val plan = injector.plan(definition)
-//      val context = injector.produceUnsafe(plan)
+//      val context = injector.produce(plan).unsafeGet()
 //
 //      assert(context.get[TestTrait].x == TestDependency(TestConf(false)))
 //      assert(context.get[TestTrait].testConf == TestConf(true))
@@ -185,7 +185,7 @@
 //        make[TestGenericConfFactory[TestConfAlias]]
 //      })
 //      val plan = injector.plan(definition)
-//      val context = injector.produceUnsafe(plan)
+//      val context = injector.produce(plan).unsafeGet()
 //
 //      val factory = context.get[TestFactory]
 //      assert(factory.make(5) == ConcreteProduct(TestConf(true), 5))

--- a/distage/distage-extension-config/src/test/scala/izumi/distage/config/StaticConfigTest.scala
+++ b/distage/distage-extension-config/src/test/scala/izumi/distage/config/StaticConfigTest.scala
@@ -22,7 +22,7 @@
 //      make[TestTrait]
 //    }
 //    val plan = injector.plan(PlannerInput.noGc(definition))
-//    val context = injector.produceUnsafe(plan)
+//    val context = injector.produce(plan).unsafeGet()
 //
 //    assert(context.get[TestTrait].x == TestDependency(TestConf(false)))
 //    assert(context.get[TestTrait].testConf == TestConf(true))
@@ -40,7 +40,7 @@
 //      make[TestGenericConfFactory[TestConfAlias]]
 //    }
 //    val plan = injector.plan(PlannerInput.noGc(definition))
-//    val context = injector.produceUnsafe(plan)
+//    val context = injector.produce(plan).unsafeGet()
 //
 //    assert(context.get[TestDependency] == TestDependency(TestConf(false)))
 //    assert(context.get[TestGenericConfFactory[TestConf]].x == TestDependency(TestConf(false)))
@@ -59,7 +59,7 @@
 //      make[TestGenericConfFactory[TestConfAlias]]
 //    }
 //    val plan = injector.plan(PlannerInput.noGc(definition))
-//    val context = injector.produceUnsafe(plan)
+//    val context = injector.produce(plan).unsafeGet()
 //
 //    val factory = context.get[TestFactory]
 //    assert(factory.make(5) == ConcreteProduct(TestConf(true), 5))
@@ -85,7 +85,7 @@
 //      }
 //    }
 //    val plan = injector.plan(PlannerInput.noGc(definition))
-//    val context = injector.produceUnsafe(plan)
+//    val context = injector.produce(plan).unsafeGet()
 //
 //    assert(context.get[ConcreteProduct] == ConcreteProduct(TestConf(false), 50))
 //  }

--- a/distage/distage-extension-logstage/src/test/scala/izumi/logstage/distage/LoggerInjectionTest.scala
+++ b/distage/distage-extension-logstage/src/test/scala/izumi/logstage/distage/LoggerInjectionTest.scala
@@ -35,7 +35,7 @@ class LoggerInjectionTest extends AnyWordSpec {
 
       val injector = Injector(loggerModule)
       val plan = injector.plan(definition)
-      val context = injector.produceUnsafe(plan)
+      val context = injector.produce(plan).unsafeGet()
       assert(context.get[ExampleApp].test == 265)
 
       val messages = testSink.fetch()

--- a/distage/distage-testkit-core/src/test/scala/izumi/distage/testkit/catstest/CatsExtensionsTest.scala
+++ b/distage/distage-testkit-core/src/test/scala/izumi/distage/testkit/catstest/CatsExtensionsTest.scala
@@ -74,7 +74,7 @@ class CatsExtensionsTest extends AnyWordSpec with GivenWhenThen {
       plan3.render()
       assert(filterDynamic(plan3.steps) == filterDynamic(plan4.steps))
 
-      val objs = injector.produceUnsafeF[IO](plan3).unsafeRunSync()
+      val objs = injector.produceF[IO](plan3).unsafeGet().unsafeRunSync()
 
       assert(objs.get[TestDependency1].unresolved != null)
       assert(!objs.instances.map(_.value).contains(null))

--- a/doc/microsite/src/main/tut/distage/advanced-features.md
+++ b/doc/microsite/src/main/tut/distage/advanced-features.md
@@ -37,7 +37,7 @@ val roots = GCMode.GCRoots(Set[DIKey](DIKey.get[A]))
 // create an object graph from description in `module`
 // with `A` as a GC root
 
-val objects = Injector().produceUnsafe(module, roots)
+val objects = Injector().produce(module, roots).unsafeGet()
 
 // A and B are in the object graph
 
@@ -63,15 +63,15 @@ class A(val b: B)
 class B(val a: A) 
 class C(val c: C)
 
-val locator = Injector().produceUnsafe(new ModuleDef {
+val objects = Injector().produce(new ModuleDef {
   make[A]
   make[B]
   make[C]
-}, GCMode.NoGC)
+}, GCMode.NoGC).unsafeGet()
 
-locator.get[A] eq locator.get[B].a
-locator.get[B] eq locator.get[A].b
-locator.get[C] eq locator.get[C].c
+objects.get[A] eq objects.get[B].a
+objects.get[B] eq objects.get[A].b
+objects.get[C] eq objects.get[C].c
 ```
 
 #### Automatic Resolution with generated proxies
@@ -114,7 +114,8 @@ val module = new ModuleDef {
 // disable proxies and execute the module
 
 val locator = Injector.NoProxies()
-  .produceUnsafe(module, GCMode.NoGC)
+  .produce(module, GCMode.NoGC)
+  .unsafeGet()
 
 locator.get[A].b eq locator.get[B]
 locator.get[B].a eq locator.get[A]
@@ -160,8 +161,8 @@ val appModule = new ModuleDef {
 }
 
 val resources = Injector(bootstrapModule)
-  .produceUnsafe(appModule, GCMode.NoGC)
-  .get[Set[PrintResource]]
+  .produceGet(appModule, GCMode.NoGC)
+  .use(_.get[Set[PrintResource]])
 
 resources.foreach(_.start())
 resources.toSeq.reverse.foreach(_.stop())
@@ -212,9 +213,9 @@ val module = new ModuleDef {
 
 val roots = Set[DIKey](DIKey.get[Set[Elem]])
 
-val locator = Injector().produceUnsafe(PlannerInput(module, roots))
+val objects = Injector().produce(PlannerInput(module, roots)).unsafeGet()
 
-locator.get[Set[Elem]].size == 1
+objects.get[Set[Elem]].size == 1
 ```
 
 The `Weak` class was not required by any dependency of `Set[Elem]`, so it was pruned.
@@ -248,9 +249,9 @@ final class Strong(weak: Weak) extends Elem {
   println("Strong constructed")
 }
 
-val locator = Injector().produceUnsafe(PlannerInput(module, roots))
+val objects = Injector().produce(PlannerInput(module, roots)).unsafeGet()
 
-locator.get[Set[Elem]].size == 2
+objects.get[Set[Elem]].size == 2
 ```
 
 ### Inner Classes and Path-Dependent Types
@@ -270,8 +271,8 @@ val module = new ModuleDef {
 }
 
 Injector()
-  .produceUnsafe(module, GCMode.NoGC)
-  .get[path.A]
+  .produce(module, GCMode.NoGC)
+  .use(_.get[path.A])
 ```
 
 Since version `0.10`, path-dependent types with a type (non-value) prefix are no longer supported, see issue: https://github.com/7mind/izumi/issues/764
@@ -295,9 +296,9 @@ val module = new ModuleDef {
   make[C]
 }
 
-val locator = Injector().produceUnsafe(module, GCMode.NoGC)
+val objects = Injector().produce(module, GCMode.NoGC).unsafeGet()
 
-assert(locator.get[A].c eq locator.get[C]) 
+assert(objects.get[A].c eq objects.get[C]) 
 ```
 
 Locator contains metadata about the plan and the bindings from which it was ultimately created:

--- a/doc/microsite/src/main/tut/distage/advanced-features.md
+++ b/doc/microsite/src/main/tut/distage/advanced-features.md
@@ -161,7 +161,7 @@ val appModule = new ModuleDef {
 }
 
 val resources = Injector(bootstrapModule)
-  .produceGet(appModule, GCMode.NoGC)
+  .produce(appModule, GCMode.NoGC)
   .use(_.get[Set[PrintResource]])
 
 resources.foreach(_.start())
@@ -306,7 +306,7 @@ Locator contains metadata about the plan and the bindings from which it was ulti
 ```scala mdoc:to-string
 // Plan that created this locator
 
-val plan: OrderedPlan = locator.plan
+val plan: OrderedPlan = objects.plan
 
 // Bindings from which the Plan was built
 

--- a/doc/microsite/src/main/tut/distage/basics.md
+++ b/doc/microsite/src/main/tut/distage/basics.md
@@ -279,8 +279,6 @@ println(closedInit.initialized)
 You can convert between `DIResource` and `cats.effect.Resource` via `.toCats`/`.fromCats` methods, and between
 `zio.ZManaged` via `.toZIO`/`.fromZIO`.
 
-You need to use resource-aware `Injector.produce`/`Injector.produceF`, instead of `produceUnsafe` to be able to deallocate the object graph.
-
 ### Set Bindings
 
 Set bindings are useful for implementing listeners, plugins, hooks, http routes, healthchecks, migrations, etc.
@@ -364,7 +362,7 @@ val finalModule = Seq(
 ).merge
 
 // wire the graph
-val objects = Injector().produceUnsafeF[IO](finalModule, GCMode.NoGC).unsafeRunSync()
+val objects = Injector().produceF[IO](finalModule, GCMode.NoGC).unsafeGet().unsafeRunSync()
 
 val server = objects.get[Server[IO]]
 val client = objects.get[Client[IO]]
@@ -448,7 +446,7 @@ val io = Injector()
 new zio.DefaultRuntime{}.unsafeRun(io)
 ```
 
-You need to use effect-aware `Injector.produceF`/`Injector.produceUnsafeF` methods to use effect bindings.
+You need to use effect-aware `Injector.produceF` method to use effect bindings.
 
 ### Auto-Traits
 

--- a/doc/microsite/src/main/tut/distage/distage-framework.md
+++ b/doc/microsite/src/main/tut/distage/distage-framework.md
@@ -83,12 +83,12 @@ val appModule = new ModuleDef {
   make[ConfigPrinter]
 }
 
-val objects = Injector().produceUnsafe(
-  input = Seq(appModule, configModule, appConfigModule).merge,
-  mode  = GCMode(DIKey.get[ConfigPrinter])
-)
-
-objects.get[ConfigPrinter].print()
+Injector().produceGet[ConfigPrinter](
+  Seq(appModule, configModule, appConfigModule).merge
+).use {
+  configPrinter =>
+    configPrinter.print()
+} 
 ```
 
 Automatic derivation of config codecs is based on [circe-config](https://github.com/circe/circe-config) & [circe-derivation](https://github.com/circe/circe-derivation). 


### PR DESCRIPTION
* Replace with `produce(_).unsafeGet()`