### PR TITLE
distage-framework-docker: rename DockerContainerModule to DockerSupportModule

### DIFF
--- a/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/modules/DockerSupportModule.scala
+++ b/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/modules/DockerSupportModule.scala
@@ -6,15 +6,15 @@ import izumi.distage.config.ConfigModuleDef
 import izumi.distage.model.definition.ModuleDef
 import izumi.distage.docker.{Docker, DockerClientWrapper, DockerCmdExecFactoryResource}
 
-class DockerContainerModule[F[_]: TagK] extends ModuleDef {
+class DockerSupportModule[F[_]: TagK] extends ModuleDef {
   make[DockerClientWrapper[F]].fromResource[DockerClientWrapper.Resource[F]]
   make[DockerCmdExecFactory].fromResource[DockerCmdExecFactoryResource[F]]
 
-  include(DockerContainerModule.config)
+  include(DockerSupportModule.config)
 }
 
-object DockerContainerModule {
-  def apply[F[_]: TagK]: DockerContainerModule[F] = new DockerContainerModule[F]
+object DockerSupportModule {
+  def apply[F[_]: TagK]: DockerSupportModule[F] = new DockerContainerModule[F]
 
   final val config = new ConfigModuleDef {
     makeConfig[Docker.ClientConfig]("docker")

--- a/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/modules/package.scala
+++ b/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/modules/package.scala
@@ -1,0 +1,8 @@
+package izumi.distage.docker
+
+package object modules {
+  @deprecated("DockerContainerModule has been renamed to `DockerSupportModule`", "old name will be deleted in 0.11.1")
+  type DockerContainerModule[F[_]] = DockerSupportModule[F]
+  @deprecated("DockerContainerModule has been renamed to `DockerSupportModule`", "old name will be deleted in 0.11.1")
+  lazy val DockerContainerModule: DockerSupportModule.type = DockerSupportModule
+}

--- a/distage/distage-framework-docker/src/test/scala/izumi/distage/testkit/docker/fixtures/DockerPlugin.scala
+++ b/distage/distage-framework-docker/src/test/scala/izumi/distage/testkit/docker/fixtures/DockerPlugin.scala
@@ -25,7 +25,8 @@ class PgSvcExample(
 
 object MonadPlugin extends PluginDef with CatsDIEffectModule with ZIODIEffectModule
 
-object DockerPlugin extends DockerContainerModule[Task] with PluginDef {
+object DockerPlugin extends PluginDef {
+  include(DockerSupportModule[Task])
   make[DynamoDocker.Container].fromResource {
     DynamoDocker.make[Task]
   }

--- a/distage/distage-framework-docker/src/test/scala/izumi/distage/testkit/docker/fixtures/DockerPlugin.scala
+++ b/distage/distage-framework-docker/src/test/scala/izumi/distage/testkit/docker/fixtures/DockerPlugin.scala
@@ -3,7 +3,7 @@ package izumi.distage.testkit.docker.fixtures
 import distage.config.ConfigModuleDef
 import izumi.distage.docker.Docker.AvailablePort
 import izumi.distage.docker.examples._
-import izumi.distage.docker.modules.DockerContainerModule
+import izumi.distage.docker.modules.DockerSupportModule
 import izumi.distage.effect.modules.{CatsDIEffectModule, ZIODIEffectModule}
 import izumi.distage.framework.model.IntegrationCheck
 import izumi.distage.model.definition.Id


### PR DESCRIPTION
DockerContainerModule is misnamed - the module adds the infrastructure required to launch docker containers, not adds a specific container