### PR TITLE
add `DockerContainer#dependOnContainerPorts` shortcut, makes it easier to expose ports as env vars in a container, rename `dependOnDocker`->`dependOnContainer`

### DIFF
--- a/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/ContainerDef.scala
+++ b/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/ContainerDef.scala
@@ -28,7 +28,7 @@ trait ContainerDef {
     * make[KafkaDocker.Container].fromResource {
     *   KafkaDocker
     *     .make[F]
-    *     .dependOnDocker(ZookeeperDocker)
+    *     .dependOnContainer(ZookeeperDocker)
     * }
     * }}}
     *

--- a/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/DockerContainer.scala
+++ b/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/DockerContainer.scala
@@ -67,11 +67,11 @@ object DockerContainer {
       }
     }
 
-    def dependOnDocker(containerDecl: ContainerDef)(implicit tag: distage.Tag[DockerContainer[containerDecl.Tag]]): Functoid[ContainerResource[F, T]] = {
+    def dependOnContainer(containerDecl: ContainerDef)(implicit tag: distage.Tag[DockerContainer[containerDecl.Tag]]): Functoid[ContainerResource[F, T]] = {
       self.addDependency[DockerContainer[containerDecl.Tag]]
     }
 
-    def dependOnDocker[T2](implicit tag: distage.Tag[DockerContainer[T2]]): Functoid[ContainerResource[F, T]] = {
+    def dependOnContainer[T2](implicit tag: distage.Tag[DockerContainer[T2]]): Functoid[ContainerResource[F, T]] = {
       self.addDependency[DockerContainer[T2]]
     }
 
@@ -85,12 +85,12 @@ object DockerContainer {
       *     KafkaDocker
       *       .make[F]
       *       .connectToNetwork(KafkaZookeeperNetwork)
-      *       .useDependencyPorts(ZookeeperDocker)(2181 -> "KAFKA_ZOOKEEPER_CONNECT")
+      *       .dependOnContainerPorts(ZookeeperDocker)(2181 -> "KAFKA_ZOOKEEPER_CONNECT")
       *   }
       * }
       * }}}
       */
-    def useDependencyPorts(
+    def dependOnContainerPorts(
       containerDecl: ContainerDef
     )(ports: (Int, String)*
     )(implicit tag1: distage.Tag[DockerContainer[containerDecl.Tag]],
@@ -98,10 +98,10 @@ object DockerContainer {
       tag3: distage.Tag[Docker.ContainerConfig[T]],
     ): Functoid[ContainerResource[F, T]] = {
       containerDecl.discard()
-      useDependencyPorts[containerDecl.Tag](ports: _*)
+      dependOnContainerPorts[containerDecl.Tag](ports: _*)
     }
 
-    def useDependencyPorts[T2](
+    def dependOnContainerPorts[T2](
       ports: (Int, String)*
     )(implicit tag1: distage.Tag[DockerContainer[T2]],
       tag2: distage.Tag[ContainerResource[F, T]],
@@ -140,6 +140,13 @@ object DockerContainer {
           old.copy(networks = old.networks + net)
       }
     }
+
+    @deprecated("Renamed to `dependOnContainer`", "1.0.2")
+    def dependOnDocker(containerDecl: ContainerDef)(implicit tag: distage.Tag[DockerContainer[containerDecl.Tag]]): Functoid[ContainerResource[F, T]] =
+      dependOnContainer[containerDecl.Tag]
+
+    @deprecated("Renamed to `dependOnContainer`", "1.0.2")
+    def dependOnDocker[T2](implicit tag: distage.Tag[DockerContainer[T2]]): Functoid[ContainerResource[F, T]] = dependOnContainer[T2]
   }
 
 }

--- a/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/DockerContainer.scala
+++ b/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/DockerContainer.scala
@@ -2,13 +2,11 @@ package izumi.distage.docker
 
 import izumi.distage.docker.ContainerNetworkDef.ContainerNetwork
 import izumi.distage.docker.Docker._
-import izumi.distage.docker.bundled.{KafkaDocker, ZookeeperDocker}
 import izumi.distage.docker.healthcheck.ContainerHealthCheck.VerifiedContainerConnectivity
 import izumi.distage.model.effect.{QuasiAsync, QuasiIO}
 import izumi.distage.model.providers.Functoid
 import izumi.fundamentals.platform.language.Quirks._
 import izumi.logstage.api.IzLogger
-import izumi.reflect.Tag
 
 final case class DockerContainer[Tag](
   id: ContainerId,

--- a/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/bundled/KafkaDocker.scala
+++ b/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/bundled/KafkaDocker.scala
@@ -27,11 +27,7 @@ class KafkaDockerModule[F[_]: TagK] extends ModuleDef {
     KafkaDocker
       .make[F]
       .connectToNetwork(KafkaZookeeperNetwork)
-      .modifyConfig {
-        zookeeperDocker: ZookeeperDocker.Container => old: KafkaDocker.Config =>
-          val zkEnv = old.env ++ Map("KAFKA_ZOOKEEPER_CONNECT" -> s"${zookeeperDocker.hostName}:2181")
-          old.copy(env = zkEnv)
-      }
+      .exposeDependencyPorts[ZookeeperDocker.Container](2181 -> "KAFKA_ZOOKEEPER_CONNECT")
   }
 }
 

--- a/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/bundled/KafkaDocker.scala
+++ b/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/bundled/KafkaDocker.scala
@@ -27,7 +27,7 @@ class KafkaDockerModule[F[_]: TagK] extends ModuleDef {
     KafkaDocker
       .make[F]
       .connectToNetwork(KafkaZookeeperNetwork)
-      .useDependencyPorts(ZookeeperDocker)(2181 -> "KAFKA_ZOOKEEPER_CONNECT")
+      .dependOnContainerPorts(ZookeeperDocker)(2181 -> "KAFKA_ZOOKEEPER_CONNECT")
   }
 }
 

--- a/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/bundled/KafkaDocker.scala
+++ b/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/bundled/KafkaDocker.scala
@@ -27,7 +27,7 @@ class KafkaDockerModule[F[_]: TagK] extends ModuleDef {
     KafkaDocker
       .make[F]
       .connectToNetwork(KafkaZookeeperNetwork)
-      .exposeDependencyPorts[ZookeeperDocker.Container](2181 -> "KAFKA_ZOOKEEPER_CONNECT")
+      .useDependencyPorts(ZookeeperDocker)(2181 -> "KAFKA_ZOOKEEPER_CONNECT")
   }
 }
 

--- a/distage/distage-framework-docker/src/test/scala/izumi/distage/testkit/docker/fixtures/DockerPlugin.scala
+++ b/distage/distage-framework-docker/src/test/scala/izumi/distage/testkit/docker/fixtures/DockerPlugin.scala
@@ -64,7 +64,7 @@ object DockerPlugin extends PluginDef {
 
   // this container will start once `DynamoContainer` is up and running
   make[PostgresDocker.Container].fromResource {
-    PostgresDocker.make[Task].dependOnDocker(DynamoDocker)
+    PostgresDocker.make[Task].dependOnContainer(DynamoDocker)
   }
 
   // these lines are for test scope

--- a/doc/microsite/src/main/tut/distage/distage-framework-docker.md
+++ b/doc/microsite/src/main/tut/distage/distage-framework-docker.md
@@ -173,14 +173,14 @@ class PostgresWithMountsDockerModule[F[_]: TagK] extends ModuleDef {
 }
 ```
 
-#### dependOnDocker
+#### dependOnContainer
 
-@scaladoc[`dependOnDocker`](izumi.distage.docker.DockerContainer$$DockerProviderExtensions#dependOnDocker)
-adds a dependency on a given Docker container. `distage` ensures the requested container is available
-before the dependent is provided.
+@scaladoc[`dependOnContainer`](izumi.distage.docker.DockerContainer$$DockerProviderExtensions#dependOnContainer)
+adds a dependency on a given Docker container.
+`distage` ensures the requested container is available before the dependent.
 
 For example, suppose a system under test requires both PostgreSQL and Elasticsearch. One option is to
-use `dependOnDocker` to declare the Elasticsearch container depends on the PostgreSQL container:
+use `dependOnContainer` to declare the Elasticsearch container depends on the PostgreSQL container:
 
 ```scala mdoc:to-string
 object ElasticSearchDocker extends ContainerDef {
@@ -201,7 +201,7 @@ class ElasticSearchPlusPostgresModule[F[_]: TagK] extends ModuleDef {
   }
 
   make[ElasticSearchDocker.Container].fromResource {
-    ElasticSearchDocker.make[F].dependOnDocker(PostgresDocker)
+    ElasticSearchDocker.make[F].dependOnContainer(PostgresDocker)
   }
 }
 ```
@@ -440,7 +440,7 @@ class TestClusterNetworkModule[F[_]: TagK] extends ModuleDef {
     PostgresDocker.make[F].connectToNetwork(TestClusterNetwork)
   }
   make[ElasticSearchDocker.Container].fromResource {
-    ElasticSearchDocker.make[F].dependOnDocker(PostgresDocker).connectToNetwork(TestClusterNetwork)
+    ElasticSearchDocker.make[F].dependOnContainer(PostgresDocker).connectToNetwork(TestClusterNetwork)
   }
 }
 ```

--- a/fundamentals/fundamentals-language/src/main/scala/izumi/fundamentals/platform/language/Quirks.scala
+++ b/fundamentals/fundamentals-language/src/main/scala/izumi/fundamentals/platform/language/Quirks.scala
@@ -3,11 +3,15 @@ package izumi.fundamentals.platform.language
 import scala.language.implicitConversions
 
 /**
-  * Syntax for explicitly discarding values to satisfy `-Ywarn-value-discard`, and for clarity of course!
+  * Syntax for explicitly discarding values to satisfy `-Ywarn-value-discard` and for clarity of course!
   *
   * @see also [[izumi.fundamentals.platform.language.unused]]
   */
 object Quirks {
+
+  @inline implicit final class Discarder[T](private val t: T) extends AnyVal {
+    @inline def discard(): Unit = ()
+  }
 
   @inline final def discard(@unused trash1: Any): Unit = ()
   @inline final def discard(@unused trash1: Any, @unused trash2: Any): Unit = ()
@@ -15,16 +19,11 @@ object Quirks {
   @inline final def discard(@unused trash1: Any, @unused trash2: Any, @unused trash3: Any, @unused trash4: Any): Unit = ()
   @inline final def discard(@unused trash1: Any, @unused trash2: Any, @unused trash3: Any, @unused trash4: Any, @unused trash: Any*): Unit = ()
 
-  @inline final def forget(@unused trash: LazyDiscarder[_]*): Unit = ()
-
-  @inline implicit final class Discarder[T](private val t: T) extends AnyVal {
-    @inline def discard(): Unit = ()
-  }
-
-  @inline implicit final def LazyDiscarder[T](@unused t: => T): LazyDiscarder[Unit] = new LazyDiscarder[Unit]()
-
   @inline final class LazyDiscarder[U >: Unit](private val dummy: Boolean = false) extends AnyVal {
     @inline def forget: U = ()
   }
+  @inline implicit final def LazyDiscarder[T](@unused t: => T): LazyDiscarder[Unit] = new LazyDiscarder[Unit]()
+
+  @inline final def forget(@unused trash: LazyDiscarder[_]*): Unit = ()
 
 }


### PR DESCRIPTION
…v vars in a container