### PR TITLE
distage-framework-docker: add defaults to Docker.ClientConfig constructor

### DIFF
--- a/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/Docker.scala
+++ b/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/Docker.scala
@@ -113,13 +113,13 @@ object Docker {
     * @param useRegistry      Connect to speicifed Docker Registry
     */
   final case class ClientConfig(
-    readTimeoutMs: Int,
-    connectTimeoutMs: Int,
-    allowReuse: Boolean,
-    useRemote: Boolean,
-    useRegistry: Boolean,
-    remote: Option[RemoteDockerConfig],
-    registry: Option[DockerRegistryConfig],
+    readTimeoutMs: Int = 5000,
+    connectTimeoutMs: Int = 1000,
+    allowReuse: Boolean = true,
+    useRemote: Boolean = false,
+    useRegistry: Boolean = false,
+    remote: Option[RemoteDockerConfig] = None,
+    registry: Option[DockerRegistryConfig] = None,
   )
   object ClientConfig {
     implicit val distageConfigReader: DIConfigReader[ClientConfig] = DIConfigReader.derived


### PR DESCRIPTION
Defaults are from `docker-reference.conf` except for `remote` and `registry`. I think it would be odd to have default parameters that are examples values (eg: `dockeruser`). Necessary for the `reference.conf` to show structure, but seems out of place here.