### PR TITLE
distage-framework-docker: Use default `Docker.ClientConfig` if dockerconfig section is not found, add `makeConfigWithDefault`, `wireConfig`, `wireConfigWithDefault` to `ConfigModuleDef`

### DIFF
--- a/distage/distage-extension-config/src/main/scala/izumi/distage/config/ConfigModuleDef.scala
+++ b/distage/distage-extension-config/src/main/scala/izumi/distage/config/ConfigModuleDef.scala
@@ -21,6 +21,10 @@ trait ConfigModuleDef extends ModuleDef {
     pos.discard()
     make[T].named(path).tagged(ConfTag(path)).from(wireConfig[T](path))
   }
+  final def makeConfigWithDefault[T: Tag: DIConfigReader](path: String)(default: => T)(implicit pos: CodePositionMaterializer): MakeDSLUnnamedAfterFrom[T] = {
+    pos.discard()
+    make[T].tagged(ConfTag(path)).from(wireConfigWithDefault[T](path)(default))
+  }
 
   @inline final def wireConfig[T: Tag: DIConfigReader](path: String): ProviderMagnet[T] = {
     ConfigModuleDef.wireConfig[T](path)
@@ -45,7 +49,6 @@ object ConfigModuleDef {
   def wireConfig[T: Tag: DIConfigReader](path: String): ProviderMagnet[T] = {
     DIConfigReader[T].decodeAppConfig(path)
   }
-
   def wireConfigWithDefault[T: Tag: DIConfigReader](path: String)(default: => T): ProviderMagnet[T] = {
     DIConfigReader[T].decodeAppConfigWithDefault(path)(default)
   }

--- a/distage/distage-extension-config/src/main/scala/izumi/distage/config/ConfigModuleDef.scala
+++ b/distage/distage-extension-config/src/main/scala/izumi/distage/config/ConfigModuleDef.scala
@@ -5,6 +5,7 @@ import izumi.distage.config.codec.DIConfigReader
 import izumi.distage.model.definition.BindingTag.ConfTag
 import izumi.distage.model.definition.ModuleDef
 import izumi.distage.model.definition.dsl.ModuleDefDSL.{MakeDSL, MakeDSLNamedAfterFrom, MakeDSLUnnamedAfterFrom}
+import izumi.distage.model.providers.ProviderMagnet
 import izumi.fundamentals.platform.language.CodePositionMaterializer
 import izumi.fundamentals.platform.language.Quirks._
 import izumi.reflect.Tag
@@ -14,23 +15,38 @@ import scala.language.implicitConversions
 trait ConfigModuleDef extends ModuleDef {
   final def makeConfig[T: Tag: DIConfigReader](path: String)(implicit pos: CodePositionMaterializer): MakeDSLUnnamedAfterFrom[T] = {
     pos.discard()
-    make[T].tagged(ConfTag(path)).from(DIConfigReader[T].decodeAppConfig(path))
+    make[T].tagged(ConfTag(path)).from(wireConfig[T](path))
   }
   final def makeConfigNamed[T: Tag: DIConfigReader](path: String)(implicit pos: CodePositionMaterializer): MakeDSLNamedAfterFrom[T] = {
     pos.discard()
-    make[T].named(path).tagged(ConfTag(path)).from(DIConfigReader[T].decodeAppConfig(path))
+    make[T].named(path).tagged(ConfTag(path)).from(wireConfig[T](path))
+  }
+
+  @inline final def wireConfig[T: Tag: DIConfigReader](path: String): ProviderMagnet[T] = {
+    ConfigModuleDef.wireConfig[T](path)
+  }
+  @inline final def wireConfigWithDefault[T: Tag: DIConfigReader](path: String)(default: => T): ProviderMagnet[T] = {
+    ConfigModuleDef.wireConfigWithDefault[T](path)(default)
   }
 
   @inline implicit final def FromConfig[T](dsl: MakeDSL[T]): FromConfig[T] = new FromConfig[T](dsl)
 }
 
 object ConfigModuleDef {
-  final class FromConfig[T](private val dsl: MakeDSL[T]) extends AnyVal {
+  final class FromConfig[T](private val make: MakeDSL[T]) extends AnyVal {
     def fromConfig(path: String)(implicit tag: Tag[T], dec: DIConfigReader[T]): MakeDSLUnnamedAfterFrom[T] = {
-      dsl.tagged(ConfTag(path)).from(dec.decodeAppConfig(path))
+      make.tagged(ConfTag(path)).from(wireConfig[T](path))
     }
     def fromConfigNamed(path: String)(implicit tag: Tag[T], dec: DIConfigReader[T]): MakeDSLNamedAfterFrom[T] = {
-      dsl.named(path).tagged(ConfTag(path)).from(dec.decodeAppConfig(path))
+      make.named(path).tagged(ConfTag(path)).from(wireConfig[T](path))
     }
+  }
+
+  def wireConfig[T: Tag: DIConfigReader](path: String): ProviderMagnet[T] = {
+    DIConfigReader[T].decodeAppConfig(path)
+  }
+
+  def wireConfigWithDefault[T: Tag: DIConfigReader](path: String)(default: => T): ProviderMagnet[T] = {
+    DIConfigReader[T].decodeAppConfigWithDefault(path)(default)
   }
 }

--- a/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/Docker.scala
+++ b/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/Docker.scala
@@ -36,7 +36,7 @@ object Docker {
 
   /**
     * Parameters that define the behavior of this docker container,
-    * Will be interpreted by [[DockerContainer.ContainerResource]]
+    * Will be interpreted by [[ContainerResource]]
     *
     * @param image    Docker Image to use
     *
@@ -69,26 +69,24 @@ object Docker {
     * @param cwd      Working directory to use inside the docker container
     *
     * @param mounts   Host paths mounted to Volumes inside the docker container
-    *
-    *
     */
   final case class ContainerConfig[T](
-                                       image: String,
-                                       ports: Seq[DockerPort],
-                                       name: Option[String] = None,
-                                       env: Map[String, String] = Map.empty,
-                                       cmd: Seq[String] = Seq.empty,
-                                       entrypoint: Seq[String] = Seq.empty,
-                                       cwd: Option[String] = None,
-                                       user: Option[String] = None,
-                                       mounts: Seq[Mount] = Seq.empty,
-                                       networks: Set[ContainerNetwork[_]] = Set.empty,
-                                       reuse: Boolean = true,
-                                       healthCheckInterval: FiniteDuration = FiniteDuration(1, TimeUnit.SECONDS),
-                                       healthCheckMaxAttempts: Int = 120,
-                                       pullTimeout: FiniteDuration = FiniteDuration(120, TimeUnit.SECONDS),
-                                       healthCheck: ContainerHealthCheck[T] = ContainerHealthCheck.checkTCPOnly[T],
-                                       portProbeTimeout: FiniteDuration = FiniteDuration(200, TimeUnit.MILLISECONDS)
+    image: String,
+    ports: Seq[DockerPort],
+    name: Option[String] = None,
+    env: Map[String, String] = Map.empty,
+    cmd: Seq[String] = Seq.empty,
+    entrypoint: Seq[String] = Seq.empty,
+    cwd: Option[String] = None,
+    user: Option[String] = None,
+    mounts: Seq[Mount] = Seq.empty,
+    networks: Set[ContainerNetwork[_]] = Set.empty,
+    reuse: Boolean = true,
+    healthCheckInterval: FiniteDuration = FiniteDuration(1, TimeUnit.SECONDS),
+    healthCheckMaxAttempts: Int = 120,
+    pullTimeout: FiniteDuration = FiniteDuration(120, TimeUnit.SECONDS),
+    healthCheck: ContainerHealthCheck[T] = ContainerHealthCheck.checkTCPOnly[T],
+    portProbeTimeout: FiniteDuration = FiniteDuration(200, TimeUnit.MILLISECONDS),
   )
 
   /**
@@ -130,19 +128,16 @@ object Docker {
 
   final case class DockerRegistryConfig(url: String, username: String, password: String, email: String)
 
-
-
   final case class Mount(host: String, container: String, noCopy: Boolean = false)
 
-  case class UnmappedPorts(ports: Seq[DockerPort])
+  final case class UnmappedPorts(ports: Seq[DockerPort])
 
-  case class ContainerConnectivity(
-                                    dockerHost: Option[String],
-                                    containerAddressesV4: Seq[String],
-                                    dockerPorts: Map[DockerPort, NonEmptyList[ServicePort]],
-                                  ) {
+  final case class ContainerConnectivity(
+    dockerHost: Option[String],
+    containerAddressesV4: Seq[String],
+    dockerPorts: Map[DockerPort, NonEmptyList[ServicePort]],
+  ) {
     override def toString: String = s"{host: $dockerHost; addresses=$containerAddressesV4; ports=$dockerPorts}"
   }
-
 
 }

--- a/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/modules/DockerSupportModule.scala
+++ b/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/modules/DockerSupportModule.scala
@@ -3,8 +3,8 @@ package izumi.distage.docker.modules
 import com.github.dockerjava.api.command.DockerCmdExecFactory
 import distage.TagK
 import izumi.distage.config.ConfigModuleDef
-import izumi.distage.model.definition.ModuleDef
 import izumi.distage.docker.{Docker, DockerClientWrapper, DockerCmdExecFactoryResource}
+import izumi.distage.model.definition.ModuleDef
 
 class DockerSupportModule[F[_]: TagK] extends ModuleDef {
   make[DockerClientWrapper[F]].fromResource[DockerClientWrapper.Resource[F]]
@@ -17,7 +17,7 @@ object DockerSupportModule {
   def apply[F[_]: TagK]: DockerSupportModule[F] = new DockerContainerModule[F]
 
   final val config = new ConfigModuleDef {
-    make[Docker.ClientConfig].from(wireConfigWithDefault("docker") {
+    makeConfigWithDefault[Docker.ClientConfig]("docker") {
       Docker.ClientConfig(
         readTimeoutMs = 60000,
         connectTimeoutMs = 500,
@@ -27,6 +27,6 @@ object DockerSupportModule {
         remote = None,
         registry = None,
       )
-    })
+    }
   }
 }

--- a/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/modules/DockerSupportModule.scala
+++ b/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/modules/DockerSupportModule.scala
@@ -17,6 +17,16 @@ object DockerSupportModule {
   def apply[F[_]: TagK]: DockerSupportModule[F] = new DockerContainerModule[F]
 
   final val config = new ConfigModuleDef {
-    makeConfig[Docker.ClientConfig]("docker")
+    make[Docker.ClientConfig].from(wireConfigWithDefault("docker") {
+      Docker.ClientConfig(
+        readTimeoutMs = 60000,
+        connectTimeoutMs = 500,
+        allowReuse = true,
+        useRemote = false,
+        useRegistry = false,
+        remote = None,
+        registry = None,
+      )
+    })
   }
 }


### PR DESCRIPTION
This should make `include "docker-reference.conf"` optional

/cc @coreyoconnor