### PR TITLE
distage-testkit: Fix merged environments mixing up correct Activations for tests

### DIFF
--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/TestConfig.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/TestConfig.scala
@@ -16,7 +16,8 @@ import izumi.logstage.api.Log
   *                              check the initial log output in tests for information about the memoization environments in your tests.
   *                              Components specified in `memoizationRoots` will be memoized only for the tests in the same memoization environment.
   *
-  * @param bootstrapPluginConfig Same as [[pluginConfig]], but for [[BootstrapModule]]
+  * @param bootstrapPluginConfig Same as [[pluginConfig]], but for [[BootstrapModule]].
+  *                              Every distinct `bootstrapPluginConfig` will create a distinct memoization environment.
   *
   * @param activation            Chosen activation axes. Changes in [[Activation]] that alter implementations of components in [[memoizationRoots]]
   *                              OR their dependencies will cause the test to execute in a new memoization environment,
@@ -42,6 +43,7 @@ import izumi.logstage.api.Log
   *                              check the initial log output in tests for information about the memoization environments in your tests.
   *
   * @param bootstrapOverrides    Same as [[moduleOverrides]], but for [[BootstrapModule]]
+  *                              Every distinct `bootstrapPluginConfig` will create a distinct memoization environment.
   *
   *
   * Parallelism options. Tests with different parallelism options will run in distinct memoization environments:

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/TestConfig.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/TestConfig.scala
@@ -46,13 +46,17 @@ import izumi.logstage.api.Log
   *                              Every distinct `bootstrapPluginConfig` will create a distinct memoization environment.
   *
   *
-  * Parallelism options. Tests with different parallelism options will run in distinct memoization environments:
+  * Parallelism options:
   *
   *
   * @param parallelEnvs          Whether to run distinct memoization environments in parallel, default: `true`.
   *                              Sequential envs will run in sequence after the parallel ones.
+  *
   * @param parallelSuites        Whether to run test suites in parallel, default: `true`.
+  *                              Sequential suites will run in sequence after the parallel ones.
+  *
   * @param parallelTests         Whether to run test cases in parallel, default: `true`.
+  *                              Sequential tests will run in sequence after the parallel ones.
   *
   *
   * Other options, Tests with different other options will run in distinct memoization environments:

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/services/dstest/DistageTestEnv.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/services/dstest/DistageTestEnv.scala
@@ -58,13 +58,14 @@ trait DistageTestEnv {
       memoizationRoots = testConfig.memoizationRoots.toSet,
       forcedRoots = testConfig.forcedRoots.toSet,
       parallelEnvs = testConfig.parallelEnvs,
-      parallelSuites = testConfig.parallelSuites,
-      parallelTests = testConfig.parallelTests,
       bootstrapFactory = BootstrapFactory.Impl,
       configBaseName = testConfig.configBaseName,
       configOverrides = testConfig.configOverrides,
       planningOptions = testConfig.planningOptions,
       logLevel = testConfig.logLevel,
+    )(
+      parallelSuites = testConfig.parallelSuites,
+      parallelTests = testConfig.parallelTests,
       debugOutput = testConfig.debugOutput,
     )
   }

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/services/dstest/DistageTestRunner.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/services/dstest/DistageTestRunner.scala
@@ -2,29 +2,31 @@ package izumi.distage.testkit.services.dstest
 
 import java.util.concurrent.{ConcurrentHashMap, Executors, TimeUnit}
 
-import distage.{DIKey, Injector, PlannerInput}
+import distage.{BootstrapModuleDef, DIKey, Injector, Planner, PlannerInput}
+import izumi.distage.bootstrap.{BootstrapLocator, CglibBootstrap}
 import izumi.distage.config.model.AppConfig
-import izumi.distage.framework.model.IntegrationCheck
 import izumi.distage.framework.model.exceptions.IntegrationCheckException
+import izumi.distage.framework.model.{ActivationInfo, IntegrationCheck}
 import izumi.distage.framework.services.{IntegrationChecker, PlanCircularDependencyCheck}
 import izumi.distage.model.Locator
 import izumi.distage.model.definition.Binding.SetElementBinding
-import izumi.distage.model.definition.ImplDef
+import izumi.distage.model.definition.{Activation, BootstrapModule, ImplDef, LocatorDef}
 import izumi.distage.model.effect.DIEffect.syntax._
 import izumi.distage.model.effect.DIEffectAsync.NamedThreadFactory
 import izumi.distage.model.effect.{DIEffect, DIEffectAsync, DIEffectRunner}
 import izumi.distage.model.exceptions.ProvisioningException
-import izumi.distage.model.plan.{OrderedPlan, TriSplittedPlan}
+import izumi.distage.model.plan.{ExecutableOp, OrderedPlan, TriSplittedPlan}
 import izumi.distage.model.providers.ProviderMagnet
 import izumi.distage.roles.services.EarlyLoggers
 import izumi.distage.testkit.DebugProperties
 import izumi.distage.testkit.services.dstest.DistageTestRunner._
-import izumi.distage.testkit.services.dstest.TestEnvironment.{MemoizationEnvWithPlan, MemoizationEnvironment}
+import izumi.distage.testkit.services.dstest.TestEnvironment.{EnvExecutionParams, MemoizationEnvWithPlan, PreparedTest}
 import izumi.fundamentals.platform.cli.model.raw.RawAppArgs
 import izumi.fundamentals.platform.functional.Identity
 import izumi.fundamentals.platform.integration.ResourceCheck
 import izumi.fundamentals.platform.language.CodePosition
 import izumi.fundamentals.platform.strings.IzString._
+import izumi.logstage.api.logger.LogRouter
 import izumi.logstage.api.{IzLogger, Log}
 import izumi.reflect.TagK
 
@@ -33,14 +35,13 @@ import scala.concurrent.duration.{Duration, FiniteDuration}
 
 class DistageTestRunner[F[_]: TagK](
   reporter: TestReporter,
-  tests: Seq[DistageTest[F]],
   isTestSkipException: Throwable => Boolean,
 ) {
-  def run(): Unit = {
+  def run(tests: Seq[DistageTest[F]]): Unit = {
     val envs = groupTests(tests)
     logEnvironmentsInfo(envs)
     try {
-      val (parallelEnvs, sequentialEnvs) = envs.partition(_._1.env.parallelEnvs)
+      val (parallelEnvs, sequentialEnvs) = envs.partition(_._1.envExec.parallelEnvs)
       runEnvs(parallel = true)(parallelEnvs)
       runEnvs(parallel = false)(sequentialEnvs)
     } finally reporter.endAll()
@@ -55,31 +56,62 @@ class DistageTestRunner[F[_]: TagK](
 
   /**
     *  Performs tests grouping by it's memoization environment.
-    *  [[TestEnvironment.MemoizationEnvironment]] - contains only parts of environment that will not affect plan.
+    *  [[TestEnvironment.EnvExecutionParams]] - contains only parts of environment that will not affect plan.
     *  Grouping by such structure will allow us to create memoization groups with shared logger and parallel execution policy.
     *  By result you'll got [[MemoizationEnvWithPlan]] mapped to tests wit it's plans.
     *  [[MemoizationEnvWithPlan]] represents memoization environment, with shared [[TriSplittedPlan]], [[Injector]], and runtime plan.
     * */
-  def groupTests(distageTests: Seq[DistageTest[F]]): Map[MemoizationEnvWithPlan, Seq[(DistageTest[F], OrderedPlan)]] = {
+  def groupTests(distageTests: Seq[DistageTest[F]]): Map[MemoizationEnvWithPlan, Seq[PreparedTest[F]]] = {
 
-    final case class EnvByproducts(injector: Injector, envLogger: IzLogger)
+    final case class EnvMergeCriteria(
+      bsPlanMinusActivations: Vector[ExecutableOp],
+      bsModuleMinusActivations: BootstrapModule,
+      sharedPlan: TriSplittedPlan,
+      runtimePlan: OrderedPlan,
+      envExec: EnvExecutionParams,
+    )
+    final case class PackedEnv(
+      envMergeCriteria: EnvMergeCriteria,
+      testPlans: Seq[PreparedTest[F]],
+      anyMemoizationInjector: Injector,
+      anyIntegrationLogger: IzLogger,
+    )
+
+    val unstableKeys = {
+      val activationKeys = Set(DIKey[Activation], DIKey[ActivationInfo])
+      val recursiveKeys = Set(DIKey[BootstrapModule])
+      // FIXME: remove PlanningObserverLoggingImpl and stop inserting LogstageModule in bootstrap
+      val hackyKeys = Set(DIKey[LogRouter], DIKey[Activation]("initial"))
+      activationKeys ++ recursiveKeys ++ hackyKeys
+    }
 
     // here we are grouping our tests by memoization env
-    distageTests.groupBy(_.environment.toMemoizationEnv).flatMap {
-      case (memoEnv, grouped) =>
-        val configLoadLogger = IzLogger(memoEnv.logLevel).withCustomContext("phase" -> "testRunner")
+    distageTests.groupBy(_.environment.getExecParams).flatMap {
+      case (envExec, grouped) =>
+        val configLoadLogger = IzLogger(envExec.logLevel).withCustomContext("phase" -> "testRunner")
         val memoizationEnvs = grouped.groupBy(_.environment).map {
           case (env, tests) =>
             // make a config loader for current env with logger
             val config = loadConfig(env, configLoadLogger)
-            val lateLogger = EarlyLoggers.makeLateLogger(RawAppArgs.empty, configLoadLogger, config, memoEnv.logLevel, defaultLogFormatJson = false)
+            val lateLogger = EarlyLoggers.makeLateLogger(RawAppArgs.empty, configLoadLogger, config, envExec.logLevel, defaultLogFormatJson = false)
 
             // here we scan our classpath to enumerate of our components (we have "bootstrap" components - injector plugins, and app components)
             val options = env.planningOptions
             val provider = env.bootstrapFactory.makeModuleProvider[F](options, config, lateLogger.router, env.roles, env.activationInfo, env.activation)
             val bsModule = provider.bootstrapModules().merge overridenBy env.bsModule
             val appModule = provider.appModules().merge overridenBy env.appModule
-            val injector = Injector(env.activation, bsModule)
+            val (bsPlanMinusActivations, bsModuleMinusActivations, injector, planner) = {
+              // FIXME: Checking both bootstrap Plan & bootstrap module to prevent `Bootloader` becoming becoming inconsistent
+              //  if used in tests (if BootstrapModule isn't checked it could be different from expected)
+              //  we're also removing & re-injecting Planner, Activations & BootstrapModule (in 0.11.0 activation won't be set via bsModules & won't be stored in Planner)
+              //  (planner holds activations & the rest is for Bootloader self-introspection)
+              val bsLocator = new BootstrapLocator(CglibBootstrap.cogenBootstrap overridenBy bsModule, env.activation)
+              val injector = Injector.inherit(bsLocator)
+              val bsPlanMinusActivations = bsLocator.plan.steps.filterNot(unstableKeys contains _.target)
+              val bsModuleMinusActivations = bsLocator.get[BootstrapModule].drop(unstableKeys)
+              val planner = bsLocator.get[Planner]
+              (bsPlanMinusActivations, bsModuleMinusActivations, injector, planner)
+            }
 
             // runtime plan with `runtimeGcRoots`
             val runtimePlan = injector.plan(PlannerInput(appModule, runtimeGcRoots))
@@ -89,12 +121,11 @@ class DistageTestRunner[F[_]: TagK](
             // produce plan for each test
             val testPlans = tests.map {
               distageTest =>
-                val keys = distageTest.test.get.diKeys.toSet
-                val testRoots = keys ++ env.forcedRoots
+                val testRoots = distageTest.test.get.diKeys.toSet ++ env.forcedRoots
                 val plan = if (testRoots.nonEmpty) injector.plan(PlannerInput(appModule, testRoots)) else OrderedPlan.empty
-                distageTest -> plan
+                PreparedTest(distageTest, plan, env.activationInfo, env.activation, planner)
             }
-            val envKeys = testPlans.flatMap(_._2.keys).toSet
+            val envKeys = testPlans.flatMap(_.testPlan.keys).toSet
             val sharedKeys = envKeys.intersect(env.memoizationRoots) -- runtimeKeys
 
             // we need to "strengthen" all _memoized_ weak set instances that occur in our tests to ensure that they
@@ -112,7 +143,9 @@ class DistageTestRunner[F[_]: TagK](
               _.collectChildren[IntegrationCheck].map(_.target).toSet
             }
 
-            val memoEnvHashCode = (shared, runtimePlan, memoEnv).hashCode()
+            val envMergeCriteria = EnvMergeCriteria(bsPlanMinusActivations, bsModuleMinusActivations, shared, runtimePlan, envExec)
+
+            val memoEnvHashCode = envMergeCriteria.hashCode()
             val integrationLogger = lateLogger("memoEnv" -> memoEnvHashCode)
             if (strengthenedKeys.nonEmpty) {
               integrationLogger.log(testkitDebugMessagesLogLevel(env.debugOutput))(
@@ -120,25 +153,27 @@ class DistageTestRunner[F[_]: TagK](
               )
             }
 
-            ((shared, runtimePlan), testPlans, EnvByproducts(injector, integrationLogger))
+            PackedEnv(envMergeCriteria, testPlans, injector, integrationLogger)
         }
         // merge environments together by equality of their shared & runtime plans
         // in a lot of cases memoization plan will be the same even with many minor changes to TestConfig,
         // so this saves a lot of realloaction of memoized resoorces
-        memoizationEnvs.groupBy(_._1).map {
-          case ((shared, runtimePlan), memoEnvContents) =>
-            val EnvByproducts(injector, integrationLogger) = memoEnvContents.head._3
-            val tests = memoEnvContents.iterator.flatMap(_._2).toSeq
+        val mergedEnvs = memoizationEnvs.groupBy(_.envMergeCriteria)
+        mergedEnvs.map {
+          case (EnvMergeCriteria(_, _, shared, runtimePlan, _), packedEnv) =>
+            val integrationLogger = packedEnv.head.anyIntegrationLogger
+            val memoizationInjector = packedEnv.head.anyMemoizationInjector
+            val tests = packedEnv.iterator.flatMap(_.testPlans).toSeq
 
-            MemoizationEnvWithPlan(memoEnv, integrationLogger, shared, runtimePlan, injector) -> tests
+            MemoizationEnvWithPlan(envExec, integrationLogger, shared, runtimePlan, memoizationInjector) -> tests
         }
     }
   }
 
-  def runEnvs(parallel: Boolean)(envs: Map[MemoizationEnvWithPlan, Iterable[(DistageTest[F], OrderedPlan)]]): Unit = {
+  def runEnvs(parallel: Boolean)(envs: Map[MemoizationEnvWithPlan, Iterable[PreparedTest[F]]]): Unit = {
     configuredForeach(parallel)(envs) {
-      case (MemoizationEnvWithPlan(env, integrationLogger, memoizationPlan, runtimePlan, injector), testPlans) =>
-        val allEnvTests = testPlans.map(_._1)
+      case (MemoizationEnvWithPlan(env, integrationLogger, memoizationPlan, runtimePlan, memoizationInjector), tests) =>
+        val allEnvTests = tests.map(_.test)
         integrationLogger.info(s"Processing ${allEnvTests.size -> "tests"} using ${TagK[F].tag -> "monad"}")
         withReportOnFailedExecution(allEnvTests) {
           val checker = new IntegrationChecker.Impl[F](integrationLogger)
@@ -147,7 +182,7 @@ class DistageTestRunner[F[_]: TagK](
           // producing and verifying runtime plan
           assert(runtimeGcRoots.diff(runtimePlan.keys).isEmpty)
           planCheck.verify(runtimePlan)
-          injector.produceF[Identity](runtimePlan).use {
+          memoizationInjector.produceF[Identity](runtimePlan).use {
             runtimeLocator =>
               val runner = runtimeLocator.get[DIEffectRunner[F]]
               implicit val F: DIEffect[F] = runtimeLocator.get[DIEffect[F]]
@@ -158,7 +193,7 @@ class DistageTestRunner[F[_]: TagK](
                   // producing full runtime plan with all shared keys
                   withIntegrationSharedPlan(runtimeLocator, planCheck, checker, memoizationPlan, allEnvTests) {
                     memoizedIntegrationLocator =>
-                      proceed(env, checker, planCheck, testPlans, memoizedIntegrationLocator, integrationLogger)
+                      proceedEnv(env, checker, planCheck, memoizedIntegrationLocator, integrationLogger)(tests)
                   }
                 }
               }
@@ -167,7 +202,7 @@ class DistageTestRunner[F[_]: TagK](
     }
   }
 
-  private[this] def withIntegrationSharedPlan(
+  protected def withIntegrationSharedPlan(
     runtimeLocator: Locator,
     planCheck: PlanCircularDependencyCheck,
     checker: IntegrationChecker[F],
@@ -197,7 +232,7 @@ class DistageTestRunner[F[_]: TagK](
     }
   }
 
-  def withTestsRecoverCase(tests: => Iterable[DistageTest[F]])(testsAction: => F[Unit])(implicit F: DIEffect[F]): F[Unit] = {
+  protected def withTestsRecoverCase(tests: => Iterable[DistageTest[F]])(testsAction: => F[Unit])(implicit F: DIEffect[F]): F[Unit] = {
     F.definitelyRecoverCause {
       testsAction
     } {
@@ -210,7 +245,7 @@ class DistageTestRunner[F[_]: TagK](
     }
   }
 
-  private[this] def withReportOnFailedExecution(allTests: => Iterable[DistageTest[F]])(f: => Unit): Unit = {
+  protected def withReportOnFailedExecution(allTests: => Iterable[DistageTest[F]])(f: => Unit): Unit = {
     try {
       f
     } catch {
@@ -254,21 +289,20 @@ class DistageTestRunner[F[_]: TagK](
     }
   }
 
-  protected def proceed(
-    env: MemoizationEnvironment,
+  protected def proceedEnv(
+    env: EnvExecutionParams,
     integrationChecker: IntegrationChecker[F],
     checker: PlanCircularDependencyCheck,
-    testplans: Iterable[(DistageTest[F], OrderedPlan)],
     mainSharedLocator: Locator,
     testRunnerLogger: IzLogger,
+  )(testPlans: Iterable[PreparedTest[F]]
   )(implicit
     F: DIEffect[F],
     P: DIEffectAsync[F],
   ): F[Unit] = {
-    val testInjector = Injector.inherit(mainSharedLocator)
-    val testsBySuite = testplans.groupBy {
-      t =>
-        val testId = t._1.meta.id
+    val testsBySuite = testPlans.groupBy {
+      case PreparedTest(test, _, _, _, _) =>
+        val testId = test.meta.id
         SuiteData(testId.suiteName, testId.suiteId, testId.suiteClassName)
     }
     // now we are ready to run each individual test
@@ -280,17 +314,51 @@ class DistageTestRunner[F[_]: TagK](
         )(release = _ => F.maybeSuspend(reporter.endSuite(suiteData))) {
           _ =>
             configuredTraverse_(env.parallelTests)(plans) {
-              case (test, testplan) =>
+              case PreparedTest(test, testPlan, activationInfo, activation, planner) =>
+                val locatorWithOverridenActivation: LocatorDef = new LocatorDef {
+                  // we override ActivationInfo & Activation because the test can have _different_ activation from the memoized part
+                  // FIXME: Activation will be part of PlannerInput in 0.11.0 & perhaps ActivationInfo should be derived from Bootloader/PlannerInput as well instead of injected externally
+                  make[ActivationInfo].fromValue(activationInfo)
+                  make[Activation].fromValue(activation)
+                  make[Activation].named("initial").fromValue(activation)
+                  make[Planner].fromValue(planner)
+                  make[BootstrapModule].fromValue(new BootstrapModuleDef {
+                    include(mainSharedLocator.get[BootstrapModule].drop {
+                      Set(
+                        DIKey[BootstrapModule],
+                        DIKey[ActivationInfo],
+                        DIKey[Activation],
+                        DIKey[Activation]("initial"),
+                      )
+                    })
+                    make[BootstrapModule].from(() => this)
+                    make[ActivationInfo].fromValue(activationInfo)
+                    make[Activation].fromValue(activation)
+                    make[Activation].named("initial").fromValue(activation)
+                  })
+                  override val parent: Option[Locator] = Some(mainSharedLocator)
+                }
+                require(locatorWithOverridenActivation.get[Activation] == activation)
+                val testInjector = Injector.inherit(locatorWithOverridenActivation)
+
                 val allSharedKeys = mainSharedLocator.allInstances.map(_.key).toSet
 
-                val integrations = testplan.collectChildren[IntegrationCheck].map(_.target).toSet -- allSharedKeys
-                val newTestPlan = testInjector.trisectByRoots(test.environment.appModule.drop(allSharedKeys), testplan.keys -- allSharedKeys, integrations)
+                val testIntegrationCheckKeys = testPlan.collectChildren[IntegrationCheck].map(_.target).toSet -- allSharedKeys
+                val newTestPlan = testInjector.trisectByRoots(test.environment.appModule.drop(allSharedKeys), testPlan.keys -- allSharedKeys, testIntegrationCheckKeys)
 
-                testRunnerLogger("testId" -> test.meta.id).log(testkitDebugMessagesLogLevel(env.debugOutput))("Running...")
+                testRunnerLogger("testId" -> test.meta.id).log(testkitDebugMessagesLogLevel(env.debugOutput))(
+                  s"""Running test...
+                     |
+                     |Test pre-integration plan: ${newTestPlan.shared}
+                     |
+                     |Test integration plan: ${newTestPlan.side}
+                     |
+                     |Test primary plan: ${newTestPlan.primary}""".stripMargin
+                )
 
-                checker.verify(newTestPlan.primary)
-                checker.verify(newTestPlan.side)
                 checker.verify(newTestPlan.shared)
+                checker.verify(newTestPlan.side)
+                checker.verify(newTestPlan.primary)
 
                 // we are ready to run the test, finally
                 testInjector.produceF[F](newTestPlan.shared).use {
@@ -298,7 +366,7 @@ class DistageTestRunner[F[_]: TagK](
                     Injector.inherit(sharedLocator).produceF[F](newTestPlan.side).use {
                       integrationLocator =>
                         withIntegrationCheck(integrationChecker, integrationLocator)(Seq(test), newTestPlan) {
-                          proceedIndividual(test, newTestPlan.primary, sharedLocator)
+                          proceedIndividual(test, newTestPlan.primary, integrationLocator)
                         }
                     }
                 }
@@ -395,12 +463,12 @@ class DistageTestRunner[F[_]: TagK](
     }
   }
 
-  private[this] def logEnvironmentsInfo(envs: Map[MemoizationEnvWithPlan, Iterable[(DistageTest[F], OrderedPlan)]]): Unit = {
+  private[this] def logEnvironmentsInfo(envs: Map[MemoizationEnvWithPlan, Iterable[PreparedTest[F]]]): Unit = {
     val testRunnerLogger = {
-      val minimumLogLevel = envs.map(_._1.env.logLevel).toSeq.sorted.headOption.getOrElse(Log.Level.Info)
+      val minimumLogLevel = envs.map(_._1.envExec.logLevel).toSeq.sorted.headOption.getOrElse(Log.Level.Info)
       IzLogger(minimumLogLevel)("phase" -> "testRunner")
     }
-    val originalEnvSize = envs.iterator.flatMap(_._2.map(_._1.environment)).toSet.size
+    val originalEnvSize = envs.iterator.flatMap(_._2.map(_.test.environment)).toSet.size
     val memoEnvsSize = envs.size
 
     testRunnerLogger.info(s"Created ${memoEnvsSize -> "memoization envs"} with ${envs.iterator.flatMap(_._2).size -> "tests"} using ${TagK[F].tag -> "monad"}")
@@ -409,15 +477,17 @@ class DistageTestRunner[F[_]: TagK](
     }
 
     envs.foreach {
-      case (MemoizationEnvWithPlan(env, testEnvLogger, memoizationPlan, _, _), tests) =>
-        val suites = tests.map(_._1.meta.id.suiteClassName).toList.distinct
+      case (MemoizationEnvWithPlan(env, testEnvLogger, memoizationPlan, runtimePlan, _), tests) =>
+        val suites = tests.map(_.test.meta.id.suiteClassName).toList.distinct
         testEnvLogger.info(s"Memoization environment with ${suites.size -> "suites"} ${tests.size -> "tests"} ${suites.sorted.niceList() -> "testSuites"}")
         testEnvLogger.log(testkitDebugMessagesLogLevel(env.debugOutput))(
-          s"""Integration plan: ${memoizationPlan.side}
+          s"""Effect runtime plan: $runtimePlan
              |
-             |Memoized plan: ${memoizationPlan.shared}
+             |Memoized pre-integration plan: ${memoizationPlan.shared}
              |
-             |App plan: ${memoizationPlan.primary}""".stripMargin
+             |Memoized integration plan: ${memoizationPlan.side}
+             |
+             |Memoized primary plan: ${memoizationPlan.primary}""".stripMargin
         )
     }
   }

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/services/dstest/TestEnvironment.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/services/dstest/TestEnvironment.scala
@@ -5,9 +5,10 @@ import izumi.distage.config.model.AppConfig
 import izumi.distage.framework.config.PlanningOptions
 import izumi.distage.framework.model.ActivationInfo
 import izumi.distage.model.definition.Activation
-import izumi.distage.model.plan.TriSplittedPlan
+import izumi.distage.model.plan.{OrderedPlan, TriSplittedPlan}
 import izumi.distage.roles.model.meta.RolesInfo
-import izumi.distage.testkit.services.dstest.TestEnvironment.MemoizationEnvironment
+import izumi.distage.testkit.services.dstest.DistageTestRunner.DistageTest
+import izumi.distage.testkit.services.dstest.TestEnvironment.EnvExecutionParams
 import izumi.logstage.api.{IzLogger, Log}
 
 final case class TestEnvironment(
@@ -28,8 +29,8 @@ final case class TestEnvironment(
   logLevel: Log.Level,
   debugOutput: Boolean,
 ) {
-  def toMemoizationEnv: MemoizationEnvironment = {
-    MemoizationEnvironment(
+  def getExecParams: EnvExecutionParams = {
+    EnvExecutionParams(
       parallelEnvs,
       parallelSuites,
       parallelTests,
@@ -42,7 +43,7 @@ final case class TestEnvironment(
 
 object TestEnvironment {
 
-  final case class MemoizationEnvironment(
+  final case class EnvExecutionParams(
     parallelEnvs: Boolean,
     parallelSuites: Boolean,
     parallelTests: Boolean,
@@ -52,11 +53,19 @@ object TestEnvironment {
   )
 
   final case class MemoizationEnvWithPlan(
-    env: MemoizationEnvironment,
+    envExec: EnvExecutionParams,
     integrationLogger: IzLogger,
     memoizationPlan: TriSplittedPlan,
     runtimePlan: OrderedPlan,
-    injector: Injector,
+    memoizatonInjector: Injector,
+  )
+
+  final case class PreparedTest[F[_]](
+    test: DistageTest[F],
+    testPlan: OrderedPlan,
+    activationInfo: ActivationInfo,
+    activation: Activation,
+    planner: Planner, // 0.11.0: remove
   )
 
 }

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/services/dstest/TestEnvironment.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/services/dstest/TestEnvironment.scala
@@ -20,23 +20,22 @@ final case class TestEnvironment(
   memoizationRoots: Set[DIKey],
   forcedRoots: Set[DIKey],
   parallelEnvs: Boolean,
-  parallelSuites: Boolean,
-  parallelTests: Boolean,
   bootstrapFactory: BootstrapFactory,
   configBaseName: String,
   configOverrides: Option[AppConfig],
   planningOptions: PlanningOptions,
   logLevel: Log.Level,
-  debugOutput: Boolean,
+)(// exclude from `equals` test-runner only parameters that do not affect the memoization plan and
+  // that are not used in [[DistageTestRunner.groupEnvs]] grouping to allow merging more envs
+  val parallelSuites: Boolean,
+  val parallelTests: Boolean,
+  val debugOutput: Boolean,
 ) {
   def getExecParams: EnvExecutionParams = {
     EnvExecutionParams(
       parallelEnvs,
-      parallelSuites,
-      parallelTests,
       planningOptions,
       logLevel,
-      debugOutput,
     )
   }
 }
@@ -45,11 +44,8 @@ object TestEnvironment {
 
   final case class EnvExecutionParams(
     parallelEnvs: Boolean,
-    parallelSuites: Boolean,
-    parallelTests: Boolean,
     planningOptions: PlanningOptions,
     logLevel: Log.Level,
-    debugOutput: Boolean,
   )
 
   final case class MemoizationEnvWithPlan(
@@ -58,6 +54,7 @@ object TestEnvironment {
     memoizationPlan: TriSplittedPlan,
     runtimePlan: OrderedPlan,
     memoizatonInjector: Injector,
+    highestDebugOutputInTests: Boolean,
   )
 
   final case class PreparedTest[F[_]](

--- a/distage/distage-testkit-scalatest/src/main/scala/org/scalatest/distage/DistageScalatestTestSuiteRunner.scala
+++ b/distage/distage-testkit-scalatest/src/main/scala/org/scalatest/distage/DistageScalatestTestSuiteRunner.scala
@@ -181,10 +181,8 @@ abstract class DistageScalatestTestSuiteRunner[F[_]](implicit override val tagMo
     try {
       if (toRun.nonEmpty) {
         debugLogger.log(s"GOING TO RUN TESTS in ${tagMonoIO.tag}: ${toRun.map(_.meta.id.name)}")
-        val runner = {
-          new DistageTestRunner[F](testReporter, toRun, _.isInstanceOf[TestCanceledException])
-        }
-        runner.run()
+        val runner = new DistageTestRunner[F](testReporter, _.isInstanceOf[TestCanceledException])
+        runner.run(toRun)
       }
     } finally {
       DistageTestsRegistrySingleton.completeStatuses[F]()


### PR DESCRIPTION
* Differences in bootstrap plan & bootstrap modules (but not in Activation) will now prevent memoization env merge
* Exclude `parallelSuites`, `parallelTests` and `debugOutput` from reasons to split memoization environments

