### PR TITLE
Fail fast instead of printing an error if there's a config file read error

### DIFF
--- a/distage/distage-framework/src/main/scala/izumi/distage/roles/services/EarlyLoggers.scala
+++ b/distage/distage-framework/src/main/scala/izumi/distage/roles/services/EarlyLoggers.scala
@@ -20,13 +20,7 @@ object EarlyLoggers {
   def makeLateLogger(parameters: RawAppArgs, earlyLogger: IzLogger, config: AppConfig, defaultLogLevel: Log.Level, defaultLogFormatJson: Boolean): IzLogger = {
     val rootLogLevel = getRootLogLevel(parameters.globalParameters, defaultLogLevel)
     val logJson = getLogFormatJson(parameters.globalParameters, defaultLogFormatJson)
-    val loggerConfig = Try(config.config.getConfig("logger")).getOrElse(ConfigFactory.empty("Couldn't parse `logger` configuration"))
-    val router = new SimpleLoggerConfigurator(earlyLogger)
-      .makeLogRouter(
-        config = loggerConfig,
-        root = rootLogLevel,
-        json = logJson,
-      )
+    val router = new SimpleLoggerConfigurator(earlyLogger).makeLogRouter(config.config, rootLogLevel, logJson)
 
     IzLogger(router)("phase" -> "late")
   }

--- a/distage/distage-framework/src/main/scala/izumi/distage/roles/services/EarlyLoggers.scala
+++ b/distage/distage-framework/src/main/scala/izumi/distage/roles/services/EarlyLoggers.scala
@@ -1,14 +1,11 @@
 package izumi.distage.roles.services
 
-import com.typesafe.config.ConfigFactory
 import izumi.distage.config.model.AppConfig
 import izumi.distage.roles.RoleAppLauncher.Options
 import izumi.distage.roles.logger.SimpleLoggerConfigurator
 import izumi.fundamentals.platform.cli.model.raw.{RawAppArgs, RawEntrypointParams}
 import izumi.logstage.api.Log.Level
 import izumi.logstage.api.{IzLogger, Log}
-
-import scala.util.Try
 
 object EarlyLoggers {
 

--- a/logstage/logstage-core/.jvm/src/main/scala/izumi/logstage/sink/QueueingSink.scala
+++ b/logstage/logstage-core/.jvm/src/main/scala/izumi/logstage/sink/QueueingSink.scala
@@ -12,7 +12,6 @@ import izumi.logstage.sink.QueueingSink.CountingStep
 
 import scala.concurrent.duration._
 
-
 class QueueingSink(target: LogSink, sleepTime: FiniteDuration = 50.millis)
   extends LogSink
     with AutoCloseable {


### PR DESCRIPTION
* Print a less annoying warning if there's no `logger` section in config