### PR TITLE
Update to Scala 2.13.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ lazy val `fundamentals-collections` = project.in(file("fundamentals/fundamentals
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
       case (_, "2.12.13") => false
-      case (_, _) => true
+      case (_, _) => coverageEnabled.value
     } },
     organization := "io.7mind.izumi",
     unmanagedSourceDirectories in Compile += baseDirectory.value / ".jvm/src/main/scala" ,
@@ -160,7 +160,7 @@ lazy val `fundamentals-platform` = project.in(file("fundamentals/fundamentals-pl
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
       case (_, "2.12.13") => false
-      case (_, _) => true
+      case (_, _) => coverageEnabled.value
     } },
     organization := "io.7mind.izumi",
     unmanagedSourceDirectories in Compile += baseDirectory.value / ".jvm/src/main/scala" ,
@@ -276,7 +276,7 @@ lazy val `fundamentals-language` = project.in(file("fundamentals/fundamentals-la
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
       case (_, "2.12.13") => false
-      case (_, _) => true
+      case (_, _) => coverageEnabled.value
     } },
     organization := "io.7mind.izumi",
     unmanagedSourceDirectories in Compile += baseDirectory.value / ".jvm/src/main/scala" ,
@@ -414,7 +414,7 @@ lazy val `fundamentals-reflection` = project.in(file("fundamentals/fundamentals-
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
       case (_, "2.12.13") => false
-      case (_, _) => true
+      case (_, _) => coverageEnabled.value
     } },
     organization := "io.7mind.izumi",
     unmanagedSourceDirectories in Compile += baseDirectory.value / ".jvm/src/main/scala" ,
@@ -546,7 +546,7 @@ lazy val `fundamentals-functional` = project.in(file("fundamentals/fundamentals-
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
       case (_, "2.12.13") => false
-      case (_, _) => true
+      case (_, _) => coverageEnabled.value
     } },
     organization := "io.7mind.izumi",
     unmanagedSourceDirectories in Compile += baseDirectory.value / ".jvm/src/main/scala" ,
@@ -673,7 +673,7 @@ lazy val `fundamentals-bio` = project.in(file("fundamentals/fundamentals-bio"))
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
       case (_, "2.12.13") => false
-      case (_, _) => true
+      case (_, _) => coverageEnabled.value
     } },
     organization := "io.7mind.izumi",
     unmanagedSourceDirectories in Compile += baseDirectory.value / ".jvm/src/main/scala" ,
@@ -794,7 +794,7 @@ lazy val `fundamentals-json-circe` = project.in(file("fundamentals/fundamentals-
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
       case (_, "2.12.13") => false
-      case (_, _) => true
+      case (_, _) => coverageEnabled.value
     } },
     organization := "io.7mind.izumi",
     unmanagedSourceDirectories in Compile += baseDirectory.value / ".jvm/src/main/scala" ,
@@ -913,7 +913,7 @@ lazy val `fundamentals-orphans` = project.in(file("fundamentals/fundamentals-orp
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
       case (_, "2.12.13") => false
-      case (_, _) => true
+      case (_, _) => coverageEnabled.value
     } },
     organization := "io.7mind.izumi",
     unmanagedSourceDirectories in Compile += baseDirectory.value / ".jvm/src/main/scala" ,
@@ -1026,7 +1026,7 @@ lazy val `fundamentals-literals` = project.in(file("fundamentals/fundamentals-li
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
       case (_, "2.12.13") => false
-      case (_, _) => true
+      case (_, _) => coverageEnabled.value
     } },
     organization := "io.7mind.izumi",
     unmanagedSourceDirectories in Compile += baseDirectory.value / ".jvm/src/main/scala" ,
@@ -1152,7 +1152,7 @@ lazy val `distage-core-api` = project.in(file("distage/distage-core-api"))
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
       case (_, "2.12.13") => false
-      case (_, _) => true
+      case (_, _) => coverageEnabled.value
     } },
     organization := "io.7mind.izumi",
     unmanagedSourceDirectories in Compile += baseDirectory.value / ".jvm/src/main/scala" ,
@@ -1268,7 +1268,7 @@ lazy val `distage-core-proxy-cglib` = project.in(file("distage/distage-core-prox
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
       case (_, "2.12.13") => false
-      case (_, _) => true
+      case (_, _) => coverageEnabled.value
     } },
     organization := "io.7mind.izumi",
     unmanagedSourceDirectories in Compile += baseDirectory.value / ".jvm/src/main/scala" ,
@@ -1392,7 +1392,7 @@ lazy val `distage-core` = project.in(file("distage/distage-core"))
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
       case (_, "2.12.13") => false
-      case (_, _) => true
+      case (_, _) => coverageEnabled.value
     } },
     organization := "io.7mind.izumi",
     unmanagedSourceDirectories in Compile += baseDirectory.value / ".jvm/src/main/scala" ,
@@ -1511,7 +1511,7 @@ lazy val `distage-extension-config` = project.in(file("distage/distage-extension
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
       case (_, "2.12.13") => false
-      case (_, _) => true
+      case (_, _) => coverageEnabled.value
     } },
     organization := "io.7mind.izumi",
     unmanagedSourceDirectories in Compile += baseDirectory.value / ".jvm/src/main/scala" ,
@@ -1651,7 +1651,7 @@ lazy val `distage-extension-plugins` = project.in(file("distage/distage-extensio
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
       case (_, "2.12.13") => false
-      case (_, _) => true
+      case (_, _) => coverageEnabled.value
     } },
     organization := "io.7mind.izumi",
     unmanagedSourceDirectories in Compile += baseDirectory.value / ".jvm/src/main/scala" ,
@@ -1769,7 +1769,7 @@ lazy val `distage-extension-logstage` = project.in(file("distage/distage-extensi
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
       case (_, "2.12.13") => false
-      case (_, _) => true
+      case (_, _) => coverageEnabled.value
     } },
     organization := "io.7mind.izumi",
     unmanagedSourceDirectories in Compile += baseDirectory.value / ".jvm/src/main/scala" ,
@@ -1885,7 +1885,7 @@ lazy val `distage-framework-api` = project.in(file("distage/distage-framework-ap
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
       case (_, "2.12.13") => false
-      case (_, _) => true
+      case (_, _) => coverageEnabled.value
     } },
     organization := "io.7mind.izumi",
     unmanagedSourceDirectories in Compile += baseDirectory.value / ".jvm/src/main/scala" ,
@@ -2014,7 +2014,7 @@ lazy val `distage-framework` = project.in(file("distage/distage-framework"))
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
       case (_, "2.12.13") => false
-      case (_, _) => true
+      case (_, _) => coverageEnabled.value
     } },
     organization := "io.7mind.izumi",
     unmanagedSourceDirectories in Compile += baseDirectory.value / ".jvm/src/main/scala" ,
@@ -2159,7 +2159,7 @@ lazy val `distage-framework-docker` = project.in(file("distage/distage-framework
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
       case (_, "2.12.13") => false
-      case (_, _) => true
+      case (_, _) => coverageEnabled.value
     } },
     organization := "io.7mind.izumi",
     unmanagedSourceDirectories in Compile += baseDirectory.value / ".jvm/src/main/scala" ,
@@ -2274,7 +2274,7 @@ lazy val `distage-testkit-core` = project.in(file("distage/distage-testkit-core"
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
       case (_, "2.12.13") => false
-      case (_, _) => true
+      case (_, _) => coverageEnabled.value
     } },
     organization := "io.7mind.izumi",
     unmanagedSourceDirectories in Compile += baseDirectory.value / ".jvm/src/main/scala" ,
@@ -2400,7 +2400,7 @@ lazy val `distage-testkit-scalatest` = project.in(file("distage/distage-testkit-
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
       case (_, "2.12.13") => false
-      case (_, _) => true
+      case (_, _) => coverageEnabled.value
     } },
     organization := "io.7mind.izumi",
     unmanagedSourceDirectories in Compile += baseDirectory.value / ".jvm/src/main/scala" ,
@@ -2521,7 +2521,7 @@ lazy val `logstage-core` = project.in(file("logstage/logstage-core"))
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
       case (_, "2.12.13") => false
-      case (_, _) => true
+      case (_, _) => coverageEnabled.value
     } },
     organization := "io.7mind.izumi",
     unmanagedSourceDirectories in Compile += baseDirectory.value / ".jvm/src/main/scala" ,
@@ -2637,7 +2637,7 @@ lazy val `logstage-rendering-circe` = project.in(file("logstage/logstage-renderi
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
       case (_, "2.12.13") => false
-      case (_, _) => true
+      case (_, _) => coverageEnabled.value
     } },
     organization := "io.7mind.izumi",
     unmanagedSourceDirectories in Compile += baseDirectory.value / ".jvm/src/main/scala" ,
@@ -2753,7 +2753,7 @@ lazy val `logstage-adapter-slf4j` = project.in(file("logstage/logstage-adapter-s
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
       case (_, "2.12.13") => false
-      case (_, _) => true
+      case (_, _) => coverageEnabled.value
     } },
     organization := "io.7mind.izumi",
     unmanagedSourceDirectories in Compile += baseDirectory.value / ".jvm/src/main/scala" ,
@@ -2873,7 +2873,7 @@ lazy val `logstage-sink-slf4j` = project.in(file("logstage/logstage-sink-slf4j")
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
       case (_, "2.12.13") => false
-      case (_, _) => true
+      case (_, _) => coverageEnabled.value
     } },
     organization := "io.7mind.izumi",
     unmanagedSourceDirectories in Compile += baseDirectory.value / ".jvm/src/main/scala" ,
@@ -3020,7 +3020,7 @@ lazy val `microsite` = project.in(file("doc/microsite"))
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
       case (_, "2.12.13") => false
-      case (_, _) => true
+      case (_, _) => coverageEnabled.value
     } },
     organization := "io.7mind.izumi",
     unmanagedSourceDirectories in Compile += baseDirectory.value / ".jvm/src/main/scala" ,

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ lazy val `fundamentals-collections` = project.in(file("fundamentals/fundamentals
   .settings(
     scalaVersion := crossScalaVersions.value.head,
     crossScalaVersions := Seq(
-      "2.13.4",
+      "2.13.5",
       "2.12.13"
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
@@ -80,7 +80,7 @@ lazy val `fundamentals-collections` = project.in(file("fundamentals/fundamentals
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.4") => Seq(
+      case (_, "2.13.5") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -95,12 +95,12 @@ lazy val `fundamentals-collections` = project.in(file("fundamentals/fundamentals
         "-Wunused:_",
         "-Wvalue-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Wunused:-synthetics"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
-    scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
       s"-Xmacro-settings:is-ci=${insideCI.value}"
@@ -110,7 +110,7 @@ lazy val `fundamentals-collections` = project.in(file("fundamentals/fundamentals
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.4") => Seq(
+      case (false, "2.13.5") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -155,7 +155,7 @@ lazy val `fundamentals-platform` = project.in(file("fundamentals/fundamentals-pl
   .settings(
     scalaVersion := crossScalaVersions.value.head,
     crossScalaVersions := Seq(
-      "2.13.4",
+      "2.13.5",
       "2.12.13"
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
@@ -217,7 +217,7 @@ lazy val `fundamentals-platform` = project.in(file("fundamentals/fundamentals-pl
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.4") => Seq(
+      case (_, "2.13.5") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -232,12 +232,12 @@ lazy val `fundamentals-platform` = project.in(file("fundamentals/fundamentals-pl
         "-Wunused:_",
         "-Wvalue-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Wunused:-synthetics"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
-    scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
       s"-Xmacro-settings:is-ci=${insideCI.value}"
@@ -247,7 +247,7 @@ lazy val `fundamentals-platform` = project.in(file("fundamentals/fundamentals-pl
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.4") => Seq(
+      case (false, "2.13.5") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -271,7 +271,7 @@ lazy val `fundamentals-language` = project.in(file("fundamentals/fundamentals-la
   .settings(
     scalaVersion := crossScalaVersions.value.head,
     crossScalaVersions := Seq(
-      "2.13.4",
+      "2.13.5",
       "2.12.13"
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
@@ -333,7 +333,7 @@ lazy val `fundamentals-language` = project.in(file("fundamentals/fundamentals-la
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.4") => Seq(
+      case (_, "2.13.5") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -348,12 +348,12 @@ lazy val `fundamentals-language` = project.in(file("fundamentals/fundamentals-la
         "-Wunused:_",
         "-Wvalue-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Wunused:-synthetics"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
-    scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
       s"-Xmacro-settings:is-ci=${insideCI.value}"
@@ -363,7 +363,7 @@ lazy val `fundamentals-language` = project.in(file("fundamentals/fundamentals-la
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.4") => Seq(
+      case (false, "2.13.5") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -409,7 +409,7 @@ lazy val `fundamentals-reflection` = project.in(file("fundamentals/fundamentals-
   .settings(
     scalaVersion := crossScalaVersions.value.head,
     crossScalaVersions := Seq(
-      "2.13.4",
+      "2.13.5",
       "2.12.13"
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
@@ -471,7 +471,7 @@ lazy val `fundamentals-reflection` = project.in(file("fundamentals/fundamentals-
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.4") => Seq(
+      case (_, "2.13.5") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -486,12 +486,12 @@ lazy val `fundamentals-reflection` = project.in(file("fundamentals/fundamentals-
         "-Wunused:_",
         "-Wvalue-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Wunused:-synthetics"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
-    scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
       s"-Xmacro-settings:is-ci=${insideCI.value}"
@@ -501,7 +501,7 @@ lazy val `fundamentals-reflection` = project.in(file("fundamentals/fundamentals-
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.4") => Seq(
+      case (false, "2.13.5") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -541,7 +541,7 @@ lazy val `fundamentals-functional` = project.in(file("fundamentals/fundamentals-
   .settings(
     scalaVersion := crossScalaVersions.value.head,
     crossScalaVersions := Seq(
-      "2.13.4",
+      "2.13.5",
       "2.12.13"
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
@@ -603,7 +603,7 @@ lazy val `fundamentals-functional` = project.in(file("fundamentals/fundamentals-
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.4") => Seq(
+      case (_, "2.13.5") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -618,12 +618,12 @@ lazy val `fundamentals-functional` = project.in(file("fundamentals/fundamentals-
         "-Wunused:_",
         "-Wvalue-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Wunused:-synthetics"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
-    scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
       s"-Xmacro-settings:is-ci=${insideCI.value}"
@@ -633,7 +633,7 @@ lazy val `fundamentals-functional` = project.in(file("fundamentals/fundamentals-
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.4") => Seq(
+      case (false, "2.13.5") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -668,7 +668,7 @@ lazy val `fundamentals-bio` = project.in(file("fundamentals/fundamentals-bio"))
   .settings(
     scalaVersion := crossScalaVersions.value.head,
     crossScalaVersions := Seq(
-      "2.13.4",
+      "2.13.5",
       "2.12.13"
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
@@ -730,7 +730,7 @@ lazy val `fundamentals-bio` = project.in(file("fundamentals/fundamentals-bio"))
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.4") => Seq(
+      case (_, "2.13.5") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -745,12 +745,12 @@ lazy val `fundamentals-bio` = project.in(file("fundamentals/fundamentals-bio"))
         "-Wunused:_",
         "-Wvalue-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Wunused:-synthetics"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
-    scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
       s"-Xmacro-settings:is-ci=${insideCI.value}"
@@ -760,7 +760,7 @@ lazy val `fundamentals-bio` = project.in(file("fundamentals/fundamentals-bio"))
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.4") => Seq(
+      case (false, "2.13.5") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -789,7 +789,7 @@ lazy val `fundamentals-json-circe` = project.in(file("fundamentals/fundamentals-
   .settings(
     scalaVersion := crossScalaVersions.value.head,
     crossScalaVersions := Seq(
-      "2.13.4",
+      "2.13.5",
       "2.12.13"
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
@@ -851,7 +851,7 @@ lazy val `fundamentals-json-circe` = project.in(file("fundamentals/fundamentals-
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.4") => Seq(
+      case (_, "2.13.5") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -866,12 +866,12 @@ lazy val `fundamentals-json-circe` = project.in(file("fundamentals/fundamentals-
         "-Wunused:_",
         "-Wvalue-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Wunused:-synthetics"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
-    scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
       s"-Xmacro-settings:is-ci=${insideCI.value}"
@@ -881,7 +881,7 @@ lazy val `fundamentals-json-circe` = project.in(file("fundamentals/fundamentals-
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.4") => Seq(
+      case (false, "2.13.5") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -908,7 +908,7 @@ lazy val `fundamentals-orphans` = project.in(file("fundamentals/fundamentals-orp
   .settings(
     scalaVersion := crossScalaVersions.value.head,
     crossScalaVersions := Seq(
-      "2.13.4",
+      "2.13.5",
       "2.12.13"
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
@@ -970,7 +970,7 @@ lazy val `fundamentals-orphans` = project.in(file("fundamentals/fundamentals-orp
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.4") => Seq(
+      case (_, "2.13.5") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -985,12 +985,12 @@ lazy val `fundamentals-orphans` = project.in(file("fundamentals/fundamentals-orp
         "-Wunused:_",
         "-Wvalue-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Wunused:-synthetics"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
-    scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
       s"-Xmacro-settings:is-ci=${insideCI.value}"
@@ -1000,7 +1000,7 @@ lazy val `fundamentals-orphans` = project.in(file("fundamentals/fundamentals-orp
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.4") => Seq(
+      case (false, "2.13.5") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1021,7 +1021,7 @@ lazy val `fundamentals-literals` = project.in(file("fundamentals/fundamentals-li
   .settings(
     scalaVersion := crossScalaVersions.value.head,
     crossScalaVersions := Seq(
-      "2.13.4",
+      "2.13.5",
       "2.12.13"
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
@@ -1083,7 +1083,7 @@ lazy val `fundamentals-literals` = project.in(file("fundamentals/fundamentals-li
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.4") => Seq(
+      case (_, "2.13.5") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -1098,12 +1098,12 @@ lazy val `fundamentals-literals` = project.in(file("fundamentals/fundamentals-li
         "-Wunused:_",
         "-Wvalue-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Wunused:-synthetics"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
-    scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
       s"-Xmacro-settings:is-ci=${insideCI.value}"
@@ -1113,7 +1113,7 @@ lazy val `fundamentals-literals` = project.in(file("fundamentals/fundamentals-li
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.4") => Seq(
+      case (false, "2.13.5") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1147,7 +1147,7 @@ lazy val `distage-core-api` = project.in(file("distage/distage-core-api"))
   .settings(
     scalaVersion := crossScalaVersions.value.head,
     crossScalaVersions := Seq(
-      "2.13.4",
+      "2.13.5",
       "2.12.13"
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
@@ -1209,7 +1209,7 @@ lazy val `distage-core-api` = project.in(file("distage/distage-core-api"))
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.4") => Seq(
+      case (_, "2.13.5") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -1224,12 +1224,12 @@ lazy val `distage-core-api` = project.in(file("distage/distage-core-api"))
         "-Wunused:_",
         "-Wvalue-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Wunused:-synthetics"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
-    scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
       s"-Xmacro-settings:is-ci=${insideCI.value}"
@@ -1239,7 +1239,7 @@ lazy val `distage-core-api` = project.in(file("distage/distage-core-api"))
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.4") => Seq(
+      case (false, "2.13.5") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1263,7 +1263,7 @@ lazy val `distage-core-proxy-cglib` = project.in(file("distage/distage-core-prox
   .settings(
     scalaVersion := crossScalaVersions.value.head,
     crossScalaVersions := Seq(
-      "2.13.4",
+      "2.13.5",
       "2.12.13"
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
@@ -1325,7 +1325,7 @@ lazy val `distage-core-proxy-cglib` = project.in(file("distage/distage-core-prox
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.4") => Seq(
+      case (_, "2.13.5") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -1340,12 +1340,12 @@ lazy val `distage-core-proxy-cglib` = project.in(file("distage/distage-core-prox
         "-Wunused:_",
         "-Wvalue-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Wunused:-synthetics"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
-    scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
       s"-Xmacro-settings:is-ci=${insideCI.value}"
@@ -1355,7 +1355,7 @@ lazy val `distage-core-proxy-cglib` = project.in(file("distage/distage-core-prox
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.4") => Seq(
+      case (false, "2.13.5") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1387,7 +1387,7 @@ lazy val `distage-core` = project.in(file("distage/distage-core"))
   .settings(
     scalaVersion := crossScalaVersions.value.head,
     crossScalaVersions := Seq(
-      "2.13.4",
+      "2.13.5",
       "2.12.13"
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
@@ -1449,7 +1449,7 @@ lazy val `distage-core` = project.in(file("distage/distage-core"))
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.4") => Seq(
+      case (_, "2.13.5") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -1464,12 +1464,12 @@ lazy val `distage-core` = project.in(file("distage/distage-core"))
         "-Wunused:_",
         "-Wvalue-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Wunused:-synthetics"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
-    scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
       s"-Xmacro-settings:is-ci=${insideCI.value}"
@@ -1479,7 +1479,7 @@ lazy val `distage-core` = project.in(file("distage/distage-core"))
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.4") => Seq(
+      case (false, "2.13.5") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1506,7 +1506,7 @@ lazy val `distage-extension-config` = project.in(file("distage/distage-extension
   .settings(
     scalaVersion := crossScalaVersions.value.head,
     crossScalaVersions := Seq(
-      "2.13.4",
+      "2.13.5",
       "2.12.13"
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
@@ -1568,7 +1568,7 @@ lazy val `distage-extension-config` = project.in(file("distage/distage-extension
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.4") => Seq(
+      case (_, "2.13.5") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -1583,12 +1583,12 @@ lazy val `distage-extension-config` = project.in(file("distage/distage-extension
         "-Wunused:_",
         "-Wvalue-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Wunused:-synthetics"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
-    scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
       s"-Xmacro-settings:is-ci=${insideCI.value}"
@@ -1598,7 +1598,7 @@ lazy val `distage-extension-config` = project.in(file("distage/distage-extension
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.4") => Seq(
+      case (false, "2.13.5") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1646,7 +1646,7 @@ lazy val `distage-extension-plugins` = project.in(file("distage/distage-extensio
   .settings(
     scalaVersion := crossScalaVersions.value.head,
     crossScalaVersions := Seq(
-      "2.13.4",
+      "2.13.5",
       "2.12.13"
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
@@ -1708,7 +1708,7 @@ lazy val `distage-extension-plugins` = project.in(file("distage/distage-extensio
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.4") => Seq(
+      case (_, "2.13.5") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -1723,12 +1723,12 @@ lazy val `distage-extension-plugins` = project.in(file("distage/distage-extensio
         "-Wunused:_",
         "-Wvalue-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Wunused:-synthetics"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
-    scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
       s"-Xmacro-settings:is-ci=${insideCI.value}"
@@ -1738,7 +1738,7 @@ lazy val `distage-extension-plugins` = project.in(file("distage/distage-extensio
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.4") => Seq(
+      case (false, "2.13.5") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1764,7 +1764,7 @@ lazy val `distage-extension-logstage` = project.in(file("distage/distage-extensi
   .settings(
     scalaVersion := crossScalaVersions.value.head,
     crossScalaVersions := Seq(
-      "2.13.4",
+      "2.13.5",
       "2.12.13"
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
@@ -1826,7 +1826,7 @@ lazy val `distage-extension-logstage` = project.in(file("distage/distage-extensi
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.4") => Seq(
+      case (_, "2.13.5") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -1841,12 +1841,12 @@ lazy val `distage-extension-logstage` = project.in(file("distage/distage-extensi
         "-Wunused:_",
         "-Wvalue-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Wunused:-synthetics"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
-    scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
       s"-Xmacro-settings:is-ci=${insideCI.value}"
@@ -1856,7 +1856,7 @@ lazy val `distage-extension-logstage` = project.in(file("distage/distage-extensi
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.4") => Seq(
+      case (false, "2.13.5") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1880,7 +1880,7 @@ lazy val `distage-framework-api` = project.in(file("distage/distage-framework-ap
   .settings(
     scalaVersion := crossScalaVersions.value.head,
     crossScalaVersions := Seq(
-      "2.13.4",
+      "2.13.5",
       "2.12.13"
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
@@ -1942,7 +1942,7 @@ lazy val `distage-framework-api` = project.in(file("distage/distage-framework-ap
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.4") => Seq(
+      case (_, "2.13.5") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -1957,12 +1957,12 @@ lazy val `distage-framework-api` = project.in(file("distage/distage-framework-ap
         "-Wunused:_",
         "-Wvalue-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Wunused:-synthetics"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
-    scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
       s"-Xmacro-settings:is-ci=${insideCI.value}"
@@ -1972,7 +1972,7 @@ lazy val `distage-framework-api` = project.in(file("distage/distage-framework-ap
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.4") => Seq(
+      case (false, "2.13.5") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2009,7 +2009,7 @@ lazy val `distage-framework` = project.in(file("distage/distage-framework"))
   .settings(
     scalaVersion := crossScalaVersions.value.head,
     crossScalaVersions := Seq(
-      "2.13.4",
+      "2.13.5",
       "2.12.13"
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
@@ -2071,7 +2071,7 @@ lazy val `distage-framework` = project.in(file("distage/distage-framework"))
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.4") => Seq(
+      case (_, "2.13.5") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -2086,12 +2086,12 @@ lazy val `distage-framework` = project.in(file("distage/distage-framework"))
         "-Wunused:_",
         "-Wvalue-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Wunused:-synthetics"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
-    scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
       s"-Xmacro-settings:is-ci=${insideCI.value}"
@@ -2101,7 +2101,7 @@ lazy val `distage-framework` = project.in(file("distage/distage-framework"))
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.4") => Seq(
+      case (false, "2.13.5") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2154,7 +2154,7 @@ lazy val `distage-framework-docker` = project.in(file("distage/distage-framework
   .settings(
     scalaVersion := crossScalaVersions.value.head,
     crossScalaVersions := Seq(
-      "2.13.4",
+      "2.13.5",
       "2.12.13"
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
@@ -2216,7 +2216,7 @@ lazy val `distage-framework-docker` = project.in(file("distage/distage-framework
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.4") => Seq(
+      case (_, "2.13.5") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -2231,12 +2231,12 @@ lazy val `distage-framework-docker` = project.in(file("distage/distage-framework
         "-Wunused:_",
         "-Wvalue-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Wunused:-synthetics"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
-    scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
       s"-Xmacro-settings:is-ci=${insideCI.value}"
@@ -2246,7 +2246,7 @@ lazy val `distage-framework-docker` = project.in(file("distage/distage-framework
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.4") => Seq(
+      case (false, "2.13.5") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2269,7 +2269,7 @@ lazy val `distage-testkit-core` = project.in(file("distage/distage-testkit-core"
   .settings(
     scalaVersion := crossScalaVersions.value.head,
     crossScalaVersions := Seq(
-      "2.13.4",
+      "2.13.5",
       "2.12.13"
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
@@ -2331,7 +2331,7 @@ lazy val `distage-testkit-core` = project.in(file("distage/distage-testkit-core"
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.4") => Seq(
+      case (_, "2.13.5") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -2346,12 +2346,12 @@ lazy val `distage-testkit-core` = project.in(file("distage/distage-testkit-core"
         "-Wunused:_",
         "-Wvalue-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Wunused:-synthetics"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
-    scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
       s"-Xmacro-settings:is-ci=${insideCI.value}"
@@ -2361,7 +2361,7 @@ lazy val `distage-testkit-core` = project.in(file("distage/distage-testkit-core"
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.4") => Seq(
+      case (false, "2.13.5") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2395,7 +2395,7 @@ lazy val `distage-testkit-scalatest` = project.in(file("distage/distage-testkit-
   .settings(
     scalaVersion := crossScalaVersions.value.head,
     crossScalaVersions := Seq(
-      "2.13.4",
+      "2.13.5",
       "2.12.13"
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
@@ -2457,7 +2457,7 @@ lazy val `distage-testkit-scalatest` = project.in(file("distage/distage-testkit-
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.4") => Seq(
+      case (_, "2.13.5") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -2472,12 +2472,12 @@ lazy val `distage-testkit-scalatest` = project.in(file("distage/distage-testkit-
         "-Wunused:_",
         "-Wvalue-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Wunused:-synthetics"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
-    scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
       s"-Xmacro-settings:is-ci=${insideCI.value}"
@@ -2487,7 +2487,7 @@ lazy val `distage-testkit-scalatest` = project.in(file("distage/distage-testkit-
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.4") => Seq(
+      case (false, "2.13.5") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2516,7 +2516,7 @@ lazy val `logstage-core` = project.in(file("logstage/logstage-core"))
   .settings(
     scalaVersion := crossScalaVersions.value.head,
     crossScalaVersions := Seq(
-      "2.13.4",
+      "2.13.5",
       "2.12.13"
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
@@ -2578,7 +2578,7 @@ lazy val `logstage-core` = project.in(file("logstage/logstage-core"))
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.4") => Seq(
+      case (_, "2.13.5") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -2593,12 +2593,12 @@ lazy val `logstage-core` = project.in(file("logstage/logstage-core"))
         "-Wunused:_",
         "-Wvalue-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Wunused:-synthetics"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
-    scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
       s"-Xmacro-settings:is-ci=${insideCI.value}"
@@ -2608,7 +2608,7 @@ lazy val `logstage-core` = project.in(file("logstage/logstage-core"))
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.4") => Seq(
+      case (false, "2.13.5") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2632,7 +2632,7 @@ lazy val `logstage-rendering-circe` = project.in(file("logstage/logstage-renderi
   .settings(
     scalaVersion := crossScalaVersions.value.head,
     crossScalaVersions := Seq(
-      "2.13.4",
+      "2.13.5",
       "2.12.13"
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
@@ -2694,7 +2694,7 @@ lazy val `logstage-rendering-circe` = project.in(file("logstage/logstage-renderi
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.4") => Seq(
+      case (_, "2.13.5") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -2709,12 +2709,12 @@ lazy val `logstage-rendering-circe` = project.in(file("logstage/logstage-renderi
         "-Wunused:_",
         "-Wvalue-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Wunused:-synthetics"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
-    scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
       s"-Xmacro-settings:is-ci=${insideCI.value}"
@@ -2724,7 +2724,7 @@ lazy val `logstage-rendering-circe` = project.in(file("logstage/logstage-renderi
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.4") => Seq(
+      case (false, "2.13.5") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2748,7 +2748,7 @@ lazy val `logstage-adapter-slf4j` = project.in(file("logstage/logstage-adapter-s
   .settings(
     scalaVersion := crossScalaVersions.value.head,
     crossScalaVersions := Seq(
-      "2.13.4",
+      "2.13.5",
       "2.12.13"
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
@@ -2810,7 +2810,7 @@ lazy val `logstage-adapter-slf4j` = project.in(file("logstage/logstage-adapter-s
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.4") => Seq(
+      case (_, "2.13.5") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -2825,12 +2825,12 @@ lazy val `logstage-adapter-slf4j` = project.in(file("logstage/logstage-adapter-s
         "-Wunused:_",
         "-Wvalue-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Wunused:-synthetics"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
-    scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
       s"-Xmacro-settings:is-ci=${insideCI.value}"
@@ -2840,7 +2840,7 @@ lazy val `logstage-adapter-slf4j` = project.in(file("logstage/logstage-adapter-s
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.4") => Seq(
+      case (false, "2.13.5") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2868,7 +2868,7 @@ lazy val `logstage-sink-slf4j` = project.in(file("logstage/logstage-sink-slf4j")
   .settings(
     scalaVersion := crossScalaVersions.value.head,
     crossScalaVersions := Seq(
-      "2.13.4",
+      "2.13.5",
       "2.12.13"
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
@@ -2930,7 +2930,7 @@ lazy val `logstage-sink-slf4j` = project.in(file("logstage/logstage-sink-slf4j")
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.4") => Seq(
+      case (_, "2.13.5") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -2945,12 +2945,12 @@ lazy val `logstage-sink-slf4j` = project.in(file("logstage/logstage-sink-slf4j")
         "-Wunused:_",
         "-Wvalue-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Wunused:-synthetics"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
-    scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
       s"-Xmacro-settings:is-ci=${insideCI.value}"
@@ -2960,7 +2960,7 @@ lazy val `logstage-sink-slf4j` = project.in(file("logstage/logstage-sink-slf4j")
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.4") => Seq(
+      case (false, "2.13.5") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -3015,7 +3015,7 @@ lazy val `microsite` = project.in(file("doc/microsite"))
   .settings(
     scalaVersion := crossScalaVersions.value.head,
     crossScalaVersions := Seq(
-      "2.13.4",
+      "2.13.5",
       "2.12.13"
     ),
     coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
@@ -3077,7 +3077,7 @@ lazy val `microsite` = project.in(file("doc/microsite"))
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.4") => Seq(
+      case (_, "2.13.5") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -3092,12 +3092,12 @@ lazy val `microsite` = project.in(file("doc/microsite"))
         "-Wunused:_",
         "-Wvalue-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Wunused:-synthetics"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
-    scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
       s"-Xmacro-settings:is-ci=${insideCI.value}"
@@ -3107,7 +3107,7 @@ lazy val `microsite` = project.in(file("doc/microsite"))
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.4") => Seq(
+      case (false, "2.13.5") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -3246,7 +3246,7 @@ lazy val `sbt-izumi-deps` = project.in(file("sbt-plugins/sbt-izumi-deps"))
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.4") => Seq(
+      case (_, "2.13.5") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -3261,12 +3261,12 @@ lazy val `sbt-izumi-deps` = project.in(file("sbt-plugins/sbt-izumi-deps"))
         "-Wunused:_",
         "-Wvalue-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Wunused:-synthetics"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
-    scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
       s"-Xmacro-settings:is-ci=${insideCI.value}"
@@ -3276,7 +3276,7 @@ lazy val `sbt-izumi-deps` = project.in(file("sbt-plugins/sbt-izumi-deps"))
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.4") => Seq(
+      case (false, "2.13.5") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -3291,7 +3291,7 @@ lazy val `fundamentals` = (project in file(".agg/fundamentals-fundamentals"))
   .settings(
     skip in publish := true,
     crossScalaVersions := Seq(
-      "2.13.4",
+      "2.13.5",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head
@@ -3313,7 +3313,7 @@ lazy val `fundamentals-jvm` = (project in file(".agg/fundamentals-fundamentals-j
   .settings(
     skip in publish := true,
     crossScalaVersions := Seq(
-      "2.13.4",
+      "2.13.5",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head
@@ -3335,7 +3335,7 @@ lazy val `distage` = (project in file(".agg/distage-distage"))
   .settings(
     skip in publish := true,
     crossScalaVersions := Seq(
-      "2.13.4",
+      "2.13.5",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head
@@ -3359,7 +3359,7 @@ lazy val `distage-jvm` = (project in file(".agg/distage-distage-jvm"))
   .settings(
     skip in publish := true,
     crossScalaVersions := Seq(
-      "2.13.4",
+      "2.13.5",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head
@@ -3383,7 +3383,7 @@ lazy val `logstage` = (project in file(".agg/logstage-logstage"))
   .settings(
     skip in publish := true,
     crossScalaVersions := Seq(
-      "2.13.4",
+      "2.13.5",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head
@@ -3400,7 +3400,7 @@ lazy val `logstage-jvm` = (project in file(".agg/logstage-logstage-jvm"))
   .settings(
     skip in publish := true,
     crossScalaVersions := Seq(
-      "2.13.4",
+      "2.13.5",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head
@@ -3417,7 +3417,7 @@ lazy val `doc` = (project in file(".agg/doc-doc"))
   .settings(
     skip in publish := true,
     crossScalaVersions := Seq(
-      "2.13.4",
+      "2.13.5",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head
@@ -3431,7 +3431,7 @@ lazy val `doc-jvm` = (project in file(".agg/doc-doc-jvm"))
   .settings(
     skip in publish := true,
     crossScalaVersions := Seq(
-      "2.13.4",
+      "2.13.5",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head
@@ -3444,7 +3444,8 @@ lazy val `doc-jvm` = (project in file(".agg/doc-doc-jvm"))
 lazy val `sbt-plugins` = (project in file(".agg/sbt-plugins-sbt-plugins"))
   .settings(
     skip in publish := true,
-    crossScalaVersions := Nil
+    crossScalaVersions := Nil,
+    scalaVersion := "2.12.13"
   )
   .disablePlugins(AssemblyPlugin)
   .aggregate(
@@ -3454,7 +3455,8 @@ lazy val `sbt-plugins` = (project in file(".agg/sbt-plugins-sbt-plugins"))
 lazy val `sbt-plugins-jvm` = (project in file(".agg/sbt-plugins-sbt-plugins-jvm"))
   .settings(
     skip in publish := true,
-    crossScalaVersions := Nil
+    crossScalaVersions := Nil,
+    scalaVersion := "2.12.13"
   )
   .disablePlugins(AssemblyPlugin)
   .aggregate(
@@ -3465,7 +3467,7 @@ lazy val `izumi-jvm` = (project in file(".agg/.agg-jvm"))
   .settings(
     skip in publish := true,
     crossScalaVersions := Seq(
-      "2.13.4",
+      "2.13.5",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head
@@ -3512,7 +3514,7 @@ lazy val `izumi` = (project in file("."))
       s"-Xmacro-settings:git-head-commit=${com.typesafe.sbt.SbtGit.GitKeys.gitHeadCommit.value.getOrElse("")}"
     ),
     crossScalaVersions := Nil,
-    scalaVersion := "2.13.4",
+    scalaVersion := "2.13.5",
     organization in ThisBuild := "io.7mind.izumi",
     sonatypeProfileName := "io.7mind",
     sonatypeSessionName := s"[sbt-sonatype] ${name.value} ${version.value} ${java.util.UUID.randomUUID}",

--- a/distage/distage-core-api/src/main/scala/izumi/distage/constructors/macros/ConstructorMacros.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/constructors/macros/ConstructorMacros.scala
@@ -313,7 +313,7 @@ abstract class ConstructorMacrosBase {
     val tools = DIUniverseLiftables(u)
     import tools.{liftTypeToSafeType, liftableParameter}
 
-    val seqName = TermName(c.freshName("seqAny"))
+    val seqName = if (parameters.exists(_.nonEmpty)) TermName(c.freshName("seqAny")) else TermName("_")
 
     val casts = {
       var i = 0

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/providers/Functoid.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/providers/Functoid.scala
@@ -113,7 +113,7 @@ final case class Functoid[+A](get: Provider) {
     * }}}
     */
   def ap[B, C](that: Functoid[B])(implicit @unused ev: A <:< (B => C), tag: Tag[C]): Functoid[C] = {
-    map2(that)((f, a) => f(a))
+    map2(that)((f, a) => f.asInstanceOf[B => C](a))
   }
 
   /** Add `B` as an unused dependency of this Provider */

--- a/distage/distage-extension-config/src/test/scala_2.13/izumi/distage/impl/OptionalDependencyTest213.scala
+++ b/distage/distage-extension-config/src/test/scala_2.13/izumi/distage/impl/OptionalDependencyTest213.scala
@@ -6,8 +6,8 @@ import org.scalatest.wordspec.AnyWordSpec
 class OptionalDependencyTest213 extends AnyWordSpec {
 
   "Perform exhaustive search for BIO and not find instances for ZIO / monix-bio when they're not on classpath" in {
-    final class optSearch2[C[_[_, _]]] { def find[F[_, _]](implicit a: C[F] = null.asInstanceOf[C[F]]): C[F] = a }
-    final class optSearch3[C[_[_, _, _]]] { def find[F[_, _, _]](implicit a: C[F] = null.asInstanceOf[C[F]]): C[F] = a }
+    final class optSearch2[C[_[+_, +_]]] { def find[F[+_, +_]](implicit a: C[F] = null.asInstanceOf[C[F]]): C[F] = a }
+    final class optSearch3[C[_[-_, +_, +_]]] { def find[F[-_, +_, +_]](implicit a: C[F] = null.asInstanceOf[C[F]]): C[F] = a }
 
     assert(new optSearch2[IO2].find == null)
     assert(new optSearch3[IO3].find == null)

--- a/fundamentals/fundamentals-collections/src/main/scala/izumi/fundamentals/collections/nonempty/NonEmptyList.scala
+++ b/fundamentals/fundamentals-collections/src/main/scala/izumi/fundamentals/collections/nonempty/NonEmptyList.scala
@@ -174,7 +174,7 @@ final class NonEmptyList[+T] private (val toList: List[T]) extends AnyVal {
     * @param that the <code>Seq</code> slice to look for
     * @return true if this <code>NonEmptyList</code> contains a slice with the same elements as <code>that</code>, otherwise <code>false</code>.
     */
-  def containsSlice[B](that: Seq[B]): Boolean = toList.containsSlice(that)
+  def containsSlice[U >: T](that: Seq[U]): Boolean = toList.containsSlice(that)
 
   /**
     * Indicates whether this <code>NonEmptyList</code> contains a given <code>Vector</code> as a slice.
@@ -182,7 +182,7 @@ final class NonEmptyList[+T] private (val toList: List[T]) extends AnyVal {
     * @param that the <code>Vector</code> slice to look for
     * @return true if this <code>NonEmptyList</code> contains a slice with the same elements as <code>that</code>, otherwise <code>false</code>.
     */
-  def containsSlice[B](that: Vector[B]): Boolean = toList.containsSlice(that)
+  def containsSlice[U >: T](that: Vector[U]): Boolean = toList.containsSlice(that)
 
   /**
     * Indicates whether this <code>NonEmptyList</code> contains a given <code>NonEmptyList</code> as a slice.
@@ -190,7 +190,7 @@ final class NonEmptyList[+T] private (val toList: List[T]) extends AnyVal {
     * @param that the <code>NonEmptyList</code> slice to look for
     * @return true if this <code>NonEmptyList</code> contains a slice with the same elements as <code>that</code>, otherwise <code>false</code>.
     */
-  def containsSlice[B](that: NonEmptyList[B]): Boolean = toList.containsSlice(that.toList)
+  def containsSlice[U >: T](that: NonEmptyList[U]): Boolean = toList.containsSlice(that.toList)
 
   /**
     * Copies values of this <code>NonEmptyList</code> to an array. Fills the given array <code>arr</code> with values of this <code>NonEmptyList</code>. Copying

--- a/logstage/logstage-core/.jvm/src/test/scala/izumi/logstage/ImplicitsTest.scala
+++ b/logstage/logstage-core/.jvm/src/test/scala/izumi/logstage/ImplicitsTest.scala
@@ -8,6 +8,7 @@ import izumi.fundamentals.platform.language.Quirks._
 import izumi.logstage.ImplicitsTest.Suspend2
 import izumi.logstage.api.IzLogger
 import logstage.{LogIO, LogIO2}
+import org.scalatest.exceptions.TestFailedException
 import org.scalatest.wordspec.AnyWordSpec
 
 class ImplicitsTest extends AnyWordSpec {
@@ -24,11 +25,13 @@ class ImplicitsTest extends AnyWordSpec {
   "progression test: can't create LogIO from covariant F/Sync even when annotated (FIXED in 2.13, but not in 2.12 -Xsource:2.13)" in {
     IzScala.scalaRelease match {
       case _: ScalaRelease.`2_12` =>
-        assertTypeError(
-          """
-    def logIOC[F[+_]: Sync]: LogIO[F] = LogIO.fromLogger[F](IzLogger())
-    logIOC[cats.effect.IO]
-      """
+        intercept[TestFailedException](
+          assertCompiles(
+            """
+            def logIOC[F[+_]: Sync]: LogIO[F] = LogIO.fromLogger[F](IzLogger())
+            logIOC[cats.effect.IO]
+            """
+          )
         )
       case _ =>
     }

--- a/project/Deps.sc
+++ b/project/Deps.sc
@@ -154,7 +154,7 @@ object Izumi {
         // disable scoverage on 2.12 for now due to incompatibility with 2.12.13
         "coverageEnabled" := Seq(
           SettingKey(Some(scala212), None) := false,
-          SettingKey.Default := true,
+          SettingKey.Default := "coverageEnabled.value".raw,
         )
       ),
     )

--- a/project/Deps.sc
+++ b/project/Deps.sc
@@ -133,7 +133,7 @@ object Izumi {
 
   // DON'T REMOVE, these variables are read from CI build (build.sh)
   final val scala212 = ScalaVersion("2.12.13")
-  final val scala213 = ScalaVersion("2.13.4")
+  final val scala213 = ScalaVersion("2.13.5")
 
   object Groups {
     final val fundamentals = Set(Group("fundamentals"))
@@ -238,12 +238,12 @@ object Izumi {
         "testOptions" in SettingScope.Test += """Tests.Argument("-oDF")""".raw,
         "scalacOptions" ++= Seq(
           SettingKey(Some(scala212), None) := Defaults.Scala212Options,
-          SettingKey(Some(scala213), None) := Defaults.Scala213Options,
+          SettingKey(Some(scala213), None) := (Defaults.Scala213Options ++ Seq[Const](
+            "-Wunused:-synthetics"
+          )),
           SettingKey.Default := Const.EmptySeq,
         ),
         "scalacOptions" += "-Wconf:msg=nowarn:silent",
-        // disable fatal-warnings to make sure publish goes through
-        "scalacOptions" -= "-Wconf:any:error",
         "scalacOptions" ++= Seq(
           """s"-Xmacro-settings:scalatest-version=${V.scalatest}"""".raw,
           """s"-Xmacro-settings:is-ci=${insideCI.value}"""".raw,
@@ -680,9 +680,9 @@ object Izumi {
     groups = Groups.sbt,
     defaultPlatforms = Targets.jvmSbt,
     enableProjectSharedAggSettings = false,
-    dontIncludeInSuperAgg = false,
     settings = Seq(
-      "crossScalaVersions" := "Nil".raw
+      "crossScalaVersions" := "Nil".raw,
+      "scalaVersion" := scala212.value,
     ),
   )
 


### PR DESCRIPTION
splice `_` in constructor macros when parameter is unused to avoid warnings with `-Wmacros:after`