### PR TITLE
distage-docker: dynamic ports

### DIFF
--- a/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/examples/KafkaDocker.scala
+++ b/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/examples/KafkaDocker.scala
@@ -8,14 +8,15 @@ object KafkaDocker extends ContainerDef {
   val primaryPort: DockerPort = DockerPort.DynamicTCP("dynamic_kafka_port")
 
   private[this] def portVars: String = Seq(
-    s"""KAFKA_LISTENERS="PLAINTEXT://:$$${primaryPort.toEnvVariable}"""",
-    s"""KAFKA_ADVERTISED_LISTENERS="PLAINTEXT://127.0.0.1:$$${primaryPort.toEnvVariable}"""",
+    s"""KAFKA_ADVERTISED_PORT=$$${primaryPort.toEnvVariable}""",
+    s"""KAFKA_PORT=$$${primaryPort.toEnvVariable}""",
   ).map(defn => s"export $defn").mkString("; ")
 
   override def config: Config = {
     Config(
       image = "wurstmeister/kafka:2.12-2.4.1",
       ports = Seq(primaryPort),
+      env = Map("KAFKA_ADVERTISED_HOST_NAME" -> "127.0.0.1"),
       entrypoint = Seq(
         "sh",
         "-c",

--- a/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/healthcheck/TCPContainerHealthCheck.scala
+++ b/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/healthcheck/TCPContainerHealthCheck.scala
@@ -14,7 +14,7 @@ import izumi.logstage.api.IzLogger
 
 class TCPContainerHealthCheck[Tag] extends ContainerHealthCheckBase[Tag] {
 
-  override protected def perform(logger: IzLogger, container: DockerContainer[Tag], tcpPorts: Map[DockerPort.TCP, NonEmptyList[ServicePort]], udpPorts: Map[DockerPort.UDP, NonEmptyList[ServicePort]]): HealthCheckResult.AvailableOnPorts = {
+  override protected def perform(logger: IzLogger, container: DockerContainer[Tag], tcpPorts: Map[DockerPort.TCPBase, NonEmptyList[ServicePort]], udpPorts: Map[DockerPort.UDPBase, NonEmptyList[ServicePort]]): HealthCheckResult.AvailableOnPorts = {
     val check = new PortCheck(container.containerConfig.portProbeTimeout)
 
     val dockerHostCandidates = findDockerHostCandidates(container, tcpPorts)

--- a/fundamentals/fundamentals-platform/src/main/scala/izumi/fundamentals/platform/strings/IzString.scala
+++ b/fundamentals/fundamentals-platform/src/main/scala/izumi/fundamentals/platform/strings/IzString.scala
@@ -18,6 +18,10 @@ final class IzString(private val s: String) extends AnyVal {
     Try(s.toBoolean).toOption
   }
 
+  @inline final def asInt(): Option[Int] = {
+    Try(s.toInt).toOption
+  }
+
   @inline final def shift(delta: Int, fill: String = " "): String = {
     val shift = fill * delta
     s.split("\\\n", -1).map(s => s"$shift$s").mkString("\n")


### PR DESCRIPTION
I've extended our `DockerPort`s with new types to support dynamically chosen ports. 
These ports will be allocated with a dynamic number inside and outside of containers. To support reuse of containers with these ports I've decided to store port numb as container labels (as previously), and extract the number of the port during port mapping.

Everything seems to work, and now we don't need to define advertised in/out ports in Kafka and can define general port. 

Also, in this PR I've fixed a bug when during reuse we find acceptable containers but without connection to the needed network. So now we will check not only port mapping but network connections also.