### PR TITLE
WIP: integrate sbt-doctest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3065,7 +3065,9 @@ lazy val `izumi` = (project in file("."))
     scmInfo in ThisBuild := Some(ScmInfo(url("https://github.com/7mind/izumi"), "scm:git:https://github.com/7mind/izumi.git")),
     scalacOptions in ThisBuild ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}"
-    )
+    ),
+    doctestOnlyCodeBlocksMode in ThisBuild := true,
+    doctestTestFramework in ThisBuild := DoctestTestFramework.ScalaTest
   )
   .disablePlugins(AssemblyPlugin)
   .aggregate(

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/reflection/macros/FunctoidMacro.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/reflection/macros/FunctoidMacro.scala
@@ -14,9 +14,9 @@ import scala.reflect.macros.blackbox
 /**
   * To see macro debug output during compilation, set `-Dizumi.debug.macro.distage.functoid=true` java property!
   *
-  * {{{
+  * {{{"""
   *   sbt -Dizumi.debug.macro.distage.functoid=true compile
-  * }}}
+  * """}}}
   *
   * @see [[izumi.distage.constructors.DebugProperties]]
   */

--- a/project/Deps.sc
+++ b/project/Deps.sc
@@ -232,6 +232,8 @@ object Izumi {
         "scalacOptions" in SettingScope.Build ++= Seq(
           """s"-Xmacro-settings:scalatest-version=${V.scalatest}"""".raw
         ),
+        "doctestOnlyCodeBlocksMode" in SettingScope.Build := true,
+        "doctestTestFramework" in SettingScope.Build := """DoctestTestFramework.ScalaTest""".raw,
       )
 
       final val sharedSettings = Defaults.SbtMetaOptions ++ Seq(

--- a/project/Deps.sc
+++ b/project/Deps.sc
@@ -36,6 +36,7 @@ object Izumi {
 
   object PV {
     val sbt_mdoc = Version.VExpr("PV.sbt_mdoc")
+    val sbt_doctest = Version.VExpr("PV.sbt_doctest")
     val sbt_paradox_material_theme = Version.VExpr("PV.sbt_paradox_material_theme")
     val sbt_ghpages = Version.VExpr("PV.sbt_ghpages")
     val sbt_site = Version.VExpr("PV.sbt_site")
@@ -705,6 +706,7 @@ object Izumi {
       SbtPlugin("com.typesafe.sbt", "sbt-ghpages", PV.sbt_ghpages),
       SbtPlugin("io.github.jonas", "sbt-paradox-material-theme", PV.sbt_paradox_material_theme),
       SbtPlugin("org.scalameta", "sbt-mdoc", PV.sbt_mdoc),
+      SbtPlugin("com.github.tkawachi", "sbt-doctest", PV.sbt_doctest),
     ),
   )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,3 +19,5 @@ addSbtPlugin("io.github.jonas" % "sbt-paradox-material-theme" % PV.sbt_paradox_m
 
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % PV.sbt_mdoc)
 
+addSbtPlugin("com.github.tkawachi" % "sbt-doctest" % PV.sbt_doctest)
+

--- a/project/project/PluginVersions.scala
+++ b/project/project/PluginVersions.scala
@@ -1,5 +1,6 @@
 object PV {
   val sbt_mdoc = "2.2.9"
+  val sbt_doctest = "0.9.7"
   val sbt_paradox_material_theme = "0.6.0"
   val sbt_ghpages = "0.6.3"
   val sbt_site = "1.3.3"


### PR DESCRIPTION
Current blocker:

* `sbt-doctest` generates test files inside the current artifact's test scope, but e.g. code examples in `distage-core-api` forward-reference classes that are only available in `distage-core` and onward — they cannot compile in `distage-core-api / test` scope. Now, this parameter the directory to dump source files to is controlled by this line https://github.com/tkawachi/sbt-doctest/blob/master/src/main/scala/com/github/tkawachi/doctest/DoctestPlugin.scala#L103, if we provide an alternative definition for `doctestGenTests` that uses a different key instead of `managedSourceDirectories in Test`, we could override that key and dump the tests into a different directory (e.g. `microsite` - where all the libraries are available at the same time)

/cc @vpodlnk @VladPodilnyk - would you be interested in exploring this task?