### PR TITLE
distage-testkit: Add `TestConfig#debugOutput`, rename `TestConfig#testRunnerLogLevel`->`logLevel`, choose lowest `logLevel` among all tests envs for test runner logs (allow silencing config load log).

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -10,6 +10,7 @@ spaces.inImportCurlyBraces = false
 literals.hexDigits = "Upper"
 
 align = none
+align.stripMargin = true
 
 newlines.alwaysBeforeCurlyBraceLambdaParams = true
 newlines.afterCurlyLambda = never

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/plan/TriSplittedPlan.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/plan/TriSplittedPlan.scala
@@ -2,11 +2,16 @@ package izumi.distage.model.plan
 
 import izumi.fundamentals.platform.strings.IzString._
 
-case class TriSplittedPlan(
-                            side: OrderedPlan,
-                            primary: OrderedPlan,
-                            shared: OrderedPlan,
-                          )
+/**
+  * @param side    integrations, must be inhertied from the `shared` plan
+  * @param primary plan producing roots, must be inherited from the `side` plan
+  * @param shared  creates a part of the graph shared by both `side` and `primary` plans
+  */
+final case class TriSplittedPlan(
+  side: OrderedPlan,
+  primary: OrderedPlan,
+  shared: OrderedPlan,
+)
 
 object TriSplittedPlan {
   implicit class TriPlanEx(split: TriSplittedPlan) {

--- a/distage/distage-framework-docker/src/test/scala/izumi/distage/testkit/docker/DistageTestDockerBIO.scala
+++ b/distage/distage-framework-docker/src/test/scala/izumi/distage/testkit/docker/DistageTestDockerBIO.scala
@@ -32,15 +32,14 @@ abstract class DistageTestDockerBIO extends DistageBIOSpecScalatest[IO] {
     }
   }
 
-  override protected def config: TestConfig = {
-    super.config.copy(
+  override protected def config: TestConfig = super
+    .config.copy(
       memoizationRoots = Set(DIKey.get[PgSvcExample]),
       parallelTests = true,
       parallelEnvs = true,
       moduleOverrides = super.config.moduleOverrides overridenBy new ModuleDef { make[UUID].fromValue(UUID.randomUUID()) },
-      testRunnerLogLevel = Log.Level.Info
+      logLevel = Log.Level.Info,
     )
-  }
 }
 
 final class DistageTestDockerBIO1 extends DistageTestDockerBIO

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/TestConfig.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/TestConfig.scala
@@ -9,40 +9,51 @@ import izumi.logstage.api.Log
 /**
   * General options:
   *
-  * @param pluginConfig          Source of module definitions from which to build object graphs for each tests.
-  *                              Each [[PluginConfig]] creates a distinct memoization group (aka [[izumi.distage.testkit.services.dstest.TestEnvironment]]).
-  *                              Components specified in `memoizationRoots` will be memoized only for the tests in the same memoization group.
+  *
+  * @param pluginConfig          Source of module definitions from which to build object graphs for each test.
+  *                              Changes to [[PluginConfig]] that alter implementations of components in [[memoizationRoots]]
+  *                              OR their dependencies will cause the test to execute in a new memoization environment,
+  *                              check the initial log output in tests for information about the memoization environments in your tests.
+  *                              Components specified in `memoizationRoots` will be memoized only for the tests in the same memoization environment.
   *
   * @param bootstrapPluginConfig Same as [[pluginConfig]], but for [[BootstrapModule]]
   *
-  * @param activation            Chosen activation axes. Different [[Activation]]s will create distinct memoization groups
+  * @param activation            Chosen activation axes. Changes in [[Activation]] that alter implementations of components in [[memoizationRoots]]
+  *                              OR their dependencies will cause the test to execute in a new memoization environment,
+  *                              check the initial log output in tests for information about the memoization environments in your tests.
   *
   * @param memoizationRoots      Specifies the components that will be created *once* and shared across all tests within
-  *                              the same memoization group (i.e. with the same [[TestConfig]])
-  *                              Every distinct set of `memoizationRoots` will create a distinct memoization group
-
-  * @param forcedRoots           Specifies components that will be treated as if they are a dependency of every test within
-  *                              this memoization group. They will not be garbage collected even if no other object or test
-  *                              declares a dependency on them components. When combined with `memoizationRoots`, a [[distage.DIResource]]
-  *                              binding can implement global start/stop lifecycle for all tests within this memoization group.
-  *                              Every distinct set of `forcedRoots` will create a distinct memoization group
+  *                              the same memoization environment (i.e. with the same [[TestConfig]])
+  *                              Every distinct set of `memoizationRoots` will create a distinct memoization environment
   *
-  * @param moduleOverrides       Override loaded plugins with a given [[Module]]. Using overrides
-  *                              will create a distinct memoization group, i.e. objects will be
-  *                              memoized only between tests with the exact same overrides
+  * @param forcedRoots           Specifies components that will be treated as if they are a dependency of every test within
+  *                              this memoization environment. Components designated as forced roots will not be garbage
+  *                              collected even if there are no components or tests that depend on them.
+  *                              When combined with `memoizationRoots`, a [[distage.DIResource]] binding can be used to
+  *                              implement a global start/stop action (beforeAll/afterAll) for all tests within this memoization environment.
+  *                              Changes to `forcedRoots` that alter implementations of components in [[memoizationRoots]]
+  *                              OR their dependencies will cause the test to execute in a new memoization environment,
+  *                              check the initial log output in tests for information about the memoization environments in your tests.
+  *
+  * @param moduleOverrides       Override loaded plugins with a given [[Module]]. As long as overriden bindings are not memoized,
+  *                              or dependencies of memoized components, using overrides will NOT create a new memoization environment.
+  *                              Changes to `moduleOverrides` that alter implementations of components in [[memoizationRoots]]
+  *                              OR their dependencies will cause the test to execute in a new memoization environment,
+  *                              check the initial log output in tests for information about the memoization environments in your tests.
   *
   * @param bootstrapOverrides    Same as [[moduleOverrides]], but for [[BootstrapModule]]
   *
   *
-  * Parallelism options:
+  * Parallelism options. Tests with different parallelism options will run in distinct memoization environments:
   *
   *
-  * @param parallelEnvs          Whether to run distinct memoization groups in parallel, default: `true`. Sequential envs will run in sequence after the parallel ones.
+  * @param parallelEnvs          Whether to run distinct memoization environments in parallel, default: `true`.
+  *                              Sequential envs will run in sequence after the parallel ones.
   * @param parallelSuites        Whether to run test suites in parallel, default: `true`.
   * @param parallelTests         Whether to run test cases in parallel, default: `true`.
   *
   *
-  * Other options:
+  * Other options, Tests with different other options will run in distinct memoization environments:
   *
   *
   * @param configBaseName        Search for config in HOCON resource files with names `$configBaseName.conf`,
@@ -50,11 +61,17 @@ import izumi.logstage.api.Log
   *                              (see [[izumi.distage.framework.services.ConfigLoader]]
   *
   * @param configOverrides       Overriding definitions on top of main loaded config, default `None`
+  *
   * @param planningOptions       [[PlanningOptions]], debug options for [[distage.Planner]]
-  * @param testRunnerLogLevel    Verbosity of [[services.dstest.DistageTestRunner]] log messages, default: `Info`
+  *
+  * @param logLevel              Log level for the [[logstage.IzLogger]] used in testkit and provided to the tests (will be overriden by plugin / module bindings if exist)
+  *
+  * @param debugOutput           Print testkit debug messages, including those helping diagnose memoization environment issues,
+  *                              default: `false`, also controlled by [[DebugProperties.`izumi.distage.testkit.debug`]] system property
   *
   */
-final case class TestConfig( // general options
+final case class TestConfig(
+  // general options
   pluginConfig: PluginConfig,
   bootstrapPluginConfig: PluginConfig = PluginConfig.empty,
   activation: Activation = StandardAxis.testProdActivation,
@@ -70,7 +87,8 @@ final case class TestConfig( // general options
   configBaseName: String,
   configOverrides: Option[AppConfig] = None,
   planningOptions: PlanningOptions = PlanningOptions(),
-  testRunnerLogLevel: Log.Level = Log.Level.Info,
+  logLevel: Log.Level = Log.Level.Info,
+  debugOutput: Boolean = false,
 )
 object TestConfig {
   def forSuite(clazz: Class[_]): TestConfig = {

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/services/dstest/DistageTestEnv.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/services/dstest/DistageTestEnv.scala
@@ -64,7 +64,8 @@ trait DistageTestEnv {
       configBaseName = testConfig.configBaseName,
       configOverrides = testConfig.configOverrides,
       planningOptions = testConfig.planningOptions,
-      logLevel = testConfig.testRunnerLogLevel,
+      logLevel = testConfig.logLevel,
+      debugOutput = testConfig.debugOutput,
     )
   }
 

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/services/dstest/TestEnvironment.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/services/dstest/TestEnvironment.scala
@@ -7,7 +7,7 @@ import izumi.distage.framework.model.ActivationInfo
 import izumi.distage.model.definition.Activation
 import izumi.distage.model.plan.TriSplittedPlan
 import izumi.distage.roles.model.meta.RolesInfo
-import izumi.distage.testkit.services.dstest.DistageTestRunner.DistageTest
+import izumi.distage.testkit.services.dstest.TestEnvironment.MemoizationEnvironment
 import izumi.logstage.api.{IzLogger, Log}
 
 final case class TestEnvironment(
@@ -26,50 +26,37 @@ final case class TestEnvironment(
   configOverrides: Option[AppConfig],
   planningOptions: PlanningOptions,
   logLevel: Log.Level,
-  verboseTestRunner: Boolean = false,
+  debugOutput: Boolean,
 ) {
-  def toMemoizationEnv: TestEnvironment.MemoizationEnvironment = {
-    TestEnvironment.MemoizationEnvironment(
+  def toMemoizationEnv: MemoizationEnvironment = {
+    MemoizationEnvironment(
       parallelEnvs,
       parallelSuites,
       parallelTests,
       planningOptions,
       logLevel,
-      verboseTestRunner,
+      debugOutput,
     )
   }
 }
 
 object TestEnvironment {
-  trait TestRunnerLog
-  object TestRunnerLog {
-    case object Normal extends TestRunnerLog
-    case object Debug extends TestRunnerLog
-    case object Verbose extends TestRunnerLog
-  }
 
   final case class MemoizationEnvironment(
     parallelEnvs: Boolean,
     parallelSuites: Boolean,
     parallelTests: Boolean,
     planningOptions: PlanningOptions,
-    testRunnerLogLevel: Log.Level,
-    verboseTestRunner: Boolean,
+    logLevel: Log.Level,
+    debugOutput: Boolean,
   )
 
   final case class MemoizationEnvWithPlan(
     env: MemoizationEnvironment,
-    runtimeLogger: IzLogger,
-    testEnvLogger: IzLogger,
+    integrationLogger: IzLogger,
     memoizationPlan: TriSplittedPlan,
     runtimePlan: OrderedPlan,
     injector: Injector,
-  )
-
-  final case class AppModuleTestGroup[F[_]](
-    appModule: Module,
-    testPlan: OrderedPlan,
-    distageTests: DistageTest[F],
   )
 
 }

--- a/project/Deps.sc
+++ b/project/Deps.sc
@@ -338,8 +338,8 @@ object Izumi {
           Projects.fundamentals.collections in Scope.Compile.all,
         ),
         settings = Seq(
-            "npmDependencies" in (SettingScope.Test, Platform.Js) ++= Seq("hash.js" -> "1.1.7")
-          ),
+          "npmDependencies" in (SettingScope.Test, Platform.Js) ++= Seq("hash.js" -> "1.1.7")
+        ),
         plugins = Plugins(Seq(Plugin("ScalaJSBundlerPlugin", Platform.Js))),
       ),
       Artifact(


### PR DESCRIPTION
* system property `izumi.distage.testkit.debug` sets testkit debug logs to info, instead of setting logger to Debug level
* log how many envs were merged if any
* exclude _all_ components of runtimeLocator from subsequent plans
* fixed memoizedConfig for multiple test effect types
* update TestConfig doc