### PR TITLE
Fix config loader priority: all explicit configs override all reference configs, instead of role references having a higher priority than common config

### DIFF
--- a/distage/distage-framework/src/main/scala/izumi/distage/framework/services/ConfigLoader.scala
+++ b/distage/distage-framework/src/main/scala/izumi/distage/framework/services/ConfigLoader.scala
@@ -10,6 +10,7 @@ import izumi.fundamentals.platform.resources.IzResources
 import izumi.fundamentals.platform.strings.IzString._
 import izumi.logstage.api.IzLogger
 
+import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 
@@ -24,6 +25,20 @@ import scala.util.{Failure, Success, Try}
   *   - common.conf
   *   - common-reference.conf
   *   - common-reference-dev.conf
+  *
+  * When explicit configs are passed to the role launcher on the command-line using the `-c` option, they have higher priority than all the reference configs.
+  * Role-specific configs on the command-line (`-c` option after `:role` argument) override global command-line configs (`-c` option given before the first `:role` argument).
+  *
+  * Example:
+  *
+  * {{{
+  *   ./launcher -c global.conf :role1 -c role1.conf :role2 -c role2.conf
+  * }}}
+  *
+  * Here configs will be loaded in the following order, with higher priority earlier:
+  *
+  *   - explicits: `role1.conf`, `role2.conf`, `global.conf`,
+  *   - resources: `role1[-reference,-dev].conf`, `role2[-reference,-dev].conf`, ,`application[-reference,-dev].conf`, `common[-reference,-dev].conf`
   */
 trait ConfigLoader {
   def loadConfig(): AppConfig
@@ -41,17 +56,19 @@ object ConfigLoader {
     defaultBaseConfigs: Seq[String],
   ) extends ConfigLoader {
 
+    @nowarn("msg=Unused import")
     def loadConfig(): AppConfig = {
-      val commonConfigFiles = baseConfig.fold(
-        defaultBaseConfigs.flatMap(toConfig(_, baseConfig))
-      )(f => Seq(ConfigSource.File(f)))
+      import scala.collection.compat._
 
-      val roleConfigFiles = moreConfigs.flatMap {
-        case (referenceName, maybeConfigFile) =>
-          toConfig(referenceName, maybeConfigFile)
-      }.toList
+      val commonReferenceConfigs = defaultBaseConfigs.flatMap(defaultConfigReferences)
+      val commonExplicitConfigs = baseConfig.map(ConfigSource.File).toList
 
-      val allConfigs = roleConfigFiles ++ commonConfigFiles
+      val (roleReferenceConfigs, roleExplicitConfigs) = moreConfigs.partitionMap {
+        case (role, None) => Left(defaultConfigReferences(role))
+        case (_, Some(file)) => Right(ConfigSource.File(file))
+      }
+
+      val allConfigs = (roleExplicitConfigs.iterator ++ commonExplicitConfigs ++ roleReferenceConfigs.iterator.flatten ++ commonReferenceConfigs).toList
 
       val cfgInfo = allConfigs.map {
         case r: ConfigSource.Resource =>
@@ -136,10 +153,6 @@ object ConfigLoader {
           case None => Set.empty
         }
       }
-    }
-
-    protected def toConfig(name: String, maybeConfigFile: Option[File]): Seq[ConfigSource] = {
-      maybeConfigFile.fold(defaultConfigReferences(name))(f => Seq(ConfigSource.File(f)))
     }
 
     protected def defaultConfigReferences(name: String): Seq[ConfigSource] = {

--- a/distage/distage-framework/src/main/scala/izumi/distage/framework/services/ConfigLoader.scala
+++ b/distage/distage-framework/src/main/scala/izumi/distage/framework/services/ConfigLoader.scala
@@ -63,7 +63,7 @@ object ConfigLoader {
       val commonReferenceConfigs = defaultBaseConfigs.flatMap(defaultConfigReferences)
       val commonExplicitConfigs = baseConfig.map(ConfigSource.File).toList
 
-      val (roleReferenceConfigs, roleExplicitConfigs) = moreConfigs.partitionMap {
+      val (roleReferenceConfigs, roleExplicitConfigs) = (moreConfigs: Iterable[(String, Option[File])]).partitionMap {
         case (role, None) => Left(defaultConfigReferences(role))
         case (_, Some(file)) => Right(ConfigSource.File(file))
       }

--- a/doc/microsite/src/main/tut/distage/distage-framework.md
+++ b/doc/microsite/src/main/tut/distage/distage-framework.md
@@ -83,7 +83,6 @@ Injector().produceRun(module) {
 Automatic derivation of config codecs is based on [pureconfig-magnolia](https://github.com/pureconfig/pureconfig).
 Pureconfig codecs for a type will be used if they exist.
 
-
 You don't have to explicitly `make[AppConfig]` in @ref[distage-testkit](distage-testkit.md)'s tests and in @ref[distage-framework](distage-framework.md)'s Roles, unless you want to override default behavior. By default, tests and roles will try to read the configurations from resources with the following names, in order:
 
 ```
@@ -102,7 +101,21 @@ You don't have to explicitly `make[AppConfig]` in @ref[distage-testkit](distage-
 type _ref = izumi.distage.testkit.TestConfig
 ```
 
-Where `distage-testkit` uses @scaladoc[`TestConfig#testBaseName`](izumi.distage.testkit.TestConfig#testBaseName) instead of `roleName` 
+Where `distage-testkit` uses @scaladoc[`TestConfig#testBaseName`](izumi.distage.testkit.TestConfig#testBaseName) instead of `roleName`.
+
+When explicit configs are passed to the role launcher on the command-line using the `-c` option, they have higher priority than all the reference configs.
+Role-specific configs on the command-line (`-c` option after `:role` argument) override global command-line configs (`-c` option given before the first `:role` argument).
+
+Example:
+
+```
+  ./launcher -c global.conf :role1 -c role1.conf :role2 -c role2.conf
+```
+
+Here configs will be loaded in the following order, with higher priority earlier:
+
+  - explicits: `role1.conf`, `role2.conf`, `global.conf`,
+  - resources: `role1[-reference,-dev].conf`, `role2[-reference,-dev].conf`, ,`application[-reference,-dev].conf`, `common[-reference,-dev].conf` 
 
 ### Plugins
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-addSbtPlugin("io.7mind.izumi.sbt" % "sbt-izumi" % "0.0.61")
+addSbtPlugin("io.7mind.izumi.sbt" % "sbt-izumi" % "0.0.60")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % PV.sbt_assembly)
 


### PR DESCRIPTION
* common references are now always loaded (at lower priority than explicit), not skipped if there's an explicit common config