### PR TITLE
distage-framework-docker: Revert to deleting file locks for reused containers on exit, instead of as soon as possible

### DIFF
--- a/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/ContainerDef.scala
+++ b/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/ContainerDef.scala
@@ -1,0 +1,53 @@
+package izumi.distage.docker
+
+import distage.TagK
+import izumi.distage.model.definition.DIResource.DIResourceBase
+import izumi.distage.model.providers.ProviderMagnet
+import izumi.fundamentals.platform.language.Quirks._
+
+trait ContainerDef {
+  self =>
+  type Tag
+  type Container = DockerContainer[Tag]
+  type Config = Docker.ContainerConfig[Tag]
+
+  def config: Config
+
+  /**
+    * For binding in `ModuleDef`:
+    *
+    * {{{
+    * object KafkaDocker extends ContainerDef
+    * object ZookeeperDocker extends ContainerDef
+    *
+    * make[KafkaDocker.Container].fromResource {
+    *   KafkaDocker
+    *     .make[F]
+    *     .dependOnDocker(ZookeeperDocker)
+    * }
+    * }}}
+    *
+    * To kill all containers spawned by distage, use the following command:
+    *
+    * {{{
+    *   docker rm -f $(docker ps -q -a -f 'label=distage.type')
+    * }}}
+    *
+    */
+  final def make[F[_]: TagK](implicit tag: distage.Tag[Tag]): ProviderMagnet[DockerContainer.ContainerResource[F, Tag] with DIResourceBase[F, Container]] = {
+    tag.discard()
+    DockerContainer.resource[F](this)
+  }
+
+  final def copy(config: Config): ContainerDef.Aux[self.Tag] = {
+    @inline def c = config
+    new ContainerDef {
+      override type Tag = self.Tag
+      override def config: Config = c
+    }
+  }
+}
+
+object ContainerDef {
+  type Aux[T] = ContainerDef { type Tag = T }
+}

--- a/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/ContainerNetworkDef.scala
+++ b/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/ContainerNetworkDef.scala
@@ -12,6 +12,7 @@ import izumi.logstage.api.IzLogger
 import izumi.fundamentals.platform.language.Quirks._
 
 import scala.collection.JavaConverters._
+import scala.concurrent.duration._
 
 trait ContainerNetworkDef {
   self =>
@@ -62,7 +63,7 @@ object ContainerNetworkDef {
 
     override def acquire: F[ContainerNetwork[T]] = {
       if (config.reuse) {
-        FileLockMutex.withLocalMutex(prefix, logger) {
+        FileLockMutex.withLocalMutex(logger)(prefix, waitFor = 1.second, maxAttempts = 10) {
           val labelsSet = stableLabels.toSet
           val existedNetworks = client.listNetworksCmd().exec().asScala.toList
           existedNetworks.find(_.labels.asScala.toSet == labelsSet).fold(createNew()) {

--- a/fundamentals/fundamentals-bio/src/test/scala/izumi/fundamentals/bio/test/BIOSyntaxTest.scala
+++ b/fundamentals/fundamentals-bio/src/test/scala/izumi/fundamentals/bio/test/BIOSyntaxTest.scala
@@ -178,7 +178,7 @@ class BIOSyntaxTest extends AnyWordSpec {
         }.toKleisli
       }.provide(4).flatMap(_ => F.unit).widenError[Throwable].leftMap(identity)
     }
-    def docExamples = {
+    def docExamples() = {
       import izumi.functional.bio.{F, BIOMonad, BIOMonadAsk, BIOPrimitives, BIORef3}
 
       def adder[F[+_, +_]: BIOMonad: BIOPrimitives](i: Int): F[Nothing, Int] =
@@ -211,7 +211,7 @@ class BIOSyntaxTest extends AnyWordSpec {
       biotemporalPlusLocal[zio.ZIO],
       biomonadPlusLocal[zio.ZIO],
       bifunctorOnly[zio.ZIO],
-      docExamples,
+      docExamples(),
     )
   }
 }


### PR DESCRIPTION
Could cause conflicts if a file was deleted at the same time another resource in parallel tried to lock it