### PR TITLE
distage-testkit: Fix recorded test error messages in sbt reports, scalatest xml reports, etc. 

### DIFF
--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/services/DISyntaxBIOBase.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/services/DISyntaxBIOBase.scala
@@ -2,8 +2,8 @@ package izumi.distage.testkit.services
 
 import distage.{Tag, TagKK}
 import izumi.distage.model.providers.ProviderMagnet
-import izumi.distage.testkit.services.DISyntaxBIOBase.BIOBadBranch
 import izumi.functional.bio.BIOError
+import izumi.functional.bio.BIORunner.BIOBadBranch
 import izumi.fundamentals.platform.language.CodePosition
 
 trait DISyntaxBIOBase[F[+_, +_]] extends DISyntaxBase[F[Throwable, ?]] {
@@ -15,7 +15,7 @@ trait DISyntaxBIOBase[F[+_, +_]] extends DISyntaxBase[F[Throwable, ?]] {
         (effect, F) =>
           F.leftMap(effect) {
             case t: Throwable => t
-            case otherError: Any => BIOBadBranch(otherError)
+            case otherError: Any => BIOBadBranch("Test failed, unexpectedly got bad branch. ", otherError)
           }
       }
 
@@ -26,9 +26,4 @@ trait DISyntaxBIOBase[F[+_, +_]] extends DISyntaxBase[F[Throwable, ?]] {
     takeBIO(function, pos)
   }
 
-}
-
-object DISyntaxBIOBase {
-  final case class BIOBadBranch[A](error: A)
-    extends RuntimeException(s"Test failed, unexpectedly got bad branch. Cause: $error", null, true, false)
 }

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/services/dstest/DistageTestRunner.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/services/dstest/DistageTestRunner.scala
@@ -152,16 +152,16 @@ class DistageTestRunner[F[_]: TagK]
                 case (ProvisioningIntegrationException(integrations), _) =>
                   // FIXME: temporary hack to allow missing containers to skip tests (happens when both DockerWrapper & integration check that depends on Docker.Container are memoized)
                   F.maybeSuspend(ignoreIntegrationCheckFailedTests(tests, integrations))
-                case (t, cause) =>
+                case (_, getTrace) =>
                   // fail all tests (if an exception reached here, it must have happened before the individual test runs)
-                  F.maybeSuspend(failAllTests(tests, t, cause))
+                  F.maybeSuspend(failAllTests(tests, getTrace()))
               }
             }
         }
       } catch {
         case t: Throwable =>
           // fail all tests (if an exception reaches here, it must have happened before the runtime was successfully produced)
-          failAllTests(tests, t, t)
+          failAllTests(tests, t)
           reporter.onFailure(t)
       }
     }
@@ -184,10 +184,10 @@ class DistageTestRunner[F[_]: TagK]
     }
   }
 
-  protected def failAllTests(tests: Seq[DistageTest[F]], t: Throwable, cause: Throwable): Unit = {
+  protected def failAllTests(tests: Seq[DistageTest[F]], t: Throwable): Unit = {
     tests.foreach {
       test =>
-        reporter.testStatus(test.meta, TestStatus.Failed(t, cause, Duration.Zero))
+        reporter.testStatus(test.meta, TestStatus.Failed(t, Duration.Zero))
     }
   }
 
@@ -263,9 +263,9 @@ class DistageTestRunner[F[_]: TagK]
           F.maybeSuspend {
             reporter.testStatus(test.meta, TestStatus.Cancelled(s.getMessage, testDuration(before)))
           }
-        case (t, cause) =>
+        case (_, getTrace) =>
           F.maybeSuspend {
-            reporter.testStatus(test.meta, TestStatus.Failed(t, cause, testDuration(before)))
+            reporter.testStatus(test.meta, TestStatus.Failed(getTrace(), testDuration(before)))
           }
       }
     }
@@ -350,7 +350,7 @@ object DistageTestRunner {
 
     final case class Succeed(duration: FiniteDuration) extends Finished
 
-    final case class Failed(t: Throwable, t1: Throwable, duration: FiniteDuration) extends Finished
+    final case class Failed(t: Throwable, duration: FiniteDuration) extends Finished
 
   }
 

--- a/distage/distage-testkit-scalatest/src/main/scala/org/scalatest/distage/DistageScalatestReporter.scala
+++ b/distage/distage-testkit-scalatest/src/main/scala/org/scalatest/distage/DistageScalatestReporter.scala
@@ -6,7 +6,6 @@ import izumi.distage.testkit.services.scalatest.dstest.DistageTestsRegistrySingl
 import izumi.fundamentals.platform.strings.IzString._
 import org.scalatest.Suite.getIndentedTextForTest
 import org.scalatest.events._
-import zio.{Cause, FiberFailure}
 
 class DistageScalatestReporter extends TestReporter {
 
@@ -67,11 +66,7 @@ class DistageScalatestReporter extends TestReporter {
           location = Some(LineInFile(test.pos.position.line, test.pos.position.file, None)),
           formatter = formatter,
         ))
-      case TestStatus.Failed(t, trace0, duration) =>
-        val trace = trace0 match {
-          case f: FiberFailure => f.cause.asInstanceOf[Cause[Throwable]].squashTrace
-          case x => x
-        }
+      case TestStatus.Failed(t, duration) =>
         doReport(suiteId1)(TestFailed(
           _,
           t.getMessage,
@@ -80,7 +75,7 @@ class DistageScalatestReporter extends TestReporter {
           testName,
           recordedEvents = Vector.empty,
           analysis = Vector.empty,
-          throwable = Some(trace),
+          throwable = Some(t),
           duration = Some(duration.toMillis),
           location = Some(LineInFile(test.pos.position.line, test.pos.position.file, None)),
           formatter = formatter,

--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/BIOExit.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/BIOExit.scala
@@ -6,50 +6,61 @@ sealed trait BIOExit[+E, +A]
 
 object BIOExit {
 
-  trait Trace {
+  trait Trace[+E] {
     def asString: String
     def toThrowable: Throwable
+
+    /** Unsafely Mutate the contained Throwable to attach this Trace's debugging information to it.
+      *
+      * NOTE: may mutate arbitrary Throwables contained in the trace, discard all throwables that came from the same source
+      * @param conv convert any contained typed errors into a Throwable
+      */
+    def unsafeAttachTrace(conv: E => Throwable): Throwable
 
     override final def toString: String = asString
   }
 
   object Trace {
-    def zioTrace(cause: Cause[_]): Trace = ZIOTrace(cause)
-    def empty: Trace = new Trace {
+    @deprecated("Use ZIOTrace", "will be removed after 0.10.5")
+    private[bio] def zioTrace[E](cause: Cause[E]): Trace[E] = ZIOTrace(cause)
+    def empty: Trace[Nothing] = new Trace[Nothing] {
       val asString: String = "<empty trace>"
       def toThrowable: Throwable = new RuntimeException(asString)
+      def unsafeAttachTrace(conv: Nothing => Throwable): Throwable = toThrowable
     }
 
-    final case class ZIOTrace(cause: Cause[_]) extends Trace {
+    final case class ZIOTrace[+E](cause: Cause[E]) extends Trace[E] {
       override def asString: String = cause.prettyPrint
       override def toThrowable: Throwable = FiberFailure(cause)
+      override def unsafeAttachTrace(conv: E => Throwable): Throwable = cause.squashTraceWith(conv)
     }
   }
 
   final case class Success[+A](value: A) extends BIOExit[Nothing, A]
 
   sealed trait Failure[+E] extends BIOExit[E, Nothing] {
-    def trace: Trace
+    def trace: Trace[E]
 
     def toEither: Either[List[Throwable], E]
     def toEitherCompound: Either[Throwable, E]
 
     final def toThrowable(implicit ev: E <:< Throwable): Throwable = toEitherCompound.fold(identity, ev)
     final def toThrowable(conv: E => Throwable): Throwable = toEitherCompound.fold(identity, conv)
+    final def unsafeAttachTrace(conv: E => Throwable): Throwable = trace.unsafeAttachTrace(conv)
   }
 
-  final case class Error[+E](error: E, trace: Trace) extends BIOExit.Failure[E] {
+  final case class Error[+E](error: E, trace: Trace[E]) extends BIOExit.Failure[E] {
     override def toEither: Right[Nothing, E] = Right(error)
     override def toEitherCompound: Right[Nothing, E] = Right(error)
   }
 
-  final case class Termination(compoundException: Throwable, allExceptions: List[Throwable], trace: Trace) extends BIOExit.Failure[Nothing] {
+  final case class Termination(compoundException: Throwable, allExceptions: List[Throwable], trace: Trace[Nothing]) extends BIOExit.Failure[Nothing] {
     override def toEither: Left[List[Throwable], Nothing] = Left(allExceptions)
     override def toEitherCompound: Left[Throwable, Nothing] = Left(compoundException)
   }
 
   object Termination {
-    def apply(exception: Throwable, trace: Trace): Termination = new Termination(exception, List(exception), trace)
+    def apply(exception: Throwable, trace: Trace[Nothing]): Termination = new Termination(exception, List(exception), trace)
   }
 
   object ZIOExit {
@@ -62,11 +73,9 @@ object BIOExit {
     }
 
     @inline def toBIOExit[E](result: Cause[E]): BIOExit.Failure[E] = {
-      val trace = Trace.zioTrace(result)
-
       result.failureOrCause match {
         case Left(err) =>
-          Error(err, trace)
+          Error(err, Trace.ZIOTrace(result))
         case Right(cause) =>
           val unchecked = cause.defects
           val exceptions = if (cause.interrupted) {
@@ -78,7 +87,7 @@ object BIOExit {
             case e :: Nil => e
             case _ => FiberFailure(cause)
           }
-          Termination(compound, exceptions, trace)
+          Termination(compound, exceptions, Trace.ZIOTrace(cause))
       }
     }
 

--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/BIOExit.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/BIOExit.scala
@@ -16,8 +16,8 @@ object BIOExit {
   object Trace {
     def zioTrace(cause: Cause[_]): Trace = ZIOTrace(cause)
     def empty: Trace = new Trace {
-      val asString = "<empty trace>"
-      def toThrowable = new RuntimeException(asString)
+      val asString: String = "<empty trace>"
+      def toThrowable: Throwable = new RuntimeException(asString)
     }
 
     final case class ZIOTrace(cause: Cause[_]) extends Trace {
@@ -29,12 +29,13 @@ object BIOExit {
   final case class Success[+A](value: A) extends BIOExit[Nothing, A]
 
   sealed trait Failure[+E] extends BIOExit[E, Nothing] {
+    def trace: Trace
+
     def toEither: Either[List[Throwable], E]
     def toEitherCompound: Either[Throwable, E]
 
-    def trace: Trace
-
     final def toThrowable(implicit ev: E <:< Throwable): Throwable = toEitherCompound.fold(identity, ev)
+    final def toThrowable(conv: E => Throwable): Throwable = toEitherCompound.fold(identity, conv)
   }
 
   final case class Error[+E](error: E, trace: Trace) extends BIOExit.Failure[E] {


### PR DESCRIPTION
@alexander-branevskiy 

* preserve original class of Throwable in BIORunner.unsafeRun
* add BIOExit.Trace.unsafeAttachTrace