### PR TITLE
Change activation rules for `memoizationRoots`/`forcedRoots`

### DIFF
--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/Activation.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/Activation.scala
@@ -4,11 +4,14 @@ import izumi.distage.model.definition.Axis.AxisValue
 
 final case class Activation(activeChoices: Map[Axis, AxisValue]) extends AnyVal {
   @inline def ++(activation: Activation): Activation = Activation(activeChoices ++ activation.activeChoices)
-  @inline def +(axisChoice: (Axis, AxisValue)): Activation = this ++ Activation(axisChoice._1 -> axisChoice._2)
+  @inline def +(axisChoice: (Axis, AxisValue)): Activation = Activation(activeChoices + axisChoice)
+
+  /** `that` activation is larger than `this` activation if all axis choices in `this` are present in `that` */
+  def <=(that: Activation): Boolean = activeChoices.toSet.subsetOf(that.activeChoices.toSet)
 }
 
 object Activation {
   def apply(activeChoices: (Axis, AxisValue)*): Activation = Activation(Map(activeChoices: _*))
   def apply(): Activation = empty
-  val empty: Activation = new Activation(Map.empty)
+  def empty: Activation = new Activation(Map.empty)
 }

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/ModuleBase.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/ModuleBase.scala
@@ -133,8 +133,7 @@ object ModuleBase {
       val mergedKeys = existingIndex.keySet ++ newIndex.keySet
 
       mergedKeys.flatMap {
-        k =>
-          newIndex.getOrElse(k, existingIndex.getOrElse(k, Set.empty))
+        k => newIndex.getOrElse(k, existingIndex.getOrElse(k, Set.empty))
       }
     }
   }

--- a/distage/distage-framework/src/main/scala/izumi/distage/roles/bundled/ConfigWriter.scala
+++ b/distage/distage-framework/src/main/scala/izumi/distage/roles/bundled/ConfigWriter.scala
@@ -111,9 +111,7 @@ final class ConfigWriter[F[_]](
   private[this] def minimizedConfig(config: Config, role: RoleBinding): Option[Config] = {
     val roleDIKey = role.binding.key
 
-    val bootstrapOverride = Seq(
-      new LogstageModule(LogRouter.nullRouter, setupStaticLogRouter = false)
-    ).overrideLeft
+    val bootstrapOverride = new LogstageModule(LogRouter.nullRouter, setupStaticLogRouter = false)
 
     val plans = roleAppPlanner
       .reboot(bootstrapOverride)

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/TestConfig.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/TestConfig.scala
@@ -5,10 +5,12 @@ import distage.config.AppConfig
 import izumi.distage.framework.config.PlanningOptions
 import izumi.distage.model.definition.Axis.AxisValue
 import izumi.distage.plugins.PluginConfig
-import izumi.distage.testkit.TestConfig.{ParallelLevel, TaggedKeys}
+import izumi.distage.testkit.TestConfig.{AxisDIKeys, ParallelLevel}
 import izumi.distage.testkit.services.dstest.BootstrapFactory
 import izumi.logstage.api.Log
 
+import scala.annotation.nowarn
+import scala.collection.compat.immutable.ArraySeq
 import scala.language.implicitConversions
 
 /**
@@ -84,8 +86,8 @@ final case class TestConfig(
   activation: Activation = StandardAxis.testProdActivation,
   moduleOverrides: Module = Module.empty,
   bootstrapOverrides: BootstrapModule = BootstrapModule.empty,
-  memoizationRoots: TaggedKeys = TaggedKeys.empty,
-  forcedRoots: TaggedKeys = TaggedKeys.empty,
+  memoizationRoots: AxisDIKeys = AxisDIKeys.empty,
+  forcedRoots: AxisDIKeys = AxisDIKeys.empty,
   // parallelism options
   parallelEnvs: ParallelLevel = ParallelLevel.Unlimited,
   parallelSuites: ParallelLevel = ParallelLevel.Unlimited,
@@ -107,24 +109,49 @@ object TestConfig {
     )
   }
 
-  final case class TaggedKeys(keys: Map[Set[AxisValue], Set[DIKey]]) {
+  final case class AxisDIKeys(keyMap: Map[Set[AxisValue], Set[DIKey]]) {
+    /**
+      * Consider a section to be activated if for each Axis, one of the Axis Choices in the section is present in the Activation
+      *
+      *  - empty section is always activated
+      *  - axis values for _different_ axes are implicitly under an AND relationship - all axes must be present in Activation to pass
+      *  - axis values for _the same_ axis are implicitly under an OR relationship - Activation must contain one of the axis choices for the same axis to pass
+      *
+      *  Note that this rule currently differs from the rule of activation for bindings themselves, specifically
+      *  you cannot specify multiple axis values for _the same_ axis on bindings.
+      *
+      *  @see [[izumi.fundamentals.graphs.tools.MutationResolver.ActivationChoices#allValid]]
+      */
     def getActiveKeys(activation: Activation): Set[DIKey] = {
-      keys
-        .iterator.filter {
-          case (axesValues, _) =>
-            axesValues.forall(v => activation.activeChoices.get(v.axis).contains(v))
-        }.flatMap(_._2.iterator).toSet
+      def activatedSection(axisValues: Set[AxisValue], activation: Activation): Boolean = {
+        axisValues
+          .groupBy(_.axis)
+          .forall {
+            case (axis, axisValues) =>
+              activation.activeChoices.get(axis).exists(axisValues.contains)
+          }
+      }
+      keyMap
+        .iterator.flatMap {
+          case (axisValues, keys) if activatedSection(axisValues, activation) => keys
+          case _ => Nil
+        }.toSet
     }
-    def ++(that: TaggedKeys): TaggedKeys = {
-      val allKeys = (this.keys.iterator ++ that.keys.iterator).toSeq
-      val updatedKeys = allKeys.groupBy(_._1).map { case (k, vals) => k -> vals.iterator.flatMap(_._2.iterator).toSet }
-      TaggedKeys(updatedKeys)
+
+    @nowarn("msg=Unused import")
+    def ++(that: AxisDIKeys): AxisDIKeys = {
+      import scala.collection.compat._
+      val allKeys = ArraySeq.unsafeWrapArray((this.keyMap.iterator ++ that.keyMap.iterator).toArray)
+      val updatedKeys = allKeys.groupBy(_._1).map { case (k, kvs) => k -> kvs.iterator.flatMap(_._2).toSet }
+      AxisDIKeys(updatedKeys)
     }
   }
-  object TaggedKeys {
-    val empty: TaggedKeys = TaggedKeys(Map.empty)
-    @inline implicit def fromSet(set: Set[_ <: DIKey]): TaggedKeys = TaggedKeys(Map(Set.empty -> set.toSet[DIKey]))
-    @inline implicit def fromMap[SA <: Set[_ <: AxisValue]](map: Map[SA, Set[_ <: DIKey]]): TaggedKeys = TaggedKeys(map.asInstanceOf[Map[Set[AxisValue], Set[DIKey]]])
+  object AxisDIKeys {
+    val empty: AxisDIKeys = AxisDIKeys(Map.empty)
+    @inline implicit def fromSet(set: Set[_ <: DIKey]): AxisDIKeys = AxisDIKeys(Map(Set.empty -> set.toSet[DIKey]))
+    @inline implicit def fromMap[SA <: Set[_ <: AxisValue]](map: Map[SA, Set[_ <: DIKey]]): AxisDIKeys = AxisDIKeys(
+      map.asInstanceOf[Map[Set[AxisValue], Set[DIKey]]]
+    )
   }
 
   sealed trait ParallelLevel

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/services/dstest/TestEnvironment.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/services/dstest/TestEnvironment.scala
@@ -7,7 +7,7 @@ import izumi.distage.framework.model.ActivationInfo
 import izumi.distage.model.definition.Activation
 import izumi.distage.model.plan.{OrderedPlan, TriSplittedPlan}
 import izumi.distage.roles.model.meta.RolesInfo
-import izumi.distage.testkit.TestConfig.{ParallelLevel, TaggedKeys}
+import izumi.distage.testkit.TestConfig.{AxisDIKeys, ParallelLevel}
 import izumi.distage.testkit.services.dstest.DistageTestRunner.DistageTest
 import izumi.distage.testkit.services.dstest.TestEnvironment.EnvExecutionParams
 import izumi.logstage.api.{IzLogger, Log}
@@ -18,8 +18,8 @@ final case class TestEnvironment(
   roles: RolesInfo,
   activationInfo: ActivationInfo,
   activation: Activation,
-  memoizationRoots: TaggedKeys,
-  forcedRoots: TaggedKeys,
+  memoizationRoots: AxisDIKeys,
+  forcedRoots: AxisDIKeys,
   parallelEnvs: ParallelLevel,
   bootstrapFactory: BootstrapFactory,
   configBaseName: String,


### PR DESCRIPTION
    /**
      * Consider a section to be activated if for each Axis, one of the Axis Choices in the section is present in the Activation
      *
      *  - empty section is always activated
      *  - axis values for _different_ axes are implicitly under an AND relationship - all axes must be present in Activation to pass
      *  - axis values for _the same_ axis are implicitly under an OR relationship - Activation must contain one of the axis choices for the same axis to pass
      *
      *  Note that this rule currently differs from the rule of activation for bindings themselves, specifically
      *  you cannot specify multiple axis values for _the same_ axis on bindings.
      *
      *  @see [[izumi.fundamentals.graphs.tools.MutationResolver.ActivationChoices#allValid]]
      */