### PR TITLE
Swap `?` placeholder and `_` wildcard using kind-projector 0.13.0 & scalac 2.13.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3218,6 +3218,7 @@ lazy val `microsite` = project.in(file("doc/microsite"))
     } },
     scalacOptions -= "-Wconf:any:error",
     scalacOptions -= "-Xsource:3",
+    Compile / sbt.Keys.doc / scalacOptions += "-Xsource:3",
     coverageEnabled := false,
     publish / skip := true,
     DocKeys.prefix := {if (isSnapshot.value) {

--- a/build.sbt
+++ b/build.sbt
@@ -1,24 +1,31 @@
-import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
-
 import com.typesafe.sbt.SbtGit.GitKeys._
 
 enablePlugins(SbtgenVerificationPlugin)
 
 disablePlugins(AssemblyPlugin)
 
-lazy val `fundamentals-collections` = crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Pure).in(file("fundamentals/fundamentals-collections"))
+lazy val `fundamentals-collections` = project.in(file("fundamentals/fundamentals-collections"))
   .dependsOn(
     `fundamentals-functional` % "test->compile;compile->compile"
   )
   .settings(
     libraryDependencies ++= Seq(
       compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
-      "org.scala-lang.modules" %%% "scala-collection-compat" % V.collection_compat,
-      "org.scalatest" %%% "scalatest" % V.scalatest % Test
+      "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
+      "org.scalatest" %% "scalatest" % V.scalatest % Test
     )
   )
   .settings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
+    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
+    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
+    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
+    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -134,28 +141,9 @@ lazy val `fundamentals-collections` = crossProject(JVMPlatform, JSPlatform).cros
        })
     }
   )
-  .jvmSettings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head
-  )
-  .jsSettings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
-    scalaJSLinkerConfig := { scalaJSLinkerConfig.value.withModuleKind(ModuleKind.CommonJSModule) }
-  )
-lazy val `fundamentals-collectionsJVM` = `fundamentals-collections`.jvm
-  .disablePlugins(AssemblyPlugin)
-lazy val `fundamentals-collectionsJS` = `fundamentals-collections`.js
   .disablePlugins(AssemblyPlugin)
 
-lazy val `fundamentals-platform` = crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Pure).in(file("fundamentals/fundamentals-platform"))
+lazy val `fundamentals-platform` = project.in(file("fundamentals/fundamentals-platform"))
   .dependsOn(
     `fundamentals-language` % "test->compile;compile->compile",
     `fundamentals-collections` % "test->compile;compile->compile"
@@ -163,13 +151,22 @@ lazy val `fundamentals-platform` = crossProject(JVMPlatform, JSPlatform).crossTy
   .settings(
     libraryDependencies ++= Seq(
       compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
-      "org.scala-lang.modules" %%% "scala-collection-compat" % V.collection_compat,
-      "org.scalatest" %%% "scalatest" % V.scalatest % Test,
+      "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
+      "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided
     )
   )
   .settings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
+    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
+    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
+    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
+    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -265,45 +262,31 @@ lazy val `fundamentals-platform` = crossProject(JVMPlatform, JSPlatform).crossTy
       case (_, _) => Seq.empty
     } }
   )
-  .jvmSettings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head
-  )
-  .jsSettings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
-    scalaJSLinkerConfig := { scalaJSLinkerConfig.value.withModuleKind(ModuleKind.CommonJSModule) },
-    Test / npmDependencies ++= Seq(
-      (  "hash.js",  "1.1.7")
-    )
-  )
-lazy val `fundamentals-platformJVM` = `fundamentals-platform`.jvm
-  .disablePlugins(AssemblyPlugin)
-lazy val `fundamentals-platformJS` = `fundamentals-platform`.js
-  .enablePlugins(ScalaJSBundlerPlugin)
   .disablePlugins(AssemblyPlugin)
 
-lazy val `fundamentals-language` = crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Pure).in(file("fundamentals/fundamentals-language"))
+lazy val `fundamentals-language` = project.in(file("fundamentals/fundamentals-language"))
   .dependsOn(
     `fundamentals-literals` % "test->compile;compile->compile"
   )
   .settings(
     libraryDependencies ++= Seq(
       compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
-      "org.scala-lang.modules" %%% "scala-collection-compat" % V.collection_compat,
-      "org.scalatest" %%% "scalatest" % V.scalatest % Test,
+      "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
+      "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided
     )
   )
   .settings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
+    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
+    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
+    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
+    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -419,29 +402,9 @@ lazy val `fundamentals-language` = crossProject(JVMPlatform, JSPlatform).crossTy
        })
     }
   )
-  .jvmSettings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head
-  )
-  .jsSettings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
-    scalaJSLinkerConfig := { scalaJSLinkerConfig.value.withModuleKind(ModuleKind.CommonJSModule) }
-  )
-lazy val `fundamentals-languageJVM` = `fundamentals-language`.jvm
-  .disablePlugins(AssemblyPlugin)
-lazy val `fundamentals-languageJS` = `fundamentals-language`.js
-  .enablePlugins(ScalaJSBundlerPlugin)
   .disablePlugins(AssemblyPlugin)
 
-lazy val `fundamentals-reflection` = crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Pure).in(file("fundamentals/fundamentals-reflection"))
+lazy val `fundamentals-reflection` = project.in(file("fundamentals/fundamentals-reflection"))
   .dependsOn(
     `fundamentals-platform` % "test->compile;compile->compile",
     `fundamentals-functional` % "test->compile;compile->compile"
@@ -449,14 +412,23 @@ lazy val `fundamentals-reflection` = crossProject(JVMPlatform, JSPlatform).cross
   .settings(
     libraryDependencies ++= Seq(
       compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
-      "org.scala-lang.modules" %%% "scala-collection-compat" % V.collection_compat,
-      "org.scalatest" %%% "scalatest" % V.scalatest % Test,
-      "dev.zio" %%% "izumi-reflect" % V.izumi_reflect,
+      "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
+      "org.scalatest" %% "scalatest" % V.scalatest % Test,
+      "dev.zio" %% "izumi-reflect" % V.izumi_reflect,
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided
     )
   )
   .settings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
+    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
+    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
+    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
+    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -572,37 +544,27 @@ lazy val `fundamentals-reflection` = crossProject(JVMPlatform, JSPlatform).cross
        })
     }
   )
-  .jvmSettings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head
+  .disablePlugins(AssemblyPlugin)
+
+lazy val `fundamentals-functional` = project.in(file("fundamentals/fundamentals-functional"))
+  .settings(
+    libraryDependencies ++= Seq(
+      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
+      "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
+      "org.scalatest" %% "scalatest" % V.scalatest % Test
+    )
   )
-  .jsSettings(
+  .settings(
     crossScalaVersions := Seq(
       "2.13.6",
       "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
-    scalaJSLinkerConfig := { scalaJSLinkerConfig.value.withModuleKind(ModuleKind.CommonJSModule) }
-  )
-lazy val `fundamentals-reflectionJVM` = `fundamentals-reflection`.jvm
-  .disablePlugins(AssemblyPlugin)
-lazy val `fundamentals-reflectionJS` = `fundamentals-reflection`.js
-  .disablePlugins(AssemblyPlugin)
-
-lazy val `fundamentals-functional` = crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Pure).in(file("fundamentals/fundamentals-functional"))
-  .settings(
-    libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
-      "org.scala-lang.modules" %%% "scala-collection-compat" % V.collection_compat,
-      "org.scalatest" %%% "scalatest" % V.scalatest % Test
-    )
-  )
-  .settings(
     organization := "io.7mind.izumi",
+    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
+    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
+    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
+    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -698,28 +660,9 @@ lazy val `fundamentals-functional` = crossProject(JVMPlatform, JSPlatform).cross
       case (_, _) => Seq.empty
     } }
   )
-  .jvmSettings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head
-  )
-  .jsSettings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
-    scalaJSLinkerConfig := { scalaJSLinkerConfig.value.withModuleKind(ModuleKind.CommonJSModule) }
-  )
-lazy val `fundamentals-functionalJVM` = `fundamentals-functional`.jvm
-  .disablePlugins(AssemblyPlugin)
-lazy val `fundamentals-functionalJS` = `fundamentals-functional`.js
   .disablePlugins(AssemblyPlugin)
 
-lazy val `fundamentals-bio` = crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Pure).in(file("fundamentals/fundamentals-bio"))
+lazy val `fundamentals-bio` = project.in(file("fundamentals/fundamentals-bio"))
   .dependsOn(
     `fundamentals-language` % "test->compile;compile->compile",
     `fundamentals-orphans` % "test->compile;compile->compile"
@@ -727,23 +670,32 @@ lazy val `fundamentals-bio` = crossProject(JVMPlatform, JSPlatform).crossType(Cr
   .settings(
     libraryDependencies ++= Seq(
       compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
-      "org.scala-lang.modules" %%% "scala-collection-compat" % V.collection_compat,
-      "org.scalatest" %%% "scalatest" % V.scalatest % Test,
-      "org.typelevel" %%% "cats-core" % V.cats % Optional,
-      "org.typelevel" %%% "cats-effect" % V.cats_effect % Optional,
-      "dev.zio" %%% "zio" % V.zio % Optional excludeAll("dev.zio" %% "izumi-reflect"),
-      "dev.zio" %%% "izumi-reflect" % V.izumi_reflect % Optional,
-      "io.monix" %%% "monix" % V.monix % Optional,
-      "io.monix" %%% "monix-bio" % V.monix_bio % Optional,
-      "org.typelevel" %%% "cats-effect-laws" % V.cats_effect % Test,
-      "org.scalatest" %%% "scalatest" % V.scalatest % Test,
-      "org.typelevel" %%% "discipline-core" % V.discipline % Test,
-      "org.typelevel" %%% "discipline-scalatest" % V.discipline_scalatest % Test,
-      "dev.zio" %%% "zio-interop-cats" % V.zio_interop_cats % Test excludeAll("dev.zio" %% "izumi-reflect")
+      "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
+      "org.scalatest" %% "scalatest" % V.scalatest % Test,
+      "org.typelevel" %% "cats-core" % V.cats % Optional,
+      "org.typelevel" %% "cats-effect" % V.cats_effect % Optional,
+      "dev.zio" %% "zio" % V.zio % Optional excludeAll("dev.zio" %% "izumi-reflect"),
+      "dev.zio" %% "izumi-reflect" % V.izumi_reflect % Optional,
+      "io.monix" %% "monix" % V.monix % Optional,
+      "io.monix" %% "monix-bio" % V.monix_bio % Optional,
+      "org.typelevel" %% "cats-effect-laws" % V.cats_effect % Test,
+      "org.scalatest" %% "scalatest" % V.scalatest % Test,
+      "org.typelevel" %% "discipline-core" % V.discipline % Test,
+      "org.typelevel" %% "discipline-scalatest" % V.discipline_scalatest % Test,
+      "dev.zio" %% "zio-interop-cats" % V.zio_interop_cats % Test excludeAll("dev.zio" %% "izumi-reflect")
     )
   )
   .settings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
+    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
+    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
+    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
+    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -839,50 +791,35 @@ lazy val `fundamentals-bio` = crossProject(JVMPlatform, JSPlatform).crossType(Cr
       case (_, _) => Seq.empty
     } }
   )
-  .jvmSettings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head
-  )
-  .jsSettings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
-    scalaJSLinkerConfig := { scalaJSLinkerConfig.value.withModuleKind(ModuleKind.CommonJSModule) }
-  )
-lazy val `fundamentals-bioJVM` = `fundamentals-bio`.jvm
-  .disablePlugins(AssemblyPlugin)
-lazy val `fundamentals-bioJS` = `fundamentals-bio`.js
-  .settings(
-    libraryDependencies ++= Seq(
-      "io.github.cquiroz" %%% "scala-java-time" % V.scala_java_time % Test
-    )
-  )
   .disablePlugins(AssemblyPlugin)
 
-lazy val `fundamentals-json-circe` = crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Pure).in(file("fundamentals/fundamentals-json-circe"))
+lazy val `fundamentals-json-circe` = project.in(file("fundamentals/fundamentals-json-circe"))
   .dependsOn(
     `fundamentals-platform` % "test->compile;compile->compile"
   )
   .settings(
     libraryDependencies ++= Seq(
       compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
-      "org.scala-lang.modules" %%% "scala-collection-compat" % V.collection_compat,
-      "org.scalatest" %%% "scalatest" % V.scalatest % Test,
-      "io.circe" %%% "circe-core" % V.circe,
-      "io.circe" %%% "circe-derivation" % V.circe_derivation,
+      "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
+      "org.scalatest" %% "scalatest" % V.scalatest % Test,
+      "io.circe" %% "circe-core" % V.circe,
+      "io.circe" %% "circe-derivation" % V.circe_derivation,
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided,
       "org.typelevel" %% "jawn-parser" % V.jawn % Test,
-      "io.circe" %%% "circe-literal" % V.circe % Test
+      "io.circe" %% "circe-literal" % V.circe % Test
     )
   )
   .settings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
+    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
+    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
+    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
+    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -978,44 +915,34 @@ lazy val `fundamentals-json-circe` = crossProject(JVMPlatform, JSPlatform).cross
       case (_, _) => Seq.empty
     } }
   )
-  .jvmSettings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head
+  .disablePlugins(AssemblyPlugin)
+
+lazy val `fundamentals-orphans` = project.in(file("fundamentals/fundamentals-orphans"))
+  .settings(
+    libraryDependencies ++= Seq(
+      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
+      "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
+      "org.scalatest" %% "scalatest" % V.scalatest % Test,
+      "org.typelevel" %% "cats-core" % V.cats % Optional,
+      "org.typelevel" %% "cats-effect" % V.cats_effect % Optional,
+      "dev.zio" %% "zio" % V.zio % Optional excludeAll("dev.zio" %% "izumi-reflect"),
+      "dev.zio" %% "izumi-reflect" % V.izumi_reflect % Optional,
+      "io.monix" %% "monix" % V.monix % Optional,
+      "io.monix" %% "monix-bio" % V.monix_bio % Optional,
+      "dev.zio" %% "zio-interop-cats" % V.zio_interop_cats % Optional excludeAll("dev.zio" %% "izumi-reflect")
+    )
   )
-  .jsSettings(
+  .settings(
     crossScalaVersions := Seq(
       "2.13.6",
       "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
-    scalaJSLinkerConfig := { scalaJSLinkerConfig.value.withModuleKind(ModuleKind.CommonJSModule) }
-  )
-lazy val `fundamentals-json-circeJVM` = `fundamentals-json-circe`.jvm
-  .disablePlugins(AssemblyPlugin)
-lazy val `fundamentals-json-circeJS` = `fundamentals-json-circe`.js
-  .disablePlugins(AssemblyPlugin)
-
-lazy val `fundamentals-orphans` = crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Pure).in(file("fundamentals/fundamentals-orphans"))
-  .settings(
-    libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
-      "org.scala-lang.modules" %%% "scala-collection-compat" % V.collection_compat,
-      "org.scalatest" %%% "scalatest" % V.scalatest % Test,
-      "org.typelevel" %%% "cats-core" % V.cats % Optional,
-      "org.typelevel" %%% "cats-effect" % V.cats_effect % Optional,
-      "dev.zio" %%% "zio" % V.zio % Optional excludeAll("dev.zio" %% "izumi-reflect"),
-      "dev.zio" %%% "izumi-reflect" % V.izumi_reflect % Optional,
-      "io.monix" %%% "monix" % V.monix % Optional,
-      "io.monix" %%% "monix-bio" % V.monix_bio % Optional,
-      "dev.zio" %%% "zio-interop-cats" % V.zio_interop_cats % Optional excludeAll("dev.zio" %% "izumi-reflect")
-    )
-  )
-  .settings(
     organization := "io.7mind.izumi",
+    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
+    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
+    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
+    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -1111,38 +1038,28 @@ lazy val `fundamentals-orphans` = crossProject(JVMPlatform, JSPlatform).crossTyp
       case (_, _) => Seq.empty
     } }
   )
-  .jvmSettings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head
-  )
-  .jsSettings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
-    scalaJSLinkerConfig := { scalaJSLinkerConfig.value.withModuleKind(ModuleKind.CommonJSModule) }
-  )
-lazy val `fundamentals-orphansJVM` = `fundamentals-orphans`.jvm
-  .disablePlugins(AssemblyPlugin)
-lazy val `fundamentals-orphansJS` = `fundamentals-orphans`.js
   .disablePlugins(AssemblyPlugin)
 
-lazy val `fundamentals-literals` = crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Pure).in(file("fundamentals/fundamentals-literals"))
+lazy val `fundamentals-literals` = project.in(file("fundamentals/fundamentals-literals"))
   .settings(
     libraryDependencies ++= Seq(
       compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
-      "org.scala-lang.modules" %%% "scala-collection-compat" % V.collection_compat,
-      "org.scalatest" %%% "scalatest" % V.scalatest % Test,
+      "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
+      "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided
     )
   )
   .settings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
+    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
+    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
+    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
+    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -1238,28 +1155,9 @@ lazy val `fundamentals-literals` = crossProject(JVMPlatform, JSPlatform).crossTy
       case (_, _) => Seq.empty
     } }
   )
-  .jvmSettings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head
-  )
-  .jsSettings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
-    scalaJSLinkerConfig := { scalaJSLinkerConfig.value.withModuleKind(ModuleKind.CommonJSModule) }
-  )
-lazy val `fundamentals-literalsJVM` = `fundamentals-literals`.jvm
-  .disablePlugins(AssemblyPlugin)
-lazy val `fundamentals-literalsJS` = `fundamentals-literals`.js
   .disablePlugins(AssemblyPlugin)
 
-lazy val `distage-core-api` = crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Pure).in(file("distage/distage-core-api"))
+lazy val `distage-core-api` = project.in(file("distage/distage-core-api"))
   .dependsOn(
     `fundamentals-reflection` % "test->compile;compile->compile",
     `fundamentals-bio` % "test->compile;compile->compile"
@@ -1267,22 +1165,31 @@ lazy val `distage-core-api` = crossProject(JVMPlatform, JSPlatform).crossType(Cr
   .settings(
     libraryDependencies ++= Seq(
       compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
-      "org.scala-lang.modules" %%% "scala-collection-compat" % V.collection_compat,
-      "org.scalatest" %%% "scalatest" % V.scalatest % Test,
-      "org.typelevel" %%% "cats-core" % V.cats % Optional,
-      "org.typelevel" %%% "cats-effect" % V.cats_effect % Optional,
-      "dev.zio" %%% "zio" % V.zio % Optional excludeAll("dev.zio" %% "izumi-reflect"),
-      "dev.zio" %%% "izumi-reflect" % V.izumi_reflect % Optional,
-      "org.typelevel" %%% "cats-core" % V.cats % Test,
-      "org.typelevel" %%% "cats-effect" % V.cats_effect % Test,
-      "dev.zio" %%% "zio" % V.zio % Test excludeAll("dev.zio" %% "izumi-reflect"),
-      "dev.zio" %%% "izumi-reflect" % V.izumi_reflect % Test,
-      "io.monix" %%% "monix-bio" % V.monix_bio % Test,
+      "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
+      "org.scalatest" %% "scalatest" % V.scalatest % Test,
+      "org.typelevel" %% "cats-core" % V.cats % Optional,
+      "org.typelevel" %% "cats-effect" % V.cats_effect % Optional,
+      "dev.zio" %% "zio" % V.zio % Optional excludeAll("dev.zio" %% "izumi-reflect"),
+      "dev.zio" %% "izumi-reflect" % V.izumi_reflect % Optional,
+      "org.typelevel" %% "cats-core" % V.cats % Test,
+      "org.typelevel" %% "cats-effect" % V.cats_effect % Test,
+      "dev.zio" %% "zio" % V.zio % Test excludeAll("dev.zio" %% "izumi-reflect"),
+      "dev.zio" %% "izumi-reflect" % V.izumi_reflect % Test,
+      "io.monix" %% "monix-bio" % V.monix_bio % Test,
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided
     )
   )
   .settings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
+    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
+    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
+    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
+    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -1378,30 +1285,11 @@ lazy val `distage-core-api` = crossProject(JVMPlatform, JSPlatform).crossType(Cr
       case (_, _) => Seq.empty
     } }
   )
-  .jvmSettings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head
-  )
-  .jsSettings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
-    scalaJSLinkerConfig := { scalaJSLinkerConfig.value.withModuleKind(ModuleKind.CommonJSModule) }
-  )
-lazy val `distage-core-apiJVM` = `distage-core-api`.jvm
-  .disablePlugins(AssemblyPlugin)
-lazy val `distage-core-apiJS` = `distage-core-api`.js
   .disablePlugins(AssemblyPlugin)
 
 lazy val `distage-core-proxy-cglib` = project.in(file("distage/distage-core-proxy-cglib"))
   .dependsOn(
-    `distage-core-apiJVM` % "test->compile;compile->compile"
+    `distage-core-api` % "test->compile;compile->compile"
   )
   .settings(
     libraryDependencies ++= Seq(
@@ -1418,6 +1306,10 @@ lazy val `distage-core-proxy-cglib` = project.in(file("distage/distage-core-prox
     ),
     scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
+    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
+    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
+    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
+    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -1515,155 +1407,138 @@ lazy val `distage-core-proxy-cglib` = project.in(file("distage/distage-core-prox
   )
   .disablePlugins(AssemblyPlugin)
 
-lazy val `distage-core` = crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Pure).in(file("distage/distage-core"))
+lazy val `distage-core` = project.in(file("distage/distage-core"))
   .dependsOn(
-    `distage-core-api` % "test->compile;compile->compile"
+    `distage-core-api` % "test->compile;compile->compile",
+    `distage-core-proxy-cglib` % "test->compile;compile->compile"
   )
   .settings(
     libraryDependencies ++= Seq(
       compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
-      "org.scala-lang.modules" %%% "scala-collection-compat" % V.collection_compat,
-      "org.scalatest" %%% "scalatest" % V.scalatest % Test,
-      "org.typelevel" %%% "cats-core" % V.cats % Optional,
-      "org.typelevel" %%% "cats-effect" % V.cats_effect % Optional,
-      "dev.zio" %%% "zio" % V.zio % Optional excludeAll("dev.zio" %% "izumi-reflect"),
-      "dev.zio" %%% "izumi-reflect" % V.izumi_reflect % Optional,
-      "io.monix" %%% "monix" % V.monix % Optional,
-      "io.monix" %%% "monix-bio" % V.monix_bio % Optional,
-      "dev.zio" %%% "zio-interop-cats" % V.zio_interop_cats % Optional excludeAll("dev.zio" %% "izumi-reflect"),
+      "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
+      "org.scalatest" %% "scalatest" % V.scalatest % Test,
+      "org.typelevel" %% "cats-core" % V.cats % Optional,
+      "org.typelevel" %% "cats-effect" % V.cats_effect % Optional,
+      "dev.zio" %% "zio" % V.zio % Optional excludeAll("dev.zio" %% "izumi-reflect"),
+      "dev.zio" %% "izumi-reflect" % V.izumi_reflect % Optional,
+      "io.monix" %% "monix" % V.monix % Optional,
+      "io.monix" %% "monix-bio" % V.monix_bio % Optional,
+      "dev.zio" %% "zio-interop-cats" % V.zio_interop_cats % Optional excludeAll("dev.zio" %% "izumi-reflect"),
       "javax.inject" % "javax.inject" % "1" % Test
     )
   )
   .settings(
-    organization := "io.7mind.izumi",
-    scalacOptions ++= Seq(
-      s"-Xmacro-settings:product-name=${name.value}",
-      s"-Xmacro-settings:product-version=${version.value}",
-      s"-Xmacro-settings:product-group=${organization.value}",
-      s"-Xmacro-settings:scala-version=${scalaVersion.value}",
-      s"-Xmacro-settings:scala-versions=${crossScalaVersions.value.mkString(":")}"
-    ),
-    Test / testOptions += Tests.Argument("-oDF"),
-    scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14") => Seq(
-        "-Xsource:2.13",
-        "-Ypartial-unification",
-        if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
-        "-Wconf:cat=optimizer:warning",
-        "-Wconf:cat=other-match-analysis:error",
-        "-Wconf:msg=kind-projector:silent",
-        "-Ybackend-parallelism",
-        math.min(16, math.max(1, sys.runtime.availableProcessors() - 1)).toString,
-        "-Xlint:adapted-args",
-        "-Xlint:by-name-right-associative",
-        "-Xlint:constant",
-        "-Xlint:delayedinit-select",
-        "-Xlint:doc-detached",
-        "-Xlint:inaccessible",
-        "-Xlint:infer-any",
-        "-Xlint:missing-interpolator",
-        "-Xlint:nullary-override",
-        "-Xlint:nullary-unit",
-        "-Xlint:option-implicit",
-        "-Xlint:package-object-classes",
-        "-Xlint:poly-implicit-overload",
-        "-Xlint:private-shadow",
-        "-Xlint:stars-align",
-        "-Xlint:type-parameter-shadow",
-        "-Xlint:unsound-match",
-        "-opt-warnings:_",
-        "-Ywarn-extra-implicit",
-        "-Ywarn-unused:_",
-        "-Ywarn-adapted-args",
-        "-Ywarn-dead-code",
-        "-Ywarn-inaccessible",
-        "-Ywarn-infer-any",
-        "-Ywarn-nullary-override",
-        "-Ywarn-nullary-unit",
-        "-Ywarn-numeric-widen",
-        "-Ywarn-unused-import",
-        "-Ywarn-value-discard",
-        "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified",
-        "-Xsource:3",
-        "-P:kind-projector:underscore-placeholders"
-      )
-      case (_, "2.13.6") => Seq(
-        "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
-        if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
-        "-Wconf:cat=optimizer:warning",
-        "-Wconf:cat=other-match-analysis:error",
-        "-Wconf:msg=kind-projector:silent",
-        "-Ybackend-parallelism",
-        math.min(16, math.max(1, sys.runtime.availableProcessors() - 1)).toString,
-        "-Wdead-code",
-        "-Wextra-implicit",
-        "-Wnumeric-widen",
-        "-Woctal-literal",
-        "-Wvalue-discard",
-        "-Wunused:_",
-        "-Wmacros:after",
-        "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified",
-        "-Wunused:-synthetics",
-        "-Xsource:3",
-        "-P:kind-projector:underscore-placeholders"
-      )
-      case (_, _) => Seq.empty
-    } },
-    scalacOptions += "-Wconf:msg=nowarn:silent",
-    scalacOptions += "-Wconf:msg=parameter.value.x\\$4.in.anonymous.function.is.never.used:silent",
-    scalacOptions += "-Wconf:msg=package.object.inheritance:silent",
-    Compile / sbt.Keys.doc / scalacOptions -= "-Wconf:any:error",
-    scalacOptions ++= Seq(
-      s"-Xmacro-settings:scalatest-version=${V.scalatest}",
-      s"-Xmacro-settings:is-ci=${insideCI.value}"
-    ),
-    scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.14") => Seq(
-        "-opt:l:inline",
-        "-opt-inline-from:izumi.**"
-      )
-      case (false, "2.13.6") => Seq(
-        "-opt:l:inline",
-        "-opt-inline-from:izumi.**"
-      )
-      case (_, _) => Seq.empty
-    } }
-  )
-  .jvmSettings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head
-  )
-  .jsSettings(
     crossScalaVersions := Seq(
       "2.13.6",
       "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
-    scalaJSLinkerConfig := { scalaJSLinkerConfig.value.withModuleKind(ModuleKind.CommonJSModule) }
-  )
-lazy val `distage-coreJVM` = `distage-core`.jvm
-  .dependsOn(
-    `distage-core-proxy-cglib` % "test->compile;compile->compile"
-  )
-  .disablePlugins(AssemblyPlugin)
-lazy val `distage-coreJS` = `distage-core`.js
-  .settings(
-    libraryDependencies ++= Seq(
-      "io.github.cquiroz" %%% "scala-java-time" % V.scala_java_time % Test
-    )
+    organization := "io.7mind.izumi",
+    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
+    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
+    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
+    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
+    scalacOptions ++= Seq(
+      s"-Xmacro-settings:product-name=${name.value}",
+      s"-Xmacro-settings:product-version=${version.value}",
+      s"-Xmacro-settings:product-group=${organization.value}",
+      s"-Xmacro-settings:scala-version=${scalaVersion.value}",
+      s"-Xmacro-settings:scala-versions=${crossScalaVersions.value.mkString(":")}"
+    ),
+    Test / testOptions += Tests.Argument("-oDF"),
+    scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
+      case (_, "2.12.14") => Seq(
+        "-Xsource:2.13",
+        "-Ypartial-unification",
+        if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
+        "-Wconf:cat=optimizer:warning",
+        "-Wconf:cat=other-match-analysis:error",
+        "-Wconf:msg=kind-projector:silent",
+        "-Ybackend-parallelism",
+        math.min(16, math.max(1, sys.runtime.availableProcessors() - 1)).toString,
+        "-Xlint:adapted-args",
+        "-Xlint:by-name-right-associative",
+        "-Xlint:constant",
+        "-Xlint:delayedinit-select",
+        "-Xlint:doc-detached",
+        "-Xlint:inaccessible",
+        "-Xlint:infer-any",
+        "-Xlint:missing-interpolator",
+        "-Xlint:nullary-override",
+        "-Xlint:nullary-unit",
+        "-Xlint:option-implicit",
+        "-Xlint:package-object-classes",
+        "-Xlint:poly-implicit-overload",
+        "-Xlint:private-shadow",
+        "-Xlint:stars-align",
+        "-Xlint:type-parameter-shadow",
+        "-Xlint:unsound-match",
+        "-opt-warnings:_",
+        "-Ywarn-extra-implicit",
+        "-Ywarn-unused:_",
+        "-Ywarn-adapted-args",
+        "-Ywarn-dead-code",
+        "-Ywarn-inaccessible",
+        "-Ywarn-infer-any",
+        "-Ywarn-nullary-override",
+        "-Ywarn-nullary-unit",
+        "-Ywarn-numeric-widen",
+        "-Ywarn-unused-import",
+        "-Ywarn-value-discard",
+        "-Ycache-plugin-class-loader:always",
+        "-Ycache-macro-class-loader:last-modified",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
+      )
+      case (_, "2.13.6") => Seq(
+        "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
+        if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
+        "-Wconf:cat=optimizer:warning",
+        "-Wconf:cat=other-match-analysis:error",
+        "-Wconf:msg=kind-projector:silent",
+        "-Ybackend-parallelism",
+        math.min(16, math.max(1, sys.runtime.availableProcessors() - 1)).toString,
+        "-Wdead-code",
+        "-Wextra-implicit",
+        "-Wnumeric-widen",
+        "-Woctal-literal",
+        "-Wvalue-discard",
+        "-Wunused:_",
+        "-Wmacros:after",
+        "-Ycache-plugin-class-loader:always",
+        "-Ycache-macro-class-loader:last-modified",
+        "-Wunused:-synthetics",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
+      )
+      case (_, _) => Seq.empty
+    } },
+    scalacOptions += "-Wconf:msg=nowarn:silent",
+    scalacOptions += "-Wconf:msg=parameter.value.x\\$4.in.anonymous.function.is.never.used:silent",
+    scalacOptions += "-Wconf:msg=package.object.inheritance:silent",
+    Compile / sbt.Keys.doc / scalacOptions -= "-Wconf:any:error",
+    scalacOptions ++= Seq(
+      s"-Xmacro-settings:scalatest-version=${V.scalatest}",
+      s"-Xmacro-settings:is-ci=${insideCI.value}"
+    ),
+    scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
+      case (false, "2.12.14") => Seq(
+        "-opt:l:inline",
+        "-opt-inline-from:izumi.**"
+      )
+      case (false, "2.13.6") => Seq(
+        "-opt:l:inline",
+        "-opt-inline-from:izumi.**"
+      )
+      case (_, _) => Seq.empty
+    } }
   )
   .disablePlugins(AssemblyPlugin)
 
 lazy val `distage-extension-config` = project.in(file("distage/distage-extension-config"))
   .dependsOn(
-    `distage-core-apiJVM` % "test->compile;compile->compile",
-    `distage-coreJVM` % "test->compile"
+    `distage-core-api` % "test->compile;compile->compile",
+    `distage-core` % "test->compile"
   )
   .settings(
     libraryDependencies ++= Seq(
@@ -1682,6 +1557,10 @@ lazy val `distage-extension-config` = project.in(file("distage/distage-extension
     ),
     scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
+    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
+    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
+    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
+    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -1801,10 +1680,10 @@ lazy val `distage-extension-config` = project.in(file("distage/distage-extension
 
 lazy val `distage-extension-plugins` = project.in(file("distage/distage-extension-plugins"))
   .dependsOn(
-    `distage-core-apiJVM` % "test->compile;compile->compile",
-    `distage-coreJVM` % "test->compile",
+    `distage-core-api` % "test->compile;compile->compile",
+    `distage-core` % "test->compile",
     `distage-extension-config` % "test->compile",
-    `logstage-coreJVM` % "test->compile"
+    `logstage-core` % "test->compile"
   )
   .settings(
     libraryDependencies ++= Seq(
@@ -1822,6 +1701,10 @@ lazy val `distage-extension-plugins` = project.in(file("distage/distage-extensio
     ),
     scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
+    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
+    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
+    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
+    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -1919,8 +1802,9 @@ lazy val `distage-extension-plugins` = project.in(file("distage/distage-extensio
   )
   .disablePlugins(AssemblyPlugin)
 
-lazy val `distage-extension-logstage` = crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Pure).in(file("distage/distage-extension-logstage"))
+lazy val `distage-extension-logstage` = project.in(file("distage/distage-extension-logstage"))
   .dependsOn(
+    `distage-extension-config` % "test->compile;compile->compile",
     `distage-core-api` % "test->compile;compile->compile",
     `distage-core` % "test->compile",
     `logstage-core` % "test->test;compile->compile"
@@ -1928,12 +1812,21 @@ lazy val `distage-extension-logstage` = crossProject(JVMPlatform, JSPlatform).cr
   .settings(
     libraryDependencies ++= Seq(
       compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
-      "org.scala-lang.modules" %%% "scala-collection-compat" % V.collection_compat,
-      "org.scalatest" %%% "scalatest" % V.scalatest % Test
+      "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
+      "org.scalatest" %% "scalatest" % V.scalatest % Test
     )
   )
   .settings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
+    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
+    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
+    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
+    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -2029,30 +1922,11 @@ lazy val `distage-extension-logstage` = crossProject(JVMPlatform, JSPlatform).cr
       case (_, _) => Seq.empty
     } }
   )
-  .jvmSettings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head
-  )
-  .jsSettings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
-    scalaJSLinkerConfig := { scalaJSLinkerConfig.value.withModuleKind(ModuleKind.CommonJSModule) }
-  )
-lazy val `distage-extension-logstageJVM` = `distage-extension-logstage`.jvm
-  .disablePlugins(AssemblyPlugin)
-lazy val `distage-extension-logstageJS` = `distage-extension-logstage`.js
   .disablePlugins(AssemblyPlugin)
 
 lazy val `distage-framework-api` = project.in(file("distage/distage-framework-api"))
   .dependsOn(
-    `distage-core-apiJVM` % "test->compile;compile->compile"
+    `distage-core-api` % "test->compile;compile->compile"
   )
   .settings(
     libraryDependencies ++= Seq(
@@ -2069,6 +1943,10 @@ lazy val `distage-framework-api` = project.in(file("distage/distage-framework-ap
     ),
     scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
+    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
+    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
+    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
+    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -2168,9 +2046,9 @@ lazy val `distage-framework-api` = project.in(file("distage/distage-framework-ap
 
 lazy val `distage-framework` = project.in(file("distage/distage-framework"))
   .dependsOn(
-    `distage-extension-logstageJVM` % "test->compile;compile->compile",
-    `logstage-rendering-circeJVM` % "test->compile;compile->compile",
-    `distage-coreJVM` % "test->compile;compile->compile",
+    `distage-extension-logstage` % "test->compile;compile->compile",
+    `logstage-rendering-circe` % "test->compile;compile->compile",
+    `distage-core` % "test->compile;compile->compile",
     `distage-framework-api` % "test->compile;compile->compile",
     `distage-extension-plugins` % "test->compile;compile->compile",
     `distage-extension-config` % "test->compile;compile->compile",
@@ -2198,6 +2076,10 @@ lazy val `distage-framework` = project.in(file("distage/distage-framework"))
     ),
     scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
+    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
+    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
+    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
+    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -2317,10 +2199,10 @@ lazy val `distage-framework` = project.in(file("distage/distage-framework"))
 
 lazy val `distage-framework-docker` = project.in(file("distage/distage-framework-docker"))
   .dependsOn(
-    `distage-coreJVM` % "test->compile;compile->compile",
+    `distage-core` % "test->compile;compile->compile",
     `distage-extension-config` % "test->compile;compile->compile",
     `distage-framework-api` % "test->compile;compile->compile",
-    `distage-extension-logstageJVM` % "test->compile;compile->compile",
+    `distage-extension-logstage` % "test->compile;compile->compile",
     `distage-testkit-scalatest` % "test->compile"
   )
   .settings(
@@ -2344,6 +2226,10 @@ lazy val `distage-framework-docker` = project.in(file("distage/distage-framework
     ),
     scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
+    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
+    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
+    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
+    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -2459,6 +2345,10 @@ lazy val `distage-testkit-core` = project.in(file("distage/distage-testkit-core"
     ),
     scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
+    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
+    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
+    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
+    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -2559,7 +2449,7 @@ lazy val `distage-testkit-core` = project.in(file("distage/distage-testkit-core"
 lazy val `distage-testkit-scalatest` = project.in(file("distage/distage-testkit-scalatest"))
   .dependsOn(
     `distage-testkit-core` % "test->compile;compile->compile",
-    `distage-coreJVM` % "test->compile;compile->compile",
+    `distage-core` % "test->compile;compile->compile",
     `distage-extension-plugins` % "test->compile;compile->compile",
     `distage-framework` % "test->test;compile->compile"
   )
@@ -2585,6 +2475,10 @@ lazy val `distage-testkit-scalatest` = project.in(file("distage/distage-testkit-
     ),
     scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
+    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
+    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
+    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
+    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -2682,7 +2576,7 @@ lazy val `distage-testkit-scalatest` = project.in(file("distage/distage-testkit-
   )
   .disablePlugins(AssemblyPlugin)
 
-lazy val `logstage-core` = crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Pure).in(file("logstage/logstage-core"))
+lazy val `logstage-core` = project.in(file("logstage/logstage-core"))
   .dependsOn(
     `fundamentals-bio` % "test->compile;compile->compile",
     `fundamentals-platform` % "test->compile;compile->compile"
@@ -2690,17 +2584,26 @@ lazy val `logstage-core` = crossProject(JVMPlatform, JSPlatform).crossType(Cross
   .settings(
     libraryDependencies ++= Seq(
       compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
-      "org.scala-lang.modules" %%% "scala-collection-compat" % V.collection_compat,
-      "org.scalatest" %%% "scalatest" % V.scalatest % Test,
+      "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
+      "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided,
-      "org.typelevel" %%% "cats-core" % V.cats % Optional,
-      "org.typelevel" %%% "cats-effect" % V.cats_effect % Optional,
-      "dev.zio" %%% "zio" % V.zio % Optional excludeAll("dev.zio" %% "izumi-reflect"),
-      "dev.zio" %%% "izumi-reflect" % V.izumi_reflect % Optional
+      "org.typelevel" %% "cats-core" % V.cats % Optional,
+      "org.typelevel" %% "cats-effect" % V.cats_effect % Optional,
+      "dev.zio" %% "zio" % V.zio % Optional excludeAll("dev.zio" %% "izumi-reflect"),
+      "dev.zio" %% "izumi-reflect" % V.izumi_reflect % Optional
     )
   )
   .settings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
+    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
+    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
+    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
+    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -2796,33 +2699,9 @@ lazy val `logstage-core` = crossProject(JVMPlatform, JSPlatform).crossType(Cross
       case (_, _) => Seq.empty
     } }
   )
-  .jvmSettings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head
-  )
-  .jsSettings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
-    scalaJSLinkerConfig := { scalaJSLinkerConfig.value.withModuleKind(ModuleKind.CommonJSModule) }
-  )
-lazy val `logstage-coreJVM` = `logstage-core`.jvm
-  .disablePlugins(AssemblyPlugin)
-lazy val `logstage-coreJS` = `logstage-core`.js
-  .settings(
-    libraryDependencies ++= Seq(
-      "io.github.cquiroz" %%% "scala-java-time" % V.scala_java_time
-    )
-  )
   .disablePlugins(AssemblyPlugin)
 
-lazy val `logstage-rendering-circe` = crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Pure).in(file("logstage/logstage-rendering-circe"))
+lazy val `logstage-rendering-circe` = project.in(file("logstage/logstage-rendering-circe"))
   .dependsOn(
     `fundamentals-json-circe` % "test->compile;compile->compile",
     `logstage-core` % "test->test;compile->compile"
@@ -2830,15 +2709,24 @@ lazy val `logstage-rendering-circe` = crossProject(JVMPlatform, JSPlatform).cros
   .settings(
     libraryDependencies ++= Seq(
       compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
-      "org.scala-lang.modules" %%% "scala-collection-compat" % V.collection_compat,
-      "org.scalatest" %%% "scalatest" % V.scalatest % Test,
+      "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
+      "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.typelevel" %% "jawn-parser" % V.jawn % Test,
-      "io.circe" %%% "circe-parser" % V.circe % Test,
-      "io.circe" %%% "circe-literal" % V.circe % Test
+      "io.circe" %% "circe-parser" % V.circe % Test,
+      "io.circe" %% "circe-literal" % V.circe % Test
     )
   )
   .settings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
+    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
+    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
+    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
+    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -2934,30 +2822,11 @@ lazy val `logstage-rendering-circe` = crossProject(JVMPlatform, JSPlatform).cros
       case (_, _) => Seq.empty
     } }
   )
-  .jvmSettings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head
-  )
-  .jsSettings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
-    scalaJSLinkerConfig := { scalaJSLinkerConfig.value.withModuleKind(ModuleKind.CommonJSModule) }
-  )
-lazy val `logstage-rendering-circeJVM` = `logstage-rendering-circe`.jvm
-  .disablePlugins(AssemblyPlugin)
-lazy val `logstage-rendering-circeJS` = `logstage-rendering-circe`.js
   .disablePlugins(AssemblyPlugin)
 
 lazy val `logstage-adapter-slf4j` = project.in(file("logstage/logstage-adapter-slf4j"))
   .dependsOn(
-    `logstage-coreJVM` % "test->test;compile->compile"
+    `logstage-core` % "test->test;compile->compile"
   )
   .settings(
     libraryDependencies ++= Seq(
@@ -2974,6 +2843,10 @@ lazy val `logstage-adapter-slf4j` = project.in(file("logstage/logstage-adapter-s
     ),
     scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
+    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
+    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
+    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
+    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -3076,7 +2949,7 @@ lazy val `logstage-adapter-slf4j` = project.in(file("logstage/logstage-adapter-s
 
 lazy val `logstage-sink-slf4j` = project.in(file("logstage/logstage-sink-slf4j"))
   .dependsOn(
-    `logstage-coreJVM` % "test->test;compile->compile"
+    `logstage-core` % "test->test;compile->compile"
   )
   .settings(
     libraryDependencies ++= Seq(
@@ -3094,6 +2967,10 @@ lazy val `logstage-sink-slf4j` = project.in(file("logstage/logstage-sink-slf4j")
     ),
     scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
+    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
+    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
+    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
+    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -3193,28 +3070,28 @@ lazy val `logstage-sink-slf4j` = project.in(file("logstage/logstage-sink-slf4j")
 
 lazy val `microsite` = project.in(file("doc/microsite"))
   .dependsOn(
-    `fundamentals-collectionsJVM` % "test->compile;compile->compile",
-    `fundamentals-platformJVM` % "test->compile;compile->compile",
-    `fundamentals-languageJVM` % "test->compile;compile->compile",
-    `fundamentals-reflectionJVM` % "test->compile;compile->compile",
-    `fundamentals-functionalJVM` % "test->compile;compile->compile",
-    `fundamentals-bioJVM` % "test->compile;compile->compile",
-    `fundamentals-json-circeJVM` % "test->compile;compile->compile",
-    `fundamentals-orphansJVM` % "test->compile;compile->compile",
-    `fundamentals-literalsJVM` % "test->compile;compile->compile",
-    `distage-core-apiJVM` % "test->compile;compile->compile",
+    `fundamentals-collections` % "test->compile;compile->compile",
+    `fundamentals-platform` % "test->compile;compile->compile",
+    `fundamentals-language` % "test->compile;compile->compile",
+    `fundamentals-reflection` % "test->compile;compile->compile",
+    `fundamentals-functional` % "test->compile;compile->compile",
+    `fundamentals-bio` % "test->compile;compile->compile",
+    `fundamentals-json-circe` % "test->compile;compile->compile",
+    `fundamentals-orphans` % "test->compile;compile->compile",
+    `fundamentals-literals` % "test->compile;compile->compile",
+    `distage-core-api` % "test->compile;compile->compile",
     `distage-core-proxy-cglib` % "test->compile;compile->compile",
-    `distage-coreJVM` % "test->compile;compile->compile",
+    `distage-core` % "test->compile;compile->compile",
     `distage-extension-config` % "test->compile;compile->compile",
     `distage-extension-plugins` % "test->compile;compile->compile",
-    `distage-extension-logstageJVM` % "test->compile;compile->compile",
+    `distage-extension-logstage` % "test->compile;compile->compile",
     `distage-framework-api` % "test->compile;compile->compile",
     `distage-framework` % "test->compile;compile->compile",
     `distage-framework-docker` % "test->compile;compile->compile",
     `distage-testkit-core` % "test->compile;compile->compile",
     `distage-testkit-scalatest` % "test->compile;compile->compile",
-    `logstage-coreJVM` % "test->compile;compile->compile",
-    `logstage-rendering-circeJVM` % "test->compile;compile->compile",
+    `logstage-core` % "test->compile;compile->compile",
+    `logstage-rendering-circe` % "test->compile;compile->compile",
     `logstage-adapter-slf4j` % "test->compile;compile->compile",
     `logstage-sink-slf4j` % "test->compile;compile->compile"
   )
@@ -3241,6 +3118,10 @@ lazy val `microsite` = project.in(file("doc/microsite"))
     ),
     scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
+    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
+    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
+    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
+    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -3414,6 +3295,10 @@ lazy val `sbt-izumi-deps` = project.in(file("sbt-plugins/sbt-izumi-deps"))
     scalaVersion := crossScalaVersions.value.head,
     coverageEnabled := false,
     organization := "io.7mind.izumi",
+    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
+    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
+    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
+    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -3524,24 +3409,15 @@ lazy val `fundamentals` = (project in file(".agg/fundamentals-fundamentals"))
   )
   .disablePlugins(AssemblyPlugin)
   .aggregate(
-    `fundamentals-collectionsJVM`,
-    `fundamentals-collectionsJS`,
-    `fundamentals-platformJVM`,
-    `fundamentals-platformJS`,
-    `fundamentals-languageJVM`,
-    `fundamentals-languageJS`,
-    `fundamentals-reflectionJVM`,
-    `fundamentals-reflectionJS`,
-    `fundamentals-functionalJVM`,
-    `fundamentals-functionalJS`,
-    `fundamentals-bioJVM`,
-    `fundamentals-bioJS`,
-    `fundamentals-json-circeJVM`,
-    `fundamentals-json-circeJS`,
-    `fundamentals-orphansJVM`,
-    `fundamentals-orphansJS`,
-    `fundamentals-literalsJVM`,
-    `fundamentals-literalsJS`
+    `fundamentals-collections`,
+    `fundamentals-platform`,
+    `fundamentals-language`,
+    `fundamentals-reflection`,
+    `fundamentals-functional`,
+    `fundamentals-bio`,
+    `fundamentals-json-circe`,
+    `fundamentals-orphans`,
+    `fundamentals-literals`
   )
 
 lazy val `fundamentals-jvm` = (project in file(".agg/fundamentals-fundamentals-jvm"))
@@ -3555,37 +3431,15 @@ lazy val `fundamentals-jvm` = (project in file(".agg/fundamentals-fundamentals-j
   )
   .disablePlugins(AssemblyPlugin)
   .aggregate(
-    `fundamentals-collectionsJVM`,
-    `fundamentals-platformJVM`,
-    `fundamentals-languageJVM`,
-    `fundamentals-reflectionJVM`,
-    `fundamentals-functionalJVM`,
-    `fundamentals-bioJVM`,
-    `fundamentals-json-circeJVM`,
-    `fundamentals-orphansJVM`,
-    `fundamentals-literalsJVM`
-  )
-
-lazy val `fundamentals-js` = (project in file(".agg/fundamentals-fundamentals-js"))
-  .settings(
-    publish / skip := true,
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head
-  )
-  .disablePlugins(AssemblyPlugin)
-  .aggregate(
-    `fundamentals-collectionsJS`,
-    `fundamentals-platformJS`,
-    `fundamentals-languageJS`,
-    `fundamentals-reflectionJS`,
-    `fundamentals-functionalJS`,
-    `fundamentals-bioJS`,
-    `fundamentals-json-circeJS`,
-    `fundamentals-orphansJS`,
-    `fundamentals-literalsJS`
+    `fundamentals-collections`,
+    `fundamentals-platform`,
+    `fundamentals-language`,
+    `fundamentals-reflection`,
+    `fundamentals-functional`,
+    `fundamentals-bio`,
+    `fundamentals-json-circe`,
+    `fundamentals-orphans`,
+    `fundamentals-literals`
   )
 
 lazy val `distage` = (project in file(".agg/distage-distage"))
@@ -3599,15 +3453,12 @@ lazy val `distage` = (project in file(".agg/distage-distage"))
   )
   .disablePlugins(AssemblyPlugin)
   .aggregate(
-    `distage-core-apiJVM`,
-    `distage-core-apiJS`,
+    `distage-core-api`,
     `distage-core-proxy-cglib`,
-    `distage-coreJVM`,
-    `distage-coreJS`,
+    `distage-core`,
     `distage-extension-config`,
     `distage-extension-plugins`,
-    `distage-extension-logstageJVM`,
-    `distage-extension-logstageJS`,
+    `distage-extension-logstage`,
     `distage-framework-api`,
     `distage-framework`,
     `distage-framework-docker`,
@@ -3626,36 +3477,12 @@ lazy val `distage-jvm` = (project in file(".agg/distage-distage-jvm"))
   )
   .disablePlugins(AssemblyPlugin)
   .aggregate(
-    `distage-core-apiJVM`,
+    `distage-core-api`,
     `distage-core-proxy-cglib`,
-    `distage-coreJVM`,
+    `distage-core`,
     `distage-extension-config`,
     `distage-extension-plugins`,
-    `distage-extension-logstageJVM`,
-    `distage-framework-api`,
-    `distage-framework`,
-    `distage-framework-docker`,
-    `distage-testkit-core`,
-    `distage-testkit-scalatest`
-  )
-
-lazy val `distage-js` = (project in file(".agg/distage-distage-js"))
-  .settings(
-    publish / skip := true,
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head
-  )
-  .disablePlugins(AssemblyPlugin)
-  .aggregate(
-    `distage-core-apiJS`,
-    `distage-core-proxy-cglib`,
-    `distage-coreJS`,
-    `distage-extension-config`,
-    `distage-extension-plugins`,
-    `distage-extension-logstageJS`,
+    `distage-extension-logstage`,
     `distage-framework-api`,
     `distage-framework`,
     `distage-framework-docker`,
@@ -3674,10 +3501,8 @@ lazy val `logstage` = (project in file(".agg/logstage-logstage"))
   )
   .disablePlugins(AssemblyPlugin)
   .aggregate(
-    `logstage-coreJVM`,
-    `logstage-coreJS`,
-    `logstage-rendering-circeJVM`,
-    `logstage-rendering-circeJS`,
+    `logstage-core`,
+    `logstage-rendering-circe`,
     `logstage-adapter-slf4j`,
     `logstage-sink-slf4j`
   )
@@ -3693,25 +3518,8 @@ lazy val `logstage-jvm` = (project in file(".agg/logstage-logstage-jvm"))
   )
   .disablePlugins(AssemblyPlugin)
   .aggregate(
-    `logstage-coreJVM`,
-    `logstage-rendering-circeJVM`,
-    `logstage-adapter-slf4j`,
-    `logstage-sink-slf4j`
-  )
-
-lazy val `logstage-js` = (project in file(".agg/logstage-logstage-js"))
-  .settings(
-    publish / skip := true,
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head
-  )
-  .disablePlugins(AssemblyPlugin)
-  .aggregate(
-    `logstage-coreJS`,
-    `logstage-rendering-circeJS`,
+    `logstage-core`,
+    `logstage-rendering-circe`,
     `logstage-adapter-slf4j`,
     `logstage-sink-slf4j`
   )
@@ -3731,20 +3539,6 @@ lazy val `doc` = (project in file(".agg/doc-doc"))
   )
 
 lazy val `doc-jvm` = (project in file(".agg/doc-doc-jvm"))
-  .settings(
-    publish / skip := true,
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head
-  )
-  .disablePlugins(AssemblyPlugin)
-  .aggregate(
-    `microsite`
-  )
-
-lazy val `doc-js` = (project in file(".agg/doc-doc-js"))
   .settings(
     publish / skip := true,
     crossScalaVersions := Seq(
@@ -3780,17 +3574,6 @@ lazy val `sbt-plugins-jvm` = (project in file(".agg/sbt-plugins-sbt-plugins-jvm"
     `sbt-izumi-deps`
   )
 
-lazy val `sbt-plugins-js` = (project in file(".agg/sbt-plugins-sbt-plugins-js"))
-  .settings(
-    publish / skip := true,
-    crossScalaVersions := Nil,
-    scalaVersion := "2.12.14"
-  )
-  .disablePlugins(AssemblyPlugin)
-  .aggregate(
-    `sbt-izumi-deps`
-  )
-
 lazy val `izumi-jvm` = (project in file(".agg/.agg-jvm"))
   .settings(
     publish / skip := true,
@@ -3806,23 +3589,6 @@ lazy val `izumi-jvm` = (project in file(".agg/.agg-jvm"))
     `distage-jvm`,
     `logstage-jvm`,
     `sbt-plugins-jvm`
-  )
-
-lazy val `izumi-js` = (project in file(".agg/.agg-js"))
-  .settings(
-    publish / skip := true,
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head
-  )
-  .disablePlugins(AssemblyPlugin)
-  .aggregate(
-    `fundamentals-js`,
-    `distage-js`,
-    `logstage-js`,
-    `sbt-plugins-js`
   )
 
 lazy val `izumi` = (project in file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -3217,6 +3217,7 @@ lazy val `microsite` = project.in(file("doc/microsite"))
       case (_, _) => Seq.empty
     } },
     scalacOptions -= "-Wconf:any:error",
+    scalacOptions -= "-Xsource:3",
     coverageEnabled := false,
     publish / skip := true,
     DocKeys.prefix := {if (isSnapshot.value) {

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ lazy val `fundamentals-collections` = project.in(file("fundamentals/fundamentals
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.5",
+      "2.13.6-bin-SNAPSHOT",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -76,7 +76,7 @@ lazy val `fundamentals-collections` = project.in(file("fundamentals/fundamentals
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.5") => Seq(
+      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -93,12 +93,15 @@ lazy val `fundamentals-collections` = project.in(file("fundamentals/fundamentals
         "-Wmacros:after",
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified",
-        "-Wunused:-synthetics"
+        "-Wunused:-synthetics",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
     scalacOptions += "-Wconf:msg=parameter.value.x\\$4.in.anonymous.function.is.never.used:silent",
+    scalacOptions += "-Wconf:msg=package.object.inheritance:silent",
     Compile / sbt.Keys.doc / scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
@@ -109,7 +112,7 @@ lazy val `fundamentals-collections` = project.in(file("fundamentals/fundamentals
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.5") => Seq(
+      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -153,7 +156,7 @@ lazy val `fundamentals-platform` = project.in(file("fundamentals/fundamentals-pl
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.5",
+      "2.13.6-bin-SNAPSHOT",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -212,7 +215,7 @@ lazy val `fundamentals-platform` = project.in(file("fundamentals/fundamentals-pl
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.5") => Seq(
+      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -229,12 +232,15 @@ lazy val `fundamentals-platform` = project.in(file("fundamentals/fundamentals-pl
         "-Wmacros:after",
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified",
-        "-Wunused:-synthetics"
+        "-Wunused:-synthetics",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
     scalacOptions += "-Wconf:msg=parameter.value.x\\$4.in.anonymous.function.is.never.used:silent",
+    scalacOptions += "-Wconf:msg=package.object.inheritance:silent",
     Compile / sbt.Keys.doc / scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
@@ -245,7 +251,7 @@ lazy val `fundamentals-platform` = project.in(file("fundamentals/fundamentals-pl
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.5") => Seq(
+      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -268,7 +274,7 @@ lazy val `fundamentals-language` = project.in(file("fundamentals/fundamentals-la
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.5",
+      "2.13.6-bin-SNAPSHOT",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -327,7 +333,7 @@ lazy val `fundamentals-language` = project.in(file("fundamentals/fundamentals-la
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.5") => Seq(
+      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -344,12 +350,15 @@ lazy val `fundamentals-language` = project.in(file("fundamentals/fundamentals-la
         "-Wmacros:after",
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified",
-        "-Wunused:-synthetics"
+        "-Wunused:-synthetics",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
     scalacOptions += "-Wconf:msg=parameter.value.x\\$4.in.anonymous.function.is.never.used:silent",
+    scalacOptions += "-Wconf:msg=package.object.inheritance:silent",
     Compile / sbt.Keys.doc / scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
@@ -360,7 +369,7 @@ lazy val `fundamentals-language` = project.in(file("fundamentals/fundamentals-la
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.5") => Seq(
+      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -405,7 +414,7 @@ lazy val `fundamentals-reflection` = project.in(file("fundamentals/fundamentals-
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.5",
+      "2.13.6-bin-SNAPSHOT",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -464,7 +473,7 @@ lazy val `fundamentals-reflection` = project.in(file("fundamentals/fundamentals-
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.5") => Seq(
+      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -481,12 +490,15 @@ lazy val `fundamentals-reflection` = project.in(file("fundamentals/fundamentals-
         "-Wmacros:after",
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified",
-        "-Wunused:-synthetics"
+        "-Wunused:-synthetics",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
     scalacOptions += "-Wconf:msg=parameter.value.x\\$4.in.anonymous.function.is.never.used:silent",
+    scalacOptions += "-Wconf:msg=package.object.inheritance:silent",
     Compile / sbt.Keys.doc / scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
@@ -497,7 +509,7 @@ lazy val `fundamentals-reflection` = project.in(file("fundamentals/fundamentals-
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.5") => Seq(
+      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -536,7 +548,7 @@ lazy val `fundamentals-functional` = project.in(file("fundamentals/fundamentals-
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.5",
+      "2.13.6-bin-SNAPSHOT",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -595,7 +607,7 @@ lazy val `fundamentals-functional` = project.in(file("fundamentals/fundamentals-
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.5") => Seq(
+      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -612,12 +624,15 @@ lazy val `fundamentals-functional` = project.in(file("fundamentals/fundamentals-
         "-Wmacros:after",
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified",
-        "-Wunused:-synthetics"
+        "-Wunused:-synthetics",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
     scalacOptions += "-Wconf:msg=parameter.value.x\\$4.in.anonymous.function.is.never.used:silent",
+    scalacOptions += "-Wconf:msg=package.object.inheritance:silent",
     Compile / sbt.Keys.doc / scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
@@ -628,7 +643,7 @@ lazy val `fundamentals-functional` = project.in(file("fundamentals/fundamentals-
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.5") => Seq(
+      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -662,7 +677,7 @@ lazy val `fundamentals-bio` = project.in(file("fundamentals/fundamentals-bio"))
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.5",
+      "2.13.6-bin-SNAPSHOT",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -721,7 +736,7 @@ lazy val `fundamentals-bio` = project.in(file("fundamentals/fundamentals-bio"))
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.5") => Seq(
+      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -738,12 +753,15 @@ lazy val `fundamentals-bio` = project.in(file("fundamentals/fundamentals-bio"))
         "-Wmacros:after",
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified",
-        "-Wunused:-synthetics"
+        "-Wunused:-synthetics",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
     scalacOptions += "-Wconf:msg=parameter.value.x\\$4.in.anonymous.function.is.never.used:silent",
+    scalacOptions += "-Wconf:msg=package.object.inheritance:silent",
     Compile / sbt.Keys.doc / scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
@@ -754,7 +772,7 @@ lazy val `fundamentals-bio` = project.in(file("fundamentals/fundamentals-bio"))
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.5") => Seq(
+      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -781,7 +799,7 @@ lazy val `fundamentals-json-circe` = project.in(file("fundamentals/fundamentals-
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.5",
+      "2.13.6-bin-SNAPSHOT",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -840,7 +858,7 @@ lazy val `fundamentals-json-circe` = project.in(file("fundamentals/fundamentals-
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.5") => Seq(
+      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -857,12 +875,15 @@ lazy val `fundamentals-json-circe` = project.in(file("fundamentals/fundamentals-
         "-Wmacros:after",
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified",
-        "-Wunused:-synthetics"
+        "-Wunused:-synthetics",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
     scalacOptions += "-Wconf:msg=parameter.value.x\\$4.in.anonymous.function.is.never.used:silent",
+    scalacOptions += "-Wconf:msg=package.object.inheritance:silent",
     Compile / sbt.Keys.doc / scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
@@ -873,7 +894,7 @@ lazy val `fundamentals-json-circe` = project.in(file("fundamentals/fundamentals-
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.5") => Seq(
+      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -899,7 +920,7 @@ lazy val `fundamentals-orphans` = project.in(file("fundamentals/fundamentals-orp
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.5",
+      "2.13.6-bin-SNAPSHOT",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -958,7 +979,7 @@ lazy val `fundamentals-orphans` = project.in(file("fundamentals/fundamentals-orp
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.5") => Seq(
+      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -975,12 +996,15 @@ lazy val `fundamentals-orphans` = project.in(file("fundamentals/fundamentals-orp
         "-Wmacros:after",
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified",
-        "-Wunused:-synthetics"
+        "-Wunused:-synthetics",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
     scalacOptions += "-Wconf:msg=parameter.value.x\\$4.in.anonymous.function.is.never.used:silent",
+    scalacOptions += "-Wconf:msg=package.object.inheritance:silent",
     Compile / sbt.Keys.doc / scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
@@ -991,7 +1015,7 @@ lazy val `fundamentals-orphans` = project.in(file("fundamentals/fundamentals-orp
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.5") => Seq(
+      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1011,7 +1035,7 @@ lazy val `fundamentals-literals` = project.in(file("fundamentals/fundamentals-li
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.5",
+      "2.13.6-bin-SNAPSHOT",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -1070,7 +1094,7 @@ lazy val `fundamentals-literals` = project.in(file("fundamentals/fundamentals-li
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.5") => Seq(
+      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -1087,12 +1111,15 @@ lazy val `fundamentals-literals` = project.in(file("fundamentals/fundamentals-li
         "-Wmacros:after",
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified",
-        "-Wunused:-synthetics"
+        "-Wunused:-synthetics",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
     scalacOptions += "-Wconf:msg=parameter.value.x\\$4.in.anonymous.function.is.never.used:silent",
+    scalacOptions += "-Wconf:msg=package.object.inheritance:silent",
     Compile / sbt.Keys.doc / scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
@@ -1103,7 +1130,7 @@ lazy val `fundamentals-literals` = project.in(file("fundamentals/fundamentals-li
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.5") => Seq(
+      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1136,7 +1163,7 @@ lazy val `distage-core-api` = project.in(file("distage/distage-core-api"))
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.5",
+      "2.13.6-bin-SNAPSHOT",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -1195,7 +1222,7 @@ lazy val `distage-core-api` = project.in(file("distage/distage-core-api"))
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.5") => Seq(
+      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -1212,12 +1239,15 @@ lazy val `distage-core-api` = project.in(file("distage/distage-core-api"))
         "-Wmacros:after",
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified",
-        "-Wunused:-synthetics"
+        "-Wunused:-synthetics",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
     scalacOptions += "-Wconf:msg=parameter.value.x\\$4.in.anonymous.function.is.never.used:silent",
+    scalacOptions += "-Wconf:msg=package.object.inheritance:silent",
     Compile / sbt.Keys.doc / scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
@@ -1228,7 +1258,7 @@ lazy val `distage-core-api` = project.in(file("distage/distage-core-api"))
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.5") => Seq(
+      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1251,7 +1281,7 @@ lazy val `distage-core-proxy-cglib` = project.in(file("distage/distage-core-prox
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.5",
+      "2.13.6-bin-SNAPSHOT",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -1310,7 +1340,7 @@ lazy val `distage-core-proxy-cglib` = project.in(file("distage/distage-core-prox
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.5") => Seq(
+      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -1327,12 +1357,15 @@ lazy val `distage-core-proxy-cglib` = project.in(file("distage/distage-core-prox
         "-Wmacros:after",
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified",
-        "-Wunused:-synthetics"
+        "-Wunused:-synthetics",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
     scalacOptions += "-Wconf:msg=parameter.value.x\\$4.in.anonymous.function.is.never.used:silent",
+    scalacOptions += "-Wconf:msg=package.object.inheritance:silent",
     Compile / sbt.Keys.doc / scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
@@ -1343,7 +1376,7 @@ lazy val `distage-core-proxy-cglib` = project.in(file("distage/distage-core-prox
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.5") => Seq(
+      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1374,7 +1407,7 @@ lazy val `distage-core` = project.in(file("distage/distage-core"))
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.5",
+      "2.13.6-bin-SNAPSHOT",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -1433,7 +1466,7 @@ lazy val `distage-core` = project.in(file("distage/distage-core"))
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.5") => Seq(
+      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -1450,12 +1483,15 @@ lazy val `distage-core` = project.in(file("distage/distage-core"))
         "-Wmacros:after",
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified",
-        "-Wunused:-synthetics"
+        "-Wunused:-synthetics",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
     scalacOptions += "-Wconf:msg=parameter.value.x\\$4.in.anonymous.function.is.never.used:silent",
+    scalacOptions += "-Wconf:msg=package.object.inheritance:silent",
     Compile / sbt.Keys.doc / scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
@@ -1466,7 +1502,7 @@ lazy val `distage-core` = project.in(file("distage/distage-core"))
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.5") => Seq(
+      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1492,7 +1528,7 @@ lazy val `distage-extension-config` = project.in(file("distage/distage-extension
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.5",
+      "2.13.6-bin-SNAPSHOT",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -1551,7 +1587,7 @@ lazy val `distage-extension-config` = project.in(file("distage/distage-extension
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.5") => Seq(
+      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -1568,12 +1604,15 @@ lazy val `distage-extension-config` = project.in(file("distage/distage-extension
         "-Wmacros:after",
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified",
-        "-Wunused:-synthetics"
+        "-Wunused:-synthetics",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
     scalacOptions += "-Wconf:msg=parameter.value.x\\$4.in.anonymous.function.is.never.used:silent",
+    scalacOptions += "-Wconf:msg=package.object.inheritance:silent",
     Compile / sbt.Keys.doc / scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
@@ -1584,7 +1623,7 @@ lazy val `distage-extension-config` = project.in(file("distage/distage-extension
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.5") => Seq(
+      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1631,7 +1670,7 @@ lazy val `distage-extension-plugins` = project.in(file("distage/distage-extensio
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.5",
+      "2.13.6-bin-SNAPSHOT",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -1690,7 +1729,7 @@ lazy val `distage-extension-plugins` = project.in(file("distage/distage-extensio
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.5") => Seq(
+      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -1707,12 +1746,15 @@ lazy val `distage-extension-plugins` = project.in(file("distage/distage-extensio
         "-Wmacros:after",
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified",
-        "-Wunused:-synthetics"
+        "-Wunused:-synthetics",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
     scalacOptions += "-Wconf:msg=parameter.value.x\\$4.in.anonymous.function.is.never.used:silent",
+    scalacOptions += "-Wconf:msg=package.object.inheritance:silent",
     Compile / sbt.Keys.doc / scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
@@ -1723,7 +1765,7 @@ lazy val `distage-extension-plugins` = project.in(file("distage/distage-extensio
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.5") => Seq(
+      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1748,7 +1790,7 @@ lazy val `distage-extension-logstage` = project.in(file("distage/distage-extensi
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.5",
+      "2.13.6-bin-SNAPSHOT",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -1807,7 +1849,7 @@ lazy val `distage-extension-logstage` = project.in(file("distage/distage-extensi
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.5") => Seq(
+      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -1824,12 +1866,15 @@ lazy val `distage-extension-logstage` = project.in(file("distage/distage-extensi
         "-Wmacros:after",
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified",
-        "-Wunused:-synthetics"
+        "-Wunused:-synthetics",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
     scalacOptions += "-Wconf:msg=parameter.value.x\\$4.in.anonymous.function.is.never.used:silent",
+    scalacOptions += "-Wconf:msg=package.object.inheritance:silent",
     Compile / sbt.Keys.doc / scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
@@ -1840,7 +1885,7 @@ lazy val `distage-extension-logstage` = project.in(file("distage/distage-extensi
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.5") => Seq(
+      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1863,7 +1908,7 @@ lazy val `distage-framework-api` = project.in(file("distage/distage-framework-ap
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.5",
+      "2.13.6-bin-SNAPSHOT",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -1922,7 +1967,7 @@ lazy val `distage-framework-api` = project.in(file("distage/distage-framework-ap
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.5") => Seq(
+      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -1939,12 +1984,15 @@ lazy val `distage-framework-api` = project.in(file("distage/distage-framework-ap
         "-Wmacros:after",
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified",
-        "-Wunused:-synthetics"
+        "-Wunused:-synthetics",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
     scalacOptions += "-Wconf:msg=parameter.value.x\\$4.in.anonymous.function.is.never.used:silent",
+    scalacOptions += "-Wconf:msg=package.object.inheritance:silent",
     Compile / sbt.Keys.doc / scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
@@ -1955,7 +2003,7 @@ lazy val `distage-framework-api` = project.in(file("distage/distage-framework-ap
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.5") => Seq(
+      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1991,7 +2039,7 @@ lazy val `distage-framework` = project.in(file("distage/distage-framework"))
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.5",
+      "2.13.6-bin-SNAPSHOT",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -2050,7 +2098,7 @@ lazy val `distage-framework` = project.in(file("distage/distage-framework"))
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.5") => Seq(
+      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -2067,12 +2115,15 @@ lazy val `distage-framework` = project.in(file("distage/distage-framework"))
         "-Wmacros:after",
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified",
-        "-Wunused:-synthetics"
+        "-Wunused:-synthetics",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
     scalacOptions += "-Wconf:msg=parameter.value.x\\$4.in.anonymous.function.is.never.used:silent",
+    scalacOptions += "-Wconf:msg=package.object.inheritance:silent",
     Compile / sbt.Keys.doc / scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
@@ -2083,7 +2134,7 @@ lazy val `distage-framework` = project.in(file("distage/distage-framework"))
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.5") => Seq(
+      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2136,7 +2187,7 @@ lazy val `distage-framework-docker` = project.in(file("distage/distage-framework
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.5",
+      "2.13.6-bin-SNAPSHOT",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -2195,7 +2246,7 @@ lazy val `distage-framework-docker` = project.in(file("distage/distage-framework
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.5") => Seq(
+      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -2212,12 +2263,15 @@ lazy val `distage-framework-docker` = project.in(file("distage/distage-framework
         "-Wmacros:after",
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified",
-        "-Wunused:-synthetics"
+        "-Wunused:-synthetics",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
     scalacOptions += "-Wconf:msg=parameter.value.x\\$4.in.anonymous.function.is.never.used:silent",
+    scalacOptions += "-Wconf:msg=package.object.inheritance:silent",
     Compile / sbt.Keys.doc / scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
@@ -2228,7 +2282,7 @@ lazy val `distage-framework-docker` = project.in(file("distage/distage-framework
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.5") => Seq(
+      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2250,7 +2304,7 @@ lazy val `distage-testkit-core` = project.in(file("distage/distage-testkit-core"
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.5",
+      "2.13.6-bin-SNAPSHOT",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -2309,7 +2363,7 @@ lazy val `distage-testkit-core` = project.in(file("distage/distage-testkit-core"
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.5") => Seq(
+      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -2326,12 +2380,15 @@ lazy val `distage-testkit-core` = project.in(file("distage/distage-testkit-core"
         "-Wmacros:after",
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified",
-        "-Wunused:-synthetics"
+        "-Wunused:-synthetics",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
     scalacOptions += "-Wconf:msg=parameter.value.x\\$4.in.anonymous.function.is.never.used:silent",
+    scalacOptions += "-Wconf:msg=package.object.inheritance:silent",
     Compile / sbt.Keys.doc / scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
@@ -2342,7 +2399,7 @@ lazy val `distage-testkit-core` = project.in(file("distage/distage-testkit-core"
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.5") => Seq(
+      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2375,7 +2432,7 @@ lazy val `distage-testkit-scalatest` = project.in(file("distage/distage-testkit-
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.5",
+      "2.13.6-bin-SNAPSHOT",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -2434,7 +2491,7 @@ lazy val `distage-testkit-scalatest` = project.in(file("distage/distage-testkit-
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.5") => Seq(
+      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -2451,12 +2508,15 @@ lazy val `distage-testkit-scalatest` = project.in(file("distage/distage-testkit-
         "-Wmacros:after",
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified",
-        "-Wunused:-synthetics"
+        "-Wunused:-synthetics",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
     scalacOptions += "-Wconf:msg=parameter.value.x\\$4.in.anonymous.function.is.never.used:silent",
+    scalacOptions += "-Wconf:msg=package.object.inheritance:silent",
     Compile / sbt.Keys.doc / scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
@@ -2467,7 +2527,7 @@ lazy val `distage-testkit-scalatest` = project.in(file("distage/distage-testkit-
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.5") => Seq(
+      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2495,7 +2555,7 @@ lazy val `logstage-core` = project.in(file("logstage/logstage-core"))
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.5",
+      "2.13.6-bin-SNAPSHOT",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -2554,7 +2614,7 @@ lazy val `logstage-core` = project.in(file("logstage/logstage-core"))
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.5") => Seq(
+      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -2571,12 +2631,15 @@ lazy val `logstage-core` = project.in(file("logstage/logstage-core"))
         "-Wmacros:after",
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified",
-        "-Wunused:-synthetics"
+        "-Wunused:-synthetics",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
     scalacOptions += "-Wconf:msg=parameter.value.x\\$4.in.anonymous.function.is.never.used:silent",
+    scalacOptions += "-Wconf:msg=package.object.inheritance:silent",
     Compile / sbt.Keys.doc / scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
@@ -2587,7 +2650,7 @@ lazy val `logstage-core` = project.in(file("logstage/logstage-core"))
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.5") => Seq(
+      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2613,7 +2676,7 @@ lazy val `logstage-rendering-circe` = project.in(file("logstage/logstage-renderi
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.5",
+      "2.13.6-bin-SNAPSHOT",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -2672,7 +2735,7 @@ lazy val `logstage-rendering-circe` = project.in(file("logstage/logstage-renderi
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.5") => Seq(
+      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -2689,12 +2752,15 @@ lazy val `logstage-rendering-circe` = project.in(file("logstage/logstage-renderi
         "-Wmacros:after",
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified",
-        "-Wunused:-synthetics"
+        "-Wunused:-synthetics",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
     scalacOptions += "-Wconf:msg=parameter.value.x\\$4.in.anonymous.function.is.never.used:silent",
+    scalacOptions += "-Wconf:msg=package.object.inheritance:silent",
     Compile / sbt.Keys.doc / scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
@@ -2705,7 +2771,7 @@ lazy val `logstage-rendering-circe` = project.in(file("logstage/logstage-renderi
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.5") => Seq(
+      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2728,7 +2794,7 @@ lazy val `logstage-adapter-slf4j` = project.in(file("logstage/logstage-adapter-s
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.5",
+      "2.13.6-bin-SNAPSHOT",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -2787,7 +2853,7 @@ lazy val `logstage-adapter-slf4j` = project.in(file("logstage/logstage-adapter-s
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.5") => Seq(
+      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -2804,12 +2870,15 @@ lazy val `logstage-adapter-slf4j` = project.in(file("logstage/logstage-adapter-s
         "-Wmacros:after",
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified",
-        "-Wunused:-synthetics"
+        "-Wunused:-synthetics",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
     scalacOptions += "-Wconf:msg=parameter.value.x\\$4.in.anonymous.function.is.never.used:silent",
+    scalacOptions += "-Wconf:msg=package.object.inheritance:silent",
     Compile / sbt.Keys.doc / scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
@@ -2820,7 +2889,7 @@ lazy val `logstage-adapter-slf4j` = project.in(file("logstage/logstage-adapter-s
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.5") => Seq(
+      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2847,7 +2916,7 @@ lazy val `logstage-sink-slf4j` = project.in(file("logstage/logstage-sink-slf4j")
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.5",
+      "2.13.6-bin-SNAPSHOT",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -2906,7 +2975,7 @@ lazy val `logstage-sink-slf4j` = project.in(file("logstage/logstage-sink-slf4j")
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.5") => Seq(
+      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -2923,12 +2992,15 @@ lazy val `logstage-sink-slf4j` = project.in(file("logstage/logstage-sink-slf4j")
         "-Wmacros:after",
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified",
-        "-Wunused:-synthetics"
+        "-Wunused:-synthetics",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
     scalacOptions += "-Wconf:msg=parameter.value.x\\$4.in.anonymous.function.is.never.used:silent",
+    scalacOptions += "-Wconf:msg=package.object.inheritance:silent",
     Compile / sbt.Keys.doc / scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
@@ -2939,7 +3011,7 @@ lazy val `logstage-sink-slf4j` = project.in(file("logstage/logstage-sink-slf4j")
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.5") => Seq(
+      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2993,7 +3065,7 @@ lazy val `microsite` = project.in(file("doc/microsite"))
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.5",
+      "2.13.6-bin-SNAPSHOT",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -3052,7 +3124,7 @@ lazy val `microsite` = project.in(file("doc/microsite"))
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.5") => Seq(
+      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -3069,12 +3141,15 @@ lazy val `microsite` = project.in(file("doc/microsite"))
         "-Wmacros:after",
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified",
-        "-Wunused:-synthetics"
+        "-Wunused:-synthetics",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
     scalacOptions += "-Wconf:msg=parameter.value.x\\$4.in.anonymous.function.is.never.used:silent",
+    scalacOptions += "-Wconf:msg=package.object.inheritance:silent",
     Compile / sbt.Keys.doc / scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
@@ -3085,7 +3160,7 @@ lazy val `microsite` = project.in(file("doc/microsite"))
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.5") => Seq(
+      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -3224,7 +3299,7 @@ lazy val `sbt-izumi-deps` = project.in(file("sbt-plugins/sbt-izumi-deps"))
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified"
       )
-      case (_, "2.13.5") => Seq(
+      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -3241,12 +3316,15 @@ lazy val `sbt-izumi-deps` = project.in(file("sbt-plugins/sbt-izumi-deps"))
         "-Wmacros:after",
         "-Ycache-plugin-class-loader:always",
         "-Ycache-macro-class-loader:last-modified",
-        "-Wunused:-synthetics"
+        "-Wunused:-synthetics",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, _) => Seq.empty
     } },
     scalacOptions += "-Wconf:msg=nowarn:silent",
     scalacOptions += "-Wconf:msg=parameter.value.x\\$4.in.anonymous.function.is.never.used:silent",
+    scalacOptions += "-Wconf:msg=package.object.inheritance:silent",
     Compile / sbt.Keys.doc / scalacOptions -= "-Wconf:any:error",
     scalacOptions ++= Seq(
       s"-Xmacro-settings:scalatest-version=${V.scalatest}",
@@ -3257,7 +3335,7 @@ lazy val `sbt-izumi-deps` = project.in(file("sbt-plugins/sbt-izumi-deps"))
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.5") => Seq(
+      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -3272,7 +3350,7 @@ lazy val `fundamentals` = (project in file(".agg/fundamentals-fundamentals"))
   .settings(
     publish / skip := true,
     crossScalaVersions := Seq(
-      "2.13.5",
+      "2.13.6-bin-SNAPSHOT",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head
@@ -3294,7 +3372,7 @@ lazy val `fundamentals-jvm` = (project in file(".agg/fundamentals-fundamentals-j
   .settings(
     publish / skip := true,
     crossScalaVersions := Seq(
-      "2.13.5",
+      "2.13.6-bin-SNAPSHOT",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head
@@ -3316,7 +3394,7 @@ lazy val `distage` = (project in file(".agg/distage-distage"))
   .settings(
     publish / skip := true,
     crossScalaVersions := Seq(
-      "2.13.5",
+      "2.13.6-bin-SNAPSHOT",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head
@@ -3340,7 +3418,7 @@ lazy val `distage-jvm` = (project in file(".agg/distage-distage-jvm"))
   .settings(
     publish / skip := true,
     crossScalaVersions := Seq(
-      "2.13.5",
+      "2.13.6-bin-SNAPSHOT",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head
@@ -3364,7 +3442,7 @@ lazy val `logstage` = (project in file(".agg/logstage-logstage"))
   .settings(
     publish / skip := true,
     crossScalaVersions := Seq(
-      "2.13.5",
+      "2.13.6-bin-SNAPSHOT",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head
@@ -3381,7 +3459,7 @@ lazy val `logstage-jvm` = (project in file(".agg/logstage-logstage-jvm"))
   .settings(
     publish / skip := true,
     crossScalaVersions := Seq(
-      "2.13.5",
+      "2.13.6-bin-SNAPSHOT",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head
@@ -3398,7 +3476,7 @@ lazy val `doc` = (project in file(".agg/doc-doc"))
   .settings(
     publish / skip := true,
     crossScalaVersions := Seq(
-      "2.13.5",
+      "2.13.6-bin-SNAPSHOT",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head
@@ -3412,7 +3490,7 @@ lazy val `doc-jvm` = (project in file(".agg/doc-doc-jvm"))
   .settings(
     publish / skip := true,
     crossScalaVersions := Seq(
-      "2.13.5",
+      "2.13.6-bin-SNAPSHOT",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head
@@ -3448,7 +3526,7 @@ lazy val `izumi-jvm` = (project in file(".agg/.agg-jvm"))
   .settings(
     publish / skip := true,
     crossScalaVersions := Seq(
-      "2.13.5",
+      "2.13.6-bin-SNAPSHOT",
       "2.12.13"
     ),
     scalaVersion := crossScalaVersions.value.head
@@ -3495,7 +3573,7 @@ lazy val `izumi` = (project in file("."))
       s"-Xmacro-settings:git-head-commit=${com.typesafe.sbt.SbtGit.GitKeys.gitHeadCommit.value.getOrElse("")}"
     ),
     crossScalaVersions := Nil,
-    scalaVersion := "2.13.5",
+    scalaVersion := "2.13.6-bin-SNAPSHOT",
     ThisBuild / organization := "io.7mind.izumi",
     sonatypeProfileName := "io.7mind",
     sonatypeSessionName := s"[sbt-sonatype] ${name.value} ${version.value} ${java.util.UUID.randomUUID}",

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val `fundamentals-collections` = project.in(file("fundamentals/fundamentals
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
+      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test
     )
@@ -18,13 +18,10 @@ lazy val `fundamentals-collections` = project.in(file("fundamentals/fundamentals
   .settings(
     crossScalaVersions := Seq(
       "2.13.6",
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => false
-      case (_, _) => coverageEnabled.value
-    } },
+    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -39,7 +36,7 @@ lazy val `fundamentals-collections` = project.in(file("fundamentals/fundamentals
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (_, "2.12.14") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -114,7 +111,7 @@ lazy val `fundamentals-collections` = project.in(file("fundamentals/fundamentals
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (false, "2.12.14") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -154,7 +151,7 @@ lazy val `fundamentals-platform` = project.in(file("fundamentals/fundamentals-pl
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
+      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided
@@ -163,13 +160,10 @@ lazy val `fundamentals-platform` = project.in(file("fundamentals/fundamentals-pl
   .settings(
     crossScalaVersions := Seq(
       "2.13.6",
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => false
-      case (_, _) => coverageEnabled.value
-    } },
+    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -184,7 +178,7 @@ lazy val `fundamentals-platform` = project.in(file("fundamentals/fundamentals-pl
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (_, "2.12.14") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -259,7 +253,7 @@ lazy val `fundamentals-platform` = project.in(file("fundamentals/fundamentals-pl
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (false, "2.12.14") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -278,7 +272,7 @@ lazy val `fundamentals-language` = project.in(file("fundamentals/fundamentals-la
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
+      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided
@@ -287,13 +281,10 @@ lazy val `fundamentals-language` = project.in(file("fundamentals/fundamentals-la
   .settings(
     crossScalaVersions := Seq(
       "2.13.6",
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => false
-      case (_, _) => coverageEnabled.value
-    } },
+    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -308,7 +299,7 @@ lazy val `fundamentals-language` = project.in(file("fundamentals/fundamentals-la
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (_, "2.12.14") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -383,7 +374,7 @@ lazy val `fundamentals-language` = project.in(file("fundamentals/fundamentals-la
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (false, "2.12.14") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -423,7 +414,7 @@ lazy val `fundamentals-reflection` = project.in(file("fundamentals/fundamentals-
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
+      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "dev.zio" %% "izumi-reflect" % V.izumi_reflect,
@@ -433,13 +424,10 @@ lazy val `fundamentals-reflection` = project.in(file("fundamentals/fundamentals-
   .settings(
     crossScalaVersions := Seq(
       "2.13.6",
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => false
-      case (_, _) => coverageEnabled.value
-    } },
+    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -454,7 +442,7 @@ lazy val `fundamentals-reflection` = project.in(file("fundamentals/fundamentals-
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (_, "2.12.14") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -529,7 +517,7 @@ lazy val `fundamentals-reflection` = project.in(file("fundamentals/fundamentals-
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (false, "2.12.14") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -565,7 +553,7 @@ lazy val `fundamentals-reflection` = project.in(file("fundamentals/fundamentals-
 lazy val `fundamentals-functional` = project.in(file("fundamentals/fundamentals-functional"))
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
+      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test
     )
@@ -573,13 +561,10 @@ lazy val `fundamentals-functional` = project.in(file("fundamentals/fundamentals-
   .settings(
     crossScalaVersions := Seq(
       "2.13.6",
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => false
-      case (_, _) => coverageEnabled.value
-    } },
+    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -594,7 +579,7 @@ lazy val `fundamentals-functional` = project.in(file("fundamentals/fundamentals-
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (_, "2.12.14") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -669,7 +654,7 @@ lazy val `fundamentals-functional` = project.in(file("fundamentals/fundamentals-
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (false, "2.12.14") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -689,7 +674,7 @@ lazy val `fundamentals-bio` = project.in(file("fundamentals/fundamentals-bio"))
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
+      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.typelevel" %% "cats-core" % V.cats % Optional,
@@ -708,13 +693,10 @@ lazy val `fundamentals-bio` = project.in(file("fundamentals/fundamentals-bio"))
   .settings(
     crossScalaVersions := Seq(
       "2.13.6",
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => false
-      case (_, _) => coverageEnabled.value
-    } },
+    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -729,7 +711,7 @@ lazy val `fundamentals-bio` = project.in(file("fundamentals/fundamentals-bio"))
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (_, "2.12.14") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -804,7 +786,7 @@ lazy val `fundamentals-bio` = project.in(file("fundamentals/fundamentals-bio"))
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (false, "2.12.14") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -823,7 +805,7 @@ lazy val `fundamentals-json-circe` = project.in(file("fundamentals/fundamentals-
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
+      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "io.circe" %% "circe-core" % V.circe,
@@ -836,13 +818,10 @@ lazy val `fundamentals-json-circe` = project.in(file("fundamentals/fundamentals-
   .settings(
     crossScalaVersions := Seq(
       "2.13.6",
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => false
-      case (_, _) => coverageEnabled.value
-    } },
+    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -857,7 +836,7 @@ lazy val `fundamentals-json-circe` = project.in(file("fundamentals/fundamentals-
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (_, "2.12.14") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -932,7 +911,7 @@ lazy val `fundamentals-json-circe` = project.in(file("fundamentals/fundamentals-
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (false, "2.12.14") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -948,7 +927,7 @@ lazy val `fundamentals-json-circe` = project.in(file("fundamentals/fundamentals-
 lazy val `fundamentals-orphans` = project.in(file("fundamentals/fundamentals-orphans"))
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
+      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.typelevel" %% "cats-core" % V.cats % Optional,
@@ -963,13 +942,10 @@ lazy val `fundamentals-orphans` = project.in(file("fundamentals/fundamentals-orp
   .settings(
     crossScalaVersions := Seq(
       "2.13.6",
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => false
-      case (_, _) => coverageEnabled.value
-    } },
+    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -984,7 +960,7 @@ lazy val `fundamentals-orphans` = project.in(file("fundamentals/fundamentals-orp
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (_, "2.12.14") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -1059,7 +1035,7 @@ lazy val `fundamentals-orphans` = project.in(file("fundamentals/fundamentals-orp
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (false, "2.12.14") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1075,7 +1051,7 @@ lazy val `fundamentals-orphans` = project.in(file("fundamentals/fundamentals-orp
 lazy val `fundamentals-literals` = project.in(file("fundamentals/fundamentals-literals"))
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
+      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided
@@ -1084,13 +1060,10 @@ lazy val `fundamentals-literals` = project.in(file("fundamentals/fundamentals-li
   .settings(
     crossScalaVersions := Seq(
       "2.13.6",
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => false
-      case (_, _) => coverageEnabled.value
-    } },
+    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -1105,7 +1078,7 @@ lazy val `fundamentals-literals` = project.in(file("fundamentals/fundamentals-li
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (_, "2.12.14") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -1180,7 +1153,7 @@ lazy val `fundamentals-literals` = project.in(file("fundamentals/fundamentals-li
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (false, "2.12.14") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1200,7 +1173,7 @@ lazy val `distage-core-api` = project.in(file("distage/distage-core-api"))
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
+      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.typelevel" %% "cats-core" % V.cats % Optional,
@@ -1218,13 +1191,10 @@ lazy val `distage-core-api` = project.in(file("distage/distage-core-api"))
   .settings(
     crossScalaVersions := Seq(
       "2.13.6",
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => false
-      case (_, _) => coverageEnabled.value
-    } },
+    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -1239,7 +1209,7 @@ lazy val `distage-core-api` = project.in(file("distage/distage-core-api"))
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (_, "2.12.14") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -1314,7 +1284,7 @@ lazy val `distage-core-api` = project.in(file("distage/distage-core-api"))
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (false, "2.12.14") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1333,7 +1303,7 @@ lazy val `distage-core-proxy-cglib` = project.in(file("distage/distage-core-prox
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
+      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "cglib" % "cglib-nodep" % V.cglib_nodep
@@ -1342,13 +1312,10 @@ lazy val `distage-core-proxy-cglib` = project.in(file("distage/distage-core-prox
   .settings(
     crossScalaVersions := Seq(
       "2.13.6",
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => false
-      case (_, _) => coverageEnabled.value
-    } },
+    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -1363,7 +1330,7 @@ lazy val `distage-core-proxy-cglib` = project.in(file("distage/distage-core-prox
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (_, "2.12.14") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -1438,7 +1405,7 @@ lazy val `distage-core-proxy-cglib` = project.in(file("distage/distage-core-prox
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (false, "2.12.14") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1458,7 +1425,7 @@ lazy val `distage-core` = project.in(file("distage/distage-core"))
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
+      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.typelevel" %% "cats-core" % V.cats % Optional,
@@ -1474,13 +1441,10 @@ lazy val `distage-core` = project.in(file("distage/distage-core"))
   .settings(
     crossScalaVersions := Seq(
       "2.13.6",
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => false
-      case (_, _) => coverageEnabled.value
-    } },
+    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -1495,7 +1459,7 @@ lazy val `distage-core` = project.in(file("distage/distage-core"))
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (_, "2.12.14") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -1570,7 +1534,7 @@ lazy val `distage-core` = project.in(file("distage/distage-core"))
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (false, "2.12.14") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1590,7 +1554,7 @@ lazy val `distage-extension-config` = project.in(file("distage/distage-extension
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
+      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "com.github.pureconfig" %% "pureconfig-magnolia" % V.pureconfig,
@@ -1601,13 +1565,10 @@ lazy val `distage-extension-config` = project.in(file("distage/distage-extension
   .settings(
     crossScalaVersions := Seq(
       "2.13.6",
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => false
-      case (_, _) => coverageEnabled.value
-    } },
+    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -1622,7 +1583,7 @@ lazy val `distage-extension-config` = project.in(file("distage/distage-extension
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (_, "2.12.14") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -1697,7 +1658,7 @@ lazy val `distage-extension-config` = project.in(file("distage/distage-extension
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (false, "2.12.14") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1739,7 +1700,7 @@ lazy val `distage-extension-plugins` = project.in(file("distage/distage-extensio
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
+      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "io.github.classgraph" % "classgraph" % V.classgraph,
@@ -1749,13 +1710,10 @@ lazy val `distage-extension-plugins` = project.in(file("distage/distage-extensio
   .settings(
     crossScalaVersions := Seq(
       "2.13.6",
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => false
-      case (_, _) => coverageEnabled.value
-    } },
+    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -1770,7 +1728,7 @@ lazy val `distage-extension-plugins` = project.in(file("distage/distage-extensio
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (_, "2.12.14") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -1845,7 +1803,7 @@ lazy val `distage-extension-plugins` = project.in(file("distage/distage-extensio
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (false, "2.12.14") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1867,7 +1825,7 @@ lazy val `distage-extension-logstage` = project.in(file("distage/distage-extensi
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
+      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test
     )
@@ -1875,13 +1833,10 @@ lazy val `distage-extension-logstage` = project.in(file("distage/distage-extensi
   .settings(
     crossScalaVersions := Seq(
       "2.13.6",
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => false
-      case (_, _) => coverageEnabled.value
-    } },
+    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -1896,7 +1851,7 @@ lazy val `distage-extension-logstage` = project.in(file("distage/distage-extensi
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (_, "2.12.14") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -1971,7 +1926,7 @@ lazy val `distage-extension-logstage` = project.in(file("distage/distage-extensi
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (false, "2.12.14") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1990,7 +1945,7 @@ lazy val `distage-framework-api` = project.in(file("distage/distage-framework-ap
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
+      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided
@@ -1999,13 +1954,10 @@ lazy val `distage-framework-api` = project.in(file("distage/distage-framework-ap
   .settings(
     crossScalaVersions := Seq(
       "2.13.6",
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => false
-      case (_, _) => coverageEnabled.value
-    } },
+    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -2020,7 +1972,7 @@ lazy val `distage-framework-api` = project.in(file("distage/distage-framework-ap
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (_, "2.12.14") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -2095,7 +2047,7 @@ lazy val `distage-framework-api` = project.in(file("distage/distage-framework-ap
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (false, "2.12.14") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2120,7 +2072,7 @@ lazy val `distage-framework` = project.in(file("distage/distage-framework"))
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
+      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.typelevel" %% "cats-core" % V.cats % Optional,
@@ -2136,13 +2088,10 @@ lazy val `distage-framework` = project.in(file("distage/distage-framework"))
   .settings(
     crossScalaVersions := Seq(
       "2.13.6",
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => false
-      case (_, _) => coverageEnabled.value
-    } },
+    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -2157,7 +2106,7 @@ lazy val `distage-framework` = project.in(file("distage/distage-framework"))
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (_, "2.12.14") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -2232,7 +2181,7 @@ lazy val `distage-framework` = project.in(file("distage/distage-framework"))
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (false, "2.12.14") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2275,7 +2224,7 @@ lazy val `distage-framework-docker` = project.in(file("distage/distage-framework
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
+      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.typelevel" %% "cats-core" % V.cats % Test,
@@ -2290,13 +2239,10 @@ lazy val `distage-framework-docker` = project.in(file("distage/distage-framework
   .settings(
     crossScalaVersions := Seq(
       "2.13.6",
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => false
-      case (_, _) => coverageEnabled.value
-    } },
+    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -2311,7 +2257,7 @@ lazy val `distage-framework-docker` = project.in(file("distage/distage-framework
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (_, "2.12.14") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -2386,7 +2332,7 @@ lazy val `distage-framework-docker` = project.in(file("distage/distage-framework
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (false, "2.12.14") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2405,7 +2351,7 @@ lazy val `distage-testkit-core` = project.in(file("distage/distage-testkit-core"
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
+      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test
     )
@@ -2413,13 +2359,10 @@ lazy val `distage-testkit-core` = project.in(file("distage/distage-testkit-core"
   .settings(
     crossScalaVersions := Seq(
       "2.13.6",
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => false
-      case (_, _) => coverageEnabled.value
-    } },
+    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -2434,7 +2377,7 @@ lazy val `distage-testkit-core` = project.in(file("distage/distage-testkit-core"
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (_, "2.12.14") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -2509,7 +2452,7 @@ lazy val `distage-testkit-core` = project.in(file("distage/distage-testkit-core"
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (false, "2.12.14") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2531,7 +2474,7 @@ lazy val `distage-testkit-scalatest` = project.in(file("distage/distage-testkit-
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
+      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.typelevel" %% "cats-core" % V.cats % Optional,
@@ -2547,13 +2490,10 @@ lazy val `distage-testkit-scalatest` = project.in(file("distage/distage-testkit-
   .settings(
     crossScalaVersions := Seq(
       "2.13.6",
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => false
-      case (_, _) => coverageEnabled.value
-    } },
+    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -2568,7 +2508,7 @@ lazy val `distage-testkit-scalatest` = project.in(file("distage/distage-testkit-
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (_, "2.12.14") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -2643,7 +2583,7 @@ lazy val `distage-testkit-scalatest` = project.in(file("distage/distage-testkit-
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (false, "2.12.14") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2663,7 +2603,7 @@ lazy val `logstage-core` = project.in(file("logstage/logstage-core"))
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
+      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided,
@@ -2676,13 +2616,10 @@ lazy val `logstage-core` = project.in(file("logstage/logstage-core"))
   .settings(
     crossScalaVersions := Seq(
       "2.13.6",
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => false
-      case (_, _) => coverageEnabled.value
-    } },
+    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -2697,7 +2634,7 @@ lazy val `logstage-core` = project.in(file("logstage/logstage-core"))
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (_, "2.12.14") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -2772,7 +2709,7 @@ lazy val `logstage-core` = project.in(file("logstage/logstage-core"))
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (false, "2.12.14") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2792,7 +2729,7 @@ lazy val `logstage-rendering-circe` = project.in(file("logstage/logstage-renderi
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
+      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.typelevel" %% "jawn-parser" % V.jawn % Test,
@@ -2803,13 +2740,10 @@ lazy val `logstage-rendering-circe` = project.in(file("logstage/logstage-renderi
   .settings(
     crossScalaVersions := Seq(
       "2.13.6",
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => false
-      case (_, _) => coverageEnabled.value
-    } },
+    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -2824,7 +2758,7 @@ lazy val `logstage-rendering-circe` = project.in(file("logstage/logstage-renderi
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (_, "2.12.14") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -2899,7 +2833,7 @@ lazy val `logstage-rendering-circe` = project.in(file("logstage/logstage-renderi
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (false, "2.12.14") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2918,7 +2852,7 @@ lazy val `logstage-adapter-slf4j` = project.in(file("logstage/logstage-adapter-s
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
+      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.slf4j" % "slf4j-api" % V.slf4j
@@ -2927,13 +2861,10 @@ lazy val `logstage-adapter-slf4j` = project.in(file("logstage/logstage-adapter-s
   .settings(
     crossScalaVersions := Seq(
       "2.13.6",
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => false
-      case (_, _) => coverageEnabled.value
-    } },
+    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -2948,7 +2879,7 @@ lazy val `logstage-adapter-slf4j` = project.in(file("logstage/logstage-adapter-s
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (_, "2.12.14") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -3023,7 +2954,7 @@ lazy val `logstage-adapter-slf4j` = project.in(file("logstage/logstage-adapter-s
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (false, "2.12.14") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -3045,7 +2976,7 @@ lazy val `logstage-sink-slf4j` = project.in(file("logstage/logstage-sink-slf4j")
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
+      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.slf4j" % "slf4j-api" % V.slf4j,
@@ -3055,13 +2986,10 @@ lazy val `logstage-sink-slf4j` = project.in(file("logstage/logstage-sink-slf4j")
   .settings(
     crossScalaVersions := Seq(
       "2.13.6",
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => false
-      case (_, _) => coverageEnabled.value
-    } },
+    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -3076,7 +3004,7 @@ lazy val `logstage-sink-slf4j` = project.in(file("logstage/logstage-sink-slf4j")
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (_, "2.12.14") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -3151,7 +3079,7 @@ lazy val `logstage-sink-slf4j` = project.in(file("logstage/logstage-sink-slf4j")
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (false, "2.12.14") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -3193,7 +3121,7 @@ lazy val `microsite` = project.in(file("doc/microsite"))
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
+      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.typelevel" %% "cats-core" % V.cats,
@@ -3210,13 +3138,10 @@ lazy val `microsite` = project.in(file("doc/microsite"))
   .settings(
     crossScalaVersions := Seq(
       "2.13.6",
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => false
-      case (_, _) => coverageEnabled.value
-    } },
+    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -3231,7 +3156,7 @@ lazy val `microsite` = project.in(file("doc/microsite"))
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (_, "2.12.14") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -3306,7 +3231,7 @@ lazy val `microsite` = project.in(file("doc/microsite"))
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (false, "2.12.14") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -3383,14 +3308,14 @@ lazy val `microsite` = project.in(file("doc/microsite"))
 lazy val `sbt-izumi-deps` = project.in(file("sbt-plugins/sbt-izumi-deps"))
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
+      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test
     )
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
     coverageEnabled := false,
@@ -3408,7 +3333,7 @@ lazy val `sbt-izumi-deps` = project.in(file("sbt-plugins/sbt-izumi-deps"))
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (_, "2.12.14") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -3483,7 +3408,7 @@ lazy val `sbt-izumi-deps` = project.in(file("sbt-plugins/sbt-izumi-deps"))
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
+      case (false, "2.12.14") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -3503,7 +3428,7 @@ lazy val `fundamentals` = (project in file(".agg/fundamentals-fundamentals"))
     publish / skip := true,
     crossScalaVersions := Seq(
       "2.13.6",
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head
   )
@@ -3525,7 +3450,7 @@ lazy val `fundamentals-jvm` = (project in file(".agg/fundamentals-fundamentals-j
     publish / skip := true,
     crossScalaVersions := Seq(
       "2.13.6",
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head
   )
@@ -3547,7 +3472,7 @@ lazy val `distage` = (project in file(".agg/distage-distage"))
     publish / skip := true,
     crossScalaVersions := Seq(
       "2.13.6",
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head
   )
@@ -3571,7 +3496,7 @@ lazy val `distage-jvm` = (project in file(".agg/distage-distage-jvm"))
     publish / skip := true,
     crossScalaVersions := Seq(
       "2.13.6",
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head
   )
@@ -3595,7 +3520,7 @@ lazy val `logstage` = (project in file(".agg/logstage-logstage"))
     publish / skip := true,
     crossScalaVersions := Seq(
       "2.13.6",
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head
   )
@@ -3612,7 +3537,7 @@ lazy val `logstage-jvm` = (project in file(".agg/logstage-logstage-jvm"))
     publish / skip := true,
     crossScalaVersions := Seq(
       "2.13.6",
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head
   )
@@ -3629,7 +3554,7 @@ lazy val `doc` = (project in file(".agg/doc-doc"))
     publish / skip := true,
     crossScalaVersions := Seq(
       "2.13.6",
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head
   )
@@ -3643,7 +3568,7 @@ lazy val `doc-jvm` = (project in file(".agg/doc-doc-jvm"))
     publish / skip := true,
     crossScalaVersions := Seq(
       "2.13.6",
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head
   )
@@ -3656,7 +3581,7 @@ lazy val `sbt-plugins` = (project in file(".agg/sbt-plugins-sbt-plugins"))
   .settings(
     publish / skip := true,
     crossScalaVersions := Nil,
-    scalaVersion := "2.12.14-bin-SNAPSHOT"
+    scalaVersion := "2.12.14"
   )
   .disablePlugins(AssemblyPlugin)
   .aggregate(
@@ -3667,7 +3592,7 @@ lazy val `sbt-plugins-jvm` = (project in file(".agg/sbt-plugins-sbt-plugins-jvm"
   .settings(
     publish / skip := true,
     crossScalaVersions := Nil,
-    scalaVersion := "2.12.14-bin-SNAPSHOT"
+    scalaVersion := "2.12.14"
   )
   .disablePlugins(AssemblyPlugin)
   .aggregate(
@@ -3679,7 +3604,7 @@ lazy val `izumi-jvm` = (project in file(".agg/.agg-jvm"))
     publish / skip := true,
     crossScalaVersions := Seq(
       "2.13.6",
-      "2.12.14-bin-SNAPSHOT"
+      "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head
   )

--- a/build.sbt
+++ b/build.sbt
@@ -1,31 +1,24 @@
+import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
+
 import com.typesafe.sbt.SbtGit.GitKeys._
 
 enablePlugins(SbtgenVerificationPlugin)
 
 disablePlugins(AssemblyPlugin)
 
-lazy val `fundamentals-collections` = project.in(file("fundamentals/fundamentals-collections"))
+lazy val `fundamentals-collections` = crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Pure).in(file("fundamentals/fundamentals-collections"))
   .dependsOn(
     `fundamentals-functional` % "test->compile;compile->compile"
   )
   .settings(
     libraryDependencies ++= Seq(
       compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
-      "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
-      "org.scalatest" %% "scalatest" % V.scalatest % Test
+      "org.scala-lang.modules" %%% "scala-collection-compat" % V.collection_compat,
+      "org.scalatest" %%% "scalatest" % V.scalatest % Test
     )
   )
   .settings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
-    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
-    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
-    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
-    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -141,9 +134,28 @@ lazy val `fundamentals-collections` = project.in(file("fundamentals/fundamentals
        })
     }
   )
+  .jvmSettings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head
+  )
+  .jsSettings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := false,
+    scalaJSLinkerConfig := { scalaJSLinkerConfig.value.withModuleKind(ModuleKind.CommonJSModule) }
+  )
+lazy val `fundamentals-collectionsJVM` = `fundamentals-collections`.jvm
+  .disablePlugins(AssemblyPlugin)
+lazy val `fundamentals-collectionsJS` = `fundamentals-collections`.js
   .disablePlugins(AssemblyPlugin)
 
-lazy val `fundamentals-platform` = project.in(file("fundamentals/fundamentals-platform"))
+lazy val `fundamentals-platform` = crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Pure).in(file("fundamentals/fundamentals-platform"))
   .dependsOn(
     `fundamentals-language` % "test->compile;compile->compile",
     `fundamentals-collections` % "test->compile;compile->compile"
@@ -151,22 +163,13 @@ lazy val `fundamentals-platform` = project.in(file("fundamentals/fundamentals-pl
   .settings(
     libraryDependencies ++= Seq(
       compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
-      "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
-      "org.scalatest" %% "scalatest" % V.scalatest % Test,
+      "org.scala-lang.modules" %%% "scala-collection-compat" % V.collection_compat,
+      "org.scalatest" %%% "scalatest" % V.scalatest % Test,
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided
     )
   )
   .settings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
-    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
-    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
-    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
-    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -262,31 +265,45 @@ lazy val `fundamentals-platform` = project.in(file("fundamentals/fundamentals-pl
       case (_, _) => Seq.empty
     } }
   )
+  .jvmSettings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head
+  )
+  .jsSettings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := false,
+    scalaJSLinkerConfig := { scalaJSLinkerConfig.value.withModuleKind(ModuleKind.CommonJSModule) },
+    Test / npmDependencies ++= Seq(
+      (  "hash.js",  "1.1.7")
+    )
+  )
+lazy val `fundamentals-platformJVM` = `fundamentals-platform`.jvm
+  .disablePlugins(AssemblyPlugin)
+lazy val `fundamentals-platformJS` = `fundamentals-platform`.js
+  .enablePlugins(ScalaJSBundlerPlugin)
   .disablePlugins(AssemblyPlugin)
 
-lazy val `fundamentals-language` = project.in(file("fundamentals/fundamentals-language"))
+lazy val `fundamentals-language` = crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Pure).in(file("fundamentals/fundamentals-language"))
   .dependsOn(
     `fundamentals-literals` % "test->compile;compile->compile"
   )
   .settings(
     libraryDependencies ++= Seq(
       compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
-      "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
-      "org.scalatest" %% "scalatest" % V.scalatest % Test,
+      "org.scala-lang.modules" %%% "scala-collection-compat" % V.collection_compat,
+      "org.scalatest" %%% "scalatest" % V.scalatest % Test,
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided
     )
   )
   .settings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
-    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
-    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
-    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
-    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -402,9 +419,29 @@ lazy val `fundamentals-language` = project.in(file("fundamentals/fundamentals-la
        })
     }
   )
+  .jvmSettings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head
+  )
+  .jsSettings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := false,
+    scalaJSLinkerConfig := { scalaJSLinkerConfig.value.withModuleKind(ModuleKind.CommonJSModule) }
+  )
+lazy val `fundamentals-languageJVM` = `fundamentals-language`.jvm
+  .disablePlugins(AssemblyPlugin)
+lazy val `fundamentals-languageJS` = `fundamentals-language`.js
+  .enablePlugins(ScalaJSBundlerPlugin)
   .disablePlugins(AssemblyPlugin)
 
-lazy val `fundamentals-reflection` = project.in(file("fundamentals/fundamentals-reflection"))
+lazy val `fundamentals-reflection` = crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Pure).in(file("fundamentals/fundamentals-reflection"))
   .dependsOn(
     `fundamentals-platform` % "test->compile;compile->compile",
     `fundamentals-functional` % "test->compile;compile->compile"
@@ -412,23 +449,14 @@ lazy val `fundamentals-reflection` = project.in(file("fundamentals/fundamentals-
   .settings(
     libraryDependencies ++= Seq(
       compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
-      "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
-      "org.scalatest" %% "scalatest" % V.scalatest % Test,
-      "dev.zio" %% "izumi-reflect" % V.izumi_reflect,
+      "org.scala-lang.modules" %%% "scala-collection-compat" % V.collection_compat,
+      "org.scalatest" %%% "scalatest" % V.scalatest % Test,
+      "dev.zio" %%% "izumi-reflect" % V.izumi_reflect,
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided
     )
   )
   .settings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
-    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
-    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
-    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
-    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -544,27 +572,37 @@ lazy val `fundamentals-reflection` = project.in(file("fundamentals/fundamentals-
        })
     }
   )
-  .disablePlugins(AssemblyPlugin)
-
-lazy val `fundamentals-functional` = project.in(file("fundamentals/fundamentals-functional"))
-  .settings(
-    libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
-      "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
-      "org.scalatest" %% "scalatest" % V.scalatest % Test
-    )
+  .jvmSettings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head
   )
-  .settings(
+  .jsSettings(
     crossScalaVersions := Seq(
       "2.13.6",
       "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := false,
+    scalaJSLinkerConfig := { scalaJSLinkerConfig.value.withModuleKind(ModuleKind.CommonJSModule) }
+  )
+lazy val `fundamentals-reflectionJVM` = `fundamentals-reflection`.jvm
+  .disablePlugins(AssemblyPlugin)
+lazy val `fundamentals-reflectionJS` = `fundamentals-reflection`.js
+  .disablePlugins(AssemblyPlugin)
+
+lazy val `fundamentals-functional` = crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Pure).in(file("fundamentals/fundamentals-functional"))
+  .settings(
+    libraryDependencies ++= Seq(
+      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
+      "org.scala-lang.modules" %%% "scala-collection-compat" % V.collection_compat,
+      "org.scalatest" %%% "scalatest" % V.scalatest % Test
+    )
+  )
+  .settings(
     organization := "io.7mind.izumi",
-    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
-    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
-    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
-    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -660,9 +698,28 @@ lazy val `fundamentals-functional` = project.in(file("fundamentals/fundamentals-
       case (_, _) => Seq.empty
     } }
   )
+  .jvmSettings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head
+  )
+  .jsSettings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := false,
+    scalaJSLinkerConfig := { scalaJSLinkerConfig.value.withModuleKind(ModuleKind.CommonJSModule) }
+  )
+lazy val `fundamentals-functionalJVM` = `fundamentals-functional`.jvm
+  .disablePlugins(AssemblyPlugin)
+lazy val `fundamentals-functionalJS` = `fundamentals-functional`.js
   .disablePlugins(AssemblyPlugin)
 
-lazy val `fundamentals-bio` = project.in(file("fundamentals/fundamentals-bio"))
+lazy val `fundamentals-bio` = crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Pure).in(file("fundamentals/fundamentals-bio"))
   .dependsOn(
     `fundamentals-language` % "test->compile;compile->compile",
     `fundamentals-orphans` % "test->compile;compile->compile"
@@ -670,32 +727,23 @@ lazy val `fundamentals-bio` = project.in(file("fundamentals/fundamentals-bio"))
   .settings(
     libraryDependencies ++= Seq(
       compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
-      "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
-      "org.scalatest" %% "scalatest" % V.scalatest % Test,
-      "org.typelevel" %% "cats-core" % V.cats % Optional,
-      "org.typelevel" %% "cats-effect" % V.cats_effect % Optional,
-      "dev.zio" %% "zio" % V.zio % Optional excludeAll("dev.zio" %% "izumi-reflect"),
-      "dev.zio" %% "izumi-reflect" % V.izumi_reflect % Optional,
-      "io.monix" %% "monix" % V.monix % Optional,
-      "io.monix" %% "monix-bio" % V.monix_bio % Optional,
-      "org.typelevel" %% "cats-effect-laws" % V.cats_effect % Test,
-      "org.scalatest" %% "scalatest" % V.scalatest % Test,
-      "org.typelevel" %% "discipline-core" % V.discipline % Test,
-      "org.typelevel" %% "discipline-scalatest" % V.discipline_scalatest % Test,
-      "dev.zio" %% "zio-interop-cats" % V.zio_interop_cats % Test excludeAll("dev.zio" %% "izumi-reflect")
+      "org.scala-lang.modules" %%% "scala-collection-compat" % V.collection_compat,
+      "org.scalatest" %%% "scalatest" % V.scalatest % Test,
+      "org.typelevel" %%% "cats-core" % V.cats % Optional,
+      "org.typelevel" %%% "cats-effect" % V.cats_effect % Optional,
+      "dev.zio" %%% "zio" % V.zio % Optional excludeAll("dev.zio" %% "izumi-reflect"),
+      "dev.zio" %%% "izumi-reflect" % V.izumi_reflect % Optional,
+      "io.monix" %%% "monix" % V.monix % Optional,
+      "io.monix" %%% "monix-bio" % V.monix_bio % Optional,
+      "org.typelevel" %%% "cats-effect-laws" % V.cats_effect % Test,
+      "org.scalatest" %%% "scalatest" % V.scalatest % Test,
+      "org.typelevel" %%% "discipline-core" % V.discipline % Test,
+      "org.typelevel" %%% "discipline-scalatest" % V.discipline_scalatest % Test,
+      "dev.zio" %%% "zio-interop-cats" % V.zio_interop_cats % Test excludeAll("dev.zio" %% "izumi-reflect")
     )
   )
   .settings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
-    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
-    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
-    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
-    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -791,35 +839,50 @@ lazy val `fundamentals-bio` = project.in(file("fundamentals/fundamentals-bio"))
       case (_, _) => Seq.empty
     } }
   )
+  .jvmSettings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head
+  )
+  .jsSettings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := false,
+    scalaJSLinkerConfig := { scalaJSLinkerConfig.value.withModuleKind(ModuleKind.CommonJSModule) }
+  )
+lazy val `fundamentals-bioJVM` = `fundamentals-bio`.jvm
+  .disablePlugins(AssemblyPlugin)
+lazy val `fundamentals-bioJS` = `fundamentals-bio`.js
+  .settings(
+    libraryDependencies ++= Seq(
+      "io.github.cquiroz" %%% "scala-java-time" % V.scala_java_time % Test
+    )
+  )
   .disablePlugins(AssemblyPlugin)
 
-lazy val `fundamentals-json-circe` = project.in(file("fundamentals/fundamentals-json-circe"))
+lazy val `fundamentals-json-circe` = crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Pure).in(file("fundamentals/fundamentals-json-circe"))
   .dependsOn(
     `fundamentals-platform` % "test->compile;compile->compile"
   )
   .settings(
     libraryDependencies ++= Seq(
       compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
-      "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
-      "org.scalatest" %% "scalatest" % V.scalatest % Test,
-      "io.circe" %% "circe-core" % V.circe,
-      "io.circe" %% "circe-derivation" % V.circe_derivation,
+      "org.scala-lang.modules" %%% "scala-collection-compat" % V.collection_compat,
+      "org.scalatest" %%% "scalatest" % V.scalatest % Test,
+      "io.circe" %%% "circe-core" % V.circe,
+      "io.circe" %%% "circe-derivation" % V.circe_derivation,
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided,
       "org.typelevel" %% "jawn-parser" % V.jawn % Test,
-      "io.circe" %% "circe-literal" % V.circe % Test
+      "io.circe" %%% "circe-literal" % V.circe % Test
     )
   )
   .settings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
-    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
-    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
-    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
-    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -915,34 +978,44 @@ lazy val `fundamentals-json-circe` = project.in(file("fundamentals/fundamentals-
       case (_, _) => Seq.empty
     } }
   )
-  .disablePlugins(AssemblyPlugin)
-
-lazy val `fundamentals-orphans` = project.in(file("fundamentals/fundamentals-orphans"))
-  .settings(
-    libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
-      "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
-      "org.scalatest" %% "scalatest" % V.scalatest % Test,
-      "org.typelevel" %% "cats-core" % V.cats % Optional,
-      "org.typelevel" %% "cats-effect" % V.cats_effect % Optional,
-      "dev.zio" %% "zio" % V.zio % Optional excludeAll("dev.zio" %% "izumi-reflect"),
-      "dev.zio" %% "izumi-reflect" % V.izumi_reflect % Optional,
-      "io.monix" %% "monix" % V.monix % Optional,
-      "io.monix" %% "monix-bio" % V.monix_bio % Optional,
-      "dev.zio" %% "zio-interop-cats" % V.zio_interop_cats % Optional excludeAll("dev.zio" %% "izumi-reflect")
-    )
+  .jvmSettings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head
   )
-  .settings(
+  .jsSettings(
     crossScalaVersions := Seq(
       "2.13.6",
       "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := false,
+    scalaJSLinkerConfig := { scalaJSLinkerConfig.value.withModuleKind(ModuleKind.CommonJSModule) }
+  )
+lazy val `fundamentals-json-circeJVM` = `fundamentals-json-circe`.jvm
+  .disablePlugins(AssemblyPlugin)
+lazy val `fundamentals-json-circeJS` = `fundamentals-json-circe`.js
+  .disablePlugins(AssemblyPlugin)
+
+lazy val `fundamentals-orphans` = crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Pure).in(file("fundamentals/fundamentals-orphans"))
+  .settings(
+    libraryDependencies ++= Seq(
+      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
+      "org.scala-lang.modules" %%% "scala-collection-compat" % V.collection_compat,
+      "org.scalatest" %%% "scalatest" % V.scalatest % Test,
+      "org.typelevel" %%% "cats-core" % V.cats % Optional,
+      "org.typelevel" %%% "cats-effect" % V.cats_effect % Optional,
+      "dev.zio" %%% "zio" % V.zio % Optional excludeAll("dev.zio" %% "izumi-reflect"),
+      "dev.zio" %%% "izumi-reflect" % V.izumi_reflect % Optional,
+      "io.monix" %%% "monix" % V.monix % Optional,
+      "io.monix" %%% "monix-bio" % V.monix_bio % Optional,
+      "dev.zio" %%% "zio-interop-cats" % V.zio_interop_cats % Optional excludeAll("dev.zio" %% "izumi-reflect")
+    )
+  )
+  .settings(
     organization := "io.7mind.izumi",
-    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
-    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
-    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
-    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -1038,28 +1111,38 @@ lazy val `fundamentals-orphans` = project.in(file("fundamentals/fundamentals-orp
       case (_, _) => Seq.empty
     } }
   )
+  .jvmSettings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head
+  )
+  .jsSettings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := false,
+    scalaJSLinkerConfig := { scalaJSLinkerConfig.value.withModuleKind(ModuleKind.CommonJSModule) }
+  )
+lazy val `fundamentals-orphansJVM` = `fundamentals-orphans`.jvm
+  .disablePlugins(AssemblyPlugin)
+lazy val `fundamentals-orphansJS` = `fundamentals-orphans`.js
   .disablePlugins(AssemblyPlugin)
 
-lazy val `fundamentals-literals` = project.in(file("fundamentals/fundamentals-literals"))
+lazy val `fundamentals-literals` = crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Pure).in(file("fundamentals/fundamentals-literals"))
   .settings(
     libraryDependencies ++= Seq(
       compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
-      "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
-      "org.scalatest" %% "scalatest" % V.scalatest % Test,
+      "org.scala-lang.modules" %%% "scala-collection-compat" % V.collection_compat,
+      "org.scalatest" %%% "scalatest" % V.scalatest % Test,
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided
     )
   )
   .settings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
-    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
-    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
-    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
-    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -1155,9 +1238,28 @@ lazy val `fundamentals-literals` = project.in(file("fundamentals/fundamentals-li
       case (_, _) => Seq.empty
     } }
   )
+  .jvmSettings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head
+  )
+  .jsSettings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := false,
+    scalaJSLinkerConfig := { scalaJSLinkerConfig.value.withModuleKind(ModuleKind.CommonJSModule) }
+  )
+lazy val `fundamentals-literalsJVM` = `fundamentals-literals`.jvm
+  .disablePlugins(AssemblyPlugin)
+lazy val `fundamentals-literalsJS` = `fundamentals-literals`.js
   .disablePlugins(AssemblyPlugin)
 
-lazy val `distage-core-api` = project.in(file("distage/distage-core-api"))
+lazy val `distage-core-api` = crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Pure).in(file("distage/distage-core-api"))
   .dependsOn(
     `fundamentals-reflection` % "test->compile;compile->compile",
     `fundamentals-bio` % "test->compile;compile->compile"
@@ -1165,31 +1267,22 @@ lazy val `distage-core-api` = project.in(file("distage/distage-core-api"))
   .settings(
     libraryDependencies ++= Seq(
       compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
-      "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
-      "org.scalatest" %% "scalatest" % V.scalatest % Test,
-      "org.typelevel" %% "cats-core" % V.cats % Optional,
-      "org.typelevel" %% "cats-effect" % V.cats_effect % Optional,
-      "dev.zio" %% "zio" % V.zio % Optional excludeAll("dev.zio" %% "izumi-reflect"),
-      "dev.zio" %% "izumi-reflect" % V.izumi_reflect % Optional,
-      "org.typelevel" %% "cats-core" % V.cats % Test,
-      "org.typelevel" %% "cats-effect" % V.cats_effect % Test,
-      "dev.zio" %% "zio" % V.zio % Test excludeAll("dev.zio" %% "izumi-reflect"),
-      "dev.zio" %% "izumi-reflect" % V.izumi_reflect % Test,
-      "io.monix" %% "monix-bio" % V.monix_bio % Test,
+      "org.scala-lang.modules" %%% "scala-collection-compat" % V.collection_compat,
+      "org.scalatest" %%% "scalatest" % V.scalatest % Test,
+      "org.typelevel" %%% "cats-core" % V.cats % Optional,
+      "org.typelevel" %%% "cats-effect" % V.cats_effect % Optional,
+      "dev.zio" %%% "zio" % V.zio % Optional excludeAll("dev.zio" %% "izumi-reflect"),
+      "dev.zio" %%% "izumi-reflect" % V.izumi_reflect % Optional,
+      "org.typelevel" %%% "cats-core" % V.cats % Test,
+      "org.typelevel" %%% "cats-effect" % V.cats_effect % Test,
+      "dev.zio" %%% "zio" % V.zio % Test excludeAll("dev.zio" %% "izumi-reflect"),
+      "dev.zio" %%% "izumi-reflect" % V.izumi_reflect % Test,
+      "io.monix" %%% "monix-bio" % V.monix_bio % Test,
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided
     )
   )
   .settings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
-    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
-    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
-    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
-    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -1285,11 +1378,30 @@ lazy val `distage-core-api` = project.in(file("distage/distage-core-api"))
       case (_, _) => Seq.empty
     } }
   )
+  .jvmSettings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head
+  )
+  .jsSettings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := false,
+    scalaJSLinkerConfig := { scalaJSLinkerConfig.value.withModuleKind(ModuleKind.CommonJSModule) }
+  )
+lazy val `distage-core-apiJVM` = `distage-core-api`.jvm
+  .disablePlugins(AssemblyPlugin)
+lazy val `distage-core-apiJS` = `distage-core-api`.js
   .disablePlugins(AssemblyPlugin)
 
 lazy val `distage-core-proxy-cglib` = project.in(file("distage/distage-core-proxy-cglib"))
   .dependsOn(
-    `distage-core-api` % "test->compile;compile->compile"
+    `distage-core-apiJVM` % "test->compile;compile->compile"
   )
   .settings(
     libraryDependencies ++= Seq(
@@ -1306,10 +1418,6 @@ lazy val `distage-core-proxy-cglib` = project.in(file("distage/distage-core-prox
     ),
     scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
-    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
-    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
-    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
-    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -1407,138 +1515,155 @@ lazy val `distage-core-proxy-cglib` = project.in(file("distage/distage-core-prox
   )
   .disablePlugins(AssemblyPlugin)
 
-lazy val `distage-core` = project.in(file("distage/distage-core"))
+lazy val `distage-core` = crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Pure).in(file("distage/distage-core"))
   .dependsOn(
-    `distage-core-api` % "test->compile;compile->compile",
-    `distage-core-proxy-cglib` % "test->compile;compile->compile"
+    `distage-core-api` % "test->compile;compile->compile"
   )
   .settings(
     libraryDependencies ++= Seq(
       compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
-      "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
-      "org.scalatest" %% "scalatest" % V.scalatest % Test,
-      "org.typelevel" %% "cats-core" % V.cats % Optional,
-      "org.typelevel" %% "cats-effect" % V.cats_effect % Optional,
-      "dev.zio" %% "zio" % V.zio % Optional excludeAll("dev.zio" %% "izumi-reflect"),
-      "dev.zio" %% "izumi-reflect" % V.izumi_reflect % Optional,
-      "io.monix" %% "monix" % V.monix % Optional,
-      "io.monix" %% "monix-bio" % V.monix_bio % Optional,
-      "dev.zio" %% "zio-interop-cats" % V.zio_interop_cats % Optional excludeAll("dev.zio" %% "izumi-reflect"),
+      "org.scala-lang.modules" %%% "scala-collection-compat" % V.collection_compat,
+      "org.scalatest" %%% "scalatest" % V.scalatest % Test,
+      "org.typelevel" %%% "cats-core" % V.cats % Optional,
+      "org.typelevel" %%% "cats-effect" % V.cats_effect % Optional,
+      "dev.zio" %%% "zio" % V.zio % Optional excludeAll("dev.zio" %% "izumi-reflect"),
+      "dev.zio" %%% "izumi-reflect" % V.izumi_reflect % Optional,
+      "io.monix" %%% "monix" % V.monix % Optional,
+      "io.monix" %%% "monix-bio" % V.monix_bio % Optional,
+      "dev.zio" %%% "zio-interop-cats" % V.zio_interop_cats % Optional excludeAll("dev.zio" %% "izumi-reflect"),
       "javax.inject" % "javax.inject" % "1" % Test
     )
   )
   .settings(
+    organization := "io.7mind.izumi",
+    scalacOptions ++= Seq(
+      s"-Xmacro-settings:product-name=${name.value}",
+      s"-Xmacro-settings:product-version=${version.value}",
+      s"-Xmacro-settings:product-group=${organization.value}",
+      s"-Xmacro-settings:scala-version=${scalaVersion.value}",
+      s"-Xmacro-settings:scala-versions=${crossScalaVersions.value.mkString(":")}"
+    ),
+    Test / testOptions += Tests.Argument("-oDF"),
+    scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
+      case (_, "2.12.14") => Seq(
+        "-Xsource:2.13",
+        "-Ypartial-unification",
+        if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
+        "-Wconf:cat=optimizer:warning",
+        "-Wconf:cat=other-match-analysis:error",
+        "-Wconf:msg=kind-projector:silent",
+        "-Ybackend-parallelism",
+        math.min(16, math.max(1, sys.runtime.availableProcessors() - 1)).toString,
+        "-Xlint:adapted-args",
+        "-Xlint:by-name-right-associative",
+        "-Xlint:constant",
+        "-Xlint:delayedinit-select",
+        "-Xlint:doc-detached",
+        "-Xlint:inaccessible",
+        "-Xlint:infer-any",
+        "-Xlint:missing-interpolator",
+        "-Xlint:nullary-override",
+        "-Xlint:nullary-unit",
+        "-Xlint:option-implicit",
+        "-Xlint:package-object-classes",
+        "-Xlint:poly-implicit-overload",
+        "-Xlint:private-shadow",
+        "-Xlint:stars-align",
+        "-Xlint:type-parameter-shadow",
+        "-Xlint:unsound-match",
+        "-opt-warnings:_",
+        "-Ywarn-extra-implicit",
+        "-Ywarn-unused:_",
+        "-Ywarn-adapted-args",
+        "-Ywarn-dead-code",
+        "-Ywarn-inaccessible",
+        "-Ywarn-infer-any",
+        "-Ywarn-nullary-override",
+        "-Ywarn-nullary-unit",
+        "-Ywarn-numeric-widen",
+        "-Ywarn-unused-import",
+        "-Ywarn-value-discard",
+        "-Ycache-plugin-class-loader:always",
+        "-Ycache-macro-class-loader:last-modified",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
+      )
+      case (_, "2.13.6") => Seq(
+        "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
+        if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
+        "-Wconf:cat=optimizer:warning",
+        "-Wconf:cat=other-match-analysis:error",
+        "-Wconf:msg=kind-projector:silent",
+        "-Ybackend-parallelism",
+        math.min(16, math.max(1, sys.runtime.availableProcessors() - 1)).toString,
+        "-Wdead-code",
+        "-Wextra-implicit",
+        "-Wnumeric-widen",
+        "-Woctal-literal",
+        "-Wvalue-discard",
+        "-Wunused:_",
+        "-Wmacros:after",
+        "-Ycache-plugin-class-loader:always",
+        "-Ycache-macro-class-loader:last-modified",
+        "-Wunused:-synthetics",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
+      )
+      case (_, _) => Seq.empty
+    } },
+    scalacOptions += "-Wconf:msg=nowarn:silent",
+    scalacOptions += "-Wconf:msg=parameter.value.x\\$4.in.anonymous.function.is.never.used:silent",
+    scalacOptions += "-Wconf:msg=package.object.inheritance:silent",
+    Compile / sbt.Keys.doc / scalacOptions -= "-Wconf:any:error",
+    scalacOptions ++= Seq(
+      s"-Xmacro-settings:scalatest-version=${V.scalatest}",
+      s"-Xmacro-settings:is-ci=${insideCI.value}"
+    ),
+    scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
+      case (false, "2.12.14") => Seq(
+        "-opt:l:inline",
+        "-opt-inline-from:izumi.**"
+      )
+      case (false, "2.13.6") => Seq(
+        "-opt:l:inline",
+        "-opt-inline-from:izumi.**"
+      )
+      case (_, _) => Seq.empty
+    } }
+  )
+  .jvmSettings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head
+  )
+  .jsSettings(
     crossScalaVersions := Seq(
       "2.13.6",
       "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    organization := "io.7mind.izumi",
-    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
-    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
-    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
-    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
-    scalacOptions ++= Seq(
-      s"-Xmacro-settings:product-name=${name.value}",
-      s"-Xmacro-settings:product-version=${version.value}",
-      s"-Xmacro-settings:product-group=${organization.value}",
-      s"-Xmacro-settings:scala-version=${scalaVersion.value}",
-      s"-Xmacro-settings:scala-versions=${crossScalaVersions.value.mkString(":")}"
-    ),
-    Test / testOptions += Tests.Argument("-oDF"),
-    scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.14") => Seq(
-        "-Xsource:2.13",
-        "-Ypartial-unification",
-        if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
-        "-Wconf:cat=optimizer:warning",
-        "-Wconf:cat=other-match-analysis:error",
-        "-Wconf:msg=kind-projector:silent",
-        "-Ybackend-parallelism",
-        math.min(16, math.max(1, sys.runtime.availableProcessors() - 1)).toString,
-        "-Xlint:adapted-args",
-        "-Xlint:by-name-right-associative",
-        "-Xlint:constant",
-        "-Xlint:delayedinit-select",
-        "-Xlint:doc-detached",
-        "-Xlint:inaccessible",
-        "-Xlint:infer-any",
-        "-Xlint:missing-interpolator",
-        "-Xlint:nullary-override",
-        "-Xlint:nullary-unit",
-        "-Xlint:option-implicit",
-        "-Xlint:package-object-classes",
-        "-Xlint:poly-implicit-overload",
-        "-Xlint:private-shadow",
-        "-Xlint:stars-align",
-        "-Xlint:type-parameter-shadow",
-        "-Xlint:unsound-match",
-        "-opt-warnings:_",
-        "-Ywarn-extra-implicit",
-        "-Ywarn-unused:_",
-        "-Ywarn-adapted-args",
-        "-Ywarn-dead-code",
-        "-Ywarn-inaccessible",
-        "-Ywarn-infer-any",
-        "-Ywarn-nullary-override",
-        "-Ywarn-nullary-unit",
-        "-Ywarn-numeric-widen",
-        "-Ywarn-unused-import",
-        "-Ywarn-value-discard",
-        "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified",
-        "-Xsource:3",
-        "-P:kind-projector:underscore-placeholders"
-      )
-      case (_, "2.13.6") => Seq(
-        "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
-        if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
-        "-Wconf:cat=optimizer:warning",
-        "-Wconf:cat=other-match-analysis:error",
-        "-Wconf:msg=kind-projector:silent",
-        "-Ybackend-parallelism",
-        math.min(16, math.max(1, sys.runtime.availableProcessors() - 1)).toString,
-        "-Wdead-code",
-        "-Wextra-implicit",
-        "-Wnumeric-widen",
-        "-Woctal-literal",
-        "-Wvalue-discard",
-        "-Wunused:_",
-        "-Wmacros:after",
-        "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified",
-        "-Wunused:-synthetics",
-        "-Xsource:3",
-        "-P:kind-projector:underscore-placeholders"
-      )
-      case (_, _) => Seq.empty
-    } },
-    scalacOptions += "-Wconf:msg=nowarn:silent",
-    scalacOptions += "-Wconf:msg=parameter.value.x\\$4.in.anonymous.function.is.never.used:silent",
-    scalacOptions += "-Wconf:msg=package.object.inheritance:silent",
-    Compile / sbt.Keys.doc / scalacOptions -= "-Wconf:any:error",
-    scalacOptions ++= Seq(
-      s"-Xmacro-settings:scalatest-version=${V.scalatest}",
-      s"-Xmacro-settings:is-ci=${insideCI.value}"
-    ),
-    scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.14") => Seq(
-        "-opt:l:inline",
-        "-opt-inline-from:izumi.**"
-      )
-      case (false, "2.13.6") => Seq(
-        "-opt:l:inline",
-        "-opt-inline-from:izumi.**"
-      )
-      case (_, _) => Seq.empty
-    } }
+    coverageEnabled := false,
+    scalaJSLinkerConfig := { scalaJSLinkerConfig.value.withModuleKind(ModuleKind.CommonJSModule) }
+  )
+lazy val `distage-coreJVM` = `distage-core`.jvm
+  .dependsOn(
+    `distage-core-proxy-cglib` % "test->compile;compile->compile"
+  )
+  .disablePlugins(AssemblyPlugin)
+lazy val `distage-coreJS` = `distage-core`.js
+  .settings(
+    libraryDependencies ++= Seq(
+      "io.github.cquiroz" %%% "scala-java-time" % V.scala_java_time % Test
+    )
   )
   .disablePlugins(AssemblyPlugin)
 
 lazy val `distage-extension-config` = project.in(file("distage/distage-extension-config"))
   .dependsOn(
-    `distage-core-api` % "test->compile;compile->compile",
-    `distage-core` % "test->compile"
+    `distage-core-apiJVM` % "test->compile;compile->compile",
+    `distage-coreJVM` % "test->compile"
   )
   .settings(
     libraryDependencies ++= Seq(
@@ -1557,10 +1682,6 @@ lazy val `distage-extension-config` = project.in(file("distage/distage-extension
     ),
     scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
-    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
-    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
-    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
-    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -1680,10 +1801,10 @@ lazy val `distage-extension-config` = project.in(file("distage/distage-extension
 
 lazy val `distage-extension-plugins` = project.in(file("distage/distage-extension-plugins"))
   .dependsOn(
-    `distage-core-api` % "test->compile;compile->compile",
-    `distage-core` % "test->compile",
+    `distage-core-apiJVM` % "test->compile;compile->compile",
+    `distage-coreJVM` % "test->compile",
     `distage-extension-config` % "test->compile",
-    `logstage-core` % "test->compile"
+    `logstage-coreJVM` % "test->compile"
   )
   .settings(
     libraryDependencies ++= Seq(
@@ -1701,10 +1822,6 @@ lazy val `distage-extension-plugins` = project.in(file("distage/distage-extensio
     ),
     scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
-    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
-    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
-    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
-    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -1802,9 +1919,8 @@ lazy val `distage-extension-plugins` = project.in(file("distage/distage-extensio
   )
   .disablePlugins(AssemblyPlugin)
 
-lazy val `distage-extension-logstage` = project.in(file("distage/distage-extension-logstage"))
+lazy val `distage-extension-logstage` = crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Pure).in(file("distage/distage-extension-logstage"))
   .dependsOn(
-    `distage-extension-config` % "test->compile;compile->compile",
     `distage-core-api` % "test->compile;compile->compile",
     `distage-core` % "test->compile",
     `logstage-core` % "test->test;compile->compile"
@@ -1812,21 +1928,12 @@ lazy val `distage-extension-logstage` = project.in(file("distage/distage-extensi
   .settings(
     libraryDependencies ++= Seq(
       compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
-      "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
-      "org.scalatest" %% "scalatest" % V.scalatest % Test
+      "org.scala-lang.modules" %%% "scala-collection-compat" % V.collection_compat,
+      "org.scalatest" %%% "scalatest" % V.scalatest % Test
     )
   )
   .settings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
-    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
-    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
-    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
-    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -1922,11 +2029,30 @@ lazy val `distage-extension-logstage` = project.in(file("distage/distage-extensi
       case (_, _) => Seq.empty
     } }
   )
+  .jvmSettings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head
+  )
+  .jsSettings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := false,
+    scalaJSLinkerConfig := { scalaJSLinkerConfig.value.withModuleKind(ModuleKind.CommonJSModule) }
+  )
+lazy val `distage-extension-logstageJVM` = `distage-extension-logstage`.jvm
+  .disablePlugins(AssemblyPlugin)
+lazy val `distage-extension-logstageJS` = `distage-extension-logstage`.js
   .disablePlugins(AssemblyPlugin)
 
 lazy val `distage-framework-api` = project.in(file("distage/distage-framework-api"))
   .dependsOn(
-    `distage-core-api` % "test->compile;compile->compile"
+    `distage-core-apiJVM` % "test->compile;compile->compile"
   )
   .settings(
     libraryDependencies ++= Seq(
@@ -1943,10 +2069,6 @@ lazy val `distage-framework-api` = project.in(file("distage/distage-framework-ap
     ),
     scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
-    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
-    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
-    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
-    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -2046,9 +2168,9 @@ lazy val `distage-framework-api` = project.in(file("distage/distage-framework-ap
 
 lazy val `distage-framework` = project.in(file("distage/distage-framework"))
   .dependsOn(
-    `distage-extension-logstage` % "test->compile;compile->compile",
-    `logstage-rendering-circe` % "test->compile;compile->compile",
-    `distage-core` % "test->compile;compile->compile",
+    `distage-extension-logstageJVM` % "test->compile;compile->compile",
+    `logstage-rendering-circeJVM` % "test->compile;compile->compile",
+    `distage-coreJVM` % "test->compile;compile->compile",
     `distage-framework-api` % "test->compile;compile->compile",
     `distage-extension-plugins` % "test->compile;compile->compile",
     `distage-extension-config` % "test->compile;compile->compile",
@@ -2076,10 +2198,6 @@ lazy val `distage-framework` = project.in(file("distage/distage-framework"))
     ),
     scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
-    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
-    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
-    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
-    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -2199,10 +2317,10 @@ lazy val `distage-framework` = project.in(file("distage/distage-framework"))
 
 lazy val `distage-framework-docker` = project.in(file("distage/distage-framework-docker"))
   .dependsOn(
-    `distage-core` % "test->compile;compile->compile",
+    `distage-coreJVM` % "test->compile;compile->compile",
     `distage-extension-config` % "test->compile;compile->compile",
     `distage-framework-api` % "test->compile;compile->compile",
-    `distage-extension-logstage` % "test->compile;compile->compile",
+    `distage-extension-logstageJVM` % "test->compile;compile->compile",
     `distage-testkit-scalatest` % "test->compile"
   )
   .settings(
@@ -2226,10 +2344,6 @@ lazy val `distage-framework-docker` = project.in(file("distage/distage-framework
     ),
     scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
-    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
-    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
-    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
-    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -2345,10 +2459,6 @@ lazy val `distage-testkit-core` = project.in(file("distage/distage-testkit-core"
     ),
     scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
-    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
-    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
-    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
-    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -2449,7 +2559,7 @@ lazy val `distage-testkit-core` = project.in(file("distage/distage-testkit-core"
 lazy val `distage-testkit-scalatest` = project.in(file("distage/distage-testkit-scalatest"))
   .dependsOn(
     `distage-testkit-core` % "test->compile;compile->compile",
-    `distage-core` % "test->compile;compile->compile",
+    `distage-coreJVM` % "test->compile;compile->compile",
     `distage-extension-plugins` % "test->compile;compile->compile",
     `distage-framework` % "test->test;compile->compile"
   )
@@ -2475,10 +2585,6 @@ lazy val `distage-testkit-scalatest` = project.in(file("distage/distage-testkit-
     ),
     scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
-    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
-    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
-    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
-    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -2576,7 +2682,7 @@ lazy val `distage-testkit-scalatest` = project.in(file("distage/distage-testkit-
   )
   .disablePlugins(AssemblyPlugin)
 
-lazy val `logstage-core` = project.in(file("logstage/logstage-core"))
+lazy val `logstage-core` = crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Pure).in(file("logstage/logstage-core"))
   .dependsOn(
     `fundamentals-bio` % "test->compile;compile->compile",
     `fundamentals-platform` % "test->compile;compile->compile"
@@ -2584,26 +2690,17 @@ lazy val `logstage-core` = project.in(file("logstage/logstage-core"))
   .settings(
     libraryDependencies ++= Seq(
       compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
-      "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
-      "org.scalatest" %% "scalatest" % V.scalatest % Test,
+      "org.scala-lang.modules" %%% "scala-collection-compat" % V.collection_compat,
+      "org.scalatest" %%% "scalatest" % V.scalatest % Test,
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided,
-      "org.typelevel" %% "cats-core" % V.cats % Optional,
-      "org.typelevel" %% "cats-effect" % V.cats_effect % Optional,
-      "dev.zio" %% "zio" % V.zio % Optional excludeAll("dev.zio" %% "izumi-reflect"),
-      "dev.zio" %% "izumi-reflect" % V.izumi_reflect % Optional
+      "org.typelevel" %%% "cats-core" % V.cats % Optional,
+      "org.typelevel" %%% "cats-effect" % V.cats_effect % Optional,
+      "dev.zio" %%% "zio" % V.zio % Optional excludeAll("dev.zio" %% "izumi-reflect"),
+      "dev.zio" %%% "izumi-reflect" % V.izumi_reflect % Optional
     )
   )
   .settings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
-    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
-    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
-    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
-    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -2699,9 +2796,33 @@ lazy val `logstage-core` = project.in(file("logstage/logstage-core"))
       case (_, _) => Seq.empty
     } }
   )
+  .jvmSettings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head
+  )
+  .jsSettings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := false,
+    scalaJSLinkerConfig := { scalaJSLinkerConfig.value.withModuleKind(ModuleKind.CommonJSModule) }
+  )
+lazy val `logstage-coreJVM` = `logstage-core`.jvm
+  .disablePlugins(AssemblyPlugin)
+lazy val `logstage-coreJS` = `logstage-core`.js
+  .settings(
+    libraryDependencies ++= Seq(
+      "io.github.cquiroz" %%% "scala-java-time" % V.scala_java_time
+    )
+  )
   .disablePlugins(AssemblyPlugin)
 
-lazy val `logstage-rendering-circe` = project.in(file("logstage/logstage-rendering-circe"))
+lazy val `logstage-rendering-circe` = crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Pure).in(file("logstage/logstage-rendering-circe"))
   .dependsOn(
     `fundamentals-json-circe` % "test->compile;compile->compile",
     `logstage-core` % "test->test;compile->compile"
@@ -2709,24 +2830,15 @@ lazy val `logstage-rendering-circe` = project.in(file("logstage/logstage-renderi
   .settings(
     libraryDependencies ++= Seq(
       compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
-      "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
-      "org.scalatest" %% "scalatest" % V.scalatest % Test,
+      "org.scala-lang.modules" %%% "scala-collection-compat" % V.collection_compat,
+      "org.scalatest" %%% "scalatest" % V.scalatest % Test,
       "org.typelevel" %% "jawn-parser" % V.jawn % Test,
-      "io.circe" %% "circe-parser" % V.circe % Test,
-      "io.circe" %% "circe-literal" % V.circe % Test
+      "io.circe" %%% "circe-parser" % V.circe % Test,
+      "io.circe" %%% "circe-literal" % V.circe % Test
     )
   )
   .settings(
-    crossScalaVersions := Seq(
-      "2.13.6",
-      "2.12.14"
-    ),
-    scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
-    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
-    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
-    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
-    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -2822,11 +2934,30 @@ lazy val `logstage-rendering-circe` = project.in(file("logstage/logstage-renderi
       case (_, _) => Seq.empty
     } }
   )
+  .jvmSettings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head
+  )
+  .jsSettings(
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := false,
+    scalaJSLinkerConfig := { scalaJSLinkerConfig.value.withModuleKind(ModuleKind.CommonJSModule) }
+  )
+lazy val `logstage-rendering-circeJVM` = `logstage-rendering-circe`.jvm
+  .disablePlugins(AssemblyPlugin)
+lazy val `logstage-rendering-circeJS` = `logstage-rendering-circe`.js
   .disablePlugins(AssemblyPlugin)
 
 lazy val `logstage-adapter-slf4j` = project.in(file("logstage/logstage-adapter-slf4j"))
   .dependsOn(
-    `logstage-core` % "test->test;compile->compile"
+    `logstage-coreJVM` % "test->test;compile->compile"
   )
   .settings(
     libraryDependencies ++= Seq(
@@ -2843,10 +2974,6 @@ lazy val `logstage-adapter-slf4j` = project.in(file("logstage/logstage-adapter-s
     ),
     scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
-    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
-    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
-    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
-    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -2949,7 +3076,7 @@ lazy val `logstage-adapter-slf4j` = project.in(file("logstage/logstage-adapter-s
 
 lazy val `logstage-sink-slf4j` = project.in(file("logstage/logstage-sink-slf4j"))
   .dependsOn(
-    `logstage-core` % "test->test;compile->compile"
+    `logstage-coreJVM` % "test->test;compile->compile"
   )
   .settings(
     libraryDependencies ++= Seq(
@@ -2967,10 +3094,6 @@ lazy val `logstage-sink-slf4j` = project.in(file("logstage/logstage-sink-slf4j")
     ),
     scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
-    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
-    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
-    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
-    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -3070,28 +3193,28 @@ lazy val `logstage-sink-slf4j` = project.in(file("logstage/logstage-sink-slf4j")
 
 lazy val `microsite` = project.in(file("doc/microsite"))
   .dependsOn(
-    `fundamentals-collections` % "test->compile;compile->compile",
-    `fundamentals-platform` % "test->compile;compile->compile",
-    `fundamentals-language` % "test->compile;compile->compile",
-    `fundamentals-reflection` % "test->compile;compile->compile",
-    `fundamentals-functional` % "test->compile;compile->compile",
-    `fundamentals-bio` % "test->compile;compile->compile",
-    `fundamentals-json-circe` % "test->compile;compile->compile",
-    `fundamentals-orphans` % "test->compile;compile->compile",
-    `fundamentals-literals` % "test->compile;compile->compile",
-    `distage-core-api` % "test->compile;compile->compile",
+    `fundamentals-collectionsJVM` % "test->compile;compile->compile",
+    `fundamentals-platformJVM` % "test->compile;compile->compile",
+    `fundamentals-languageJVM` % "test->compile;compile->compile",
+    `fundamentals-reflectionJVM` % "test->compile;compile->compile",
+    `fundamentals-functionalJVM` % "test->compile;compile->compile",
+    `fundamentals-bioJVM` % "test->compile;compile->compile",
+    `fundamentals-json-circeJVM` % "test->compile;compile->compile",
+    `fundamentals-orphansJVM` % "test->compile;compile->compile",
+    `fundamentals-literalsJVM` % "test->compile;compile->compile",
+    `distage-core-apiJVM` % "test->compile;compile->compile",
     `distage-core-proxy-cglib` % "test->compile;compile->compile",
-    `distage-core` % "test->compile;compile->compile",
+    `distage-coreJVM` % "test->compile;compile->compile",
     `distage-extension-config` % "test->compile;compile->compile",
     `distage-extension-plugins` % "test->compile;compile->compile",
-    `distage-extension-logstage` % "test->compile;compile->compile",
+    `distage-extension-logstageJVM` % "test->compile;compile->compile",
     `distage-framework-api` % "test->compile;compile->compile",
     `distage-framework` % "test->compile;compile->compile",
     `distage-framework-docker` % "test->compile;compile->compile",
     `distage-testkit-core` % "test->compile;compile->compile",
     `distage-testkit-scalatest` % "test->compile;compile->compile",
-    `logstage-core` % "test->compile;compile->compile",
-    `logstage-rendering-circe` % "test->compile;compile->compile",
+    `logstage-coreJVM` % "test->compile;compile->compile",
+    `logstage-rendering-circeJVM` % "test->compile;compile->compile",
     `logstage-adapter-slf4j` % "test->compile;compile->compile",
     `logstage-sink-slf4j` % "test->compile;compile->compile"
   )
@@ -3118,10 +3241,6 @@ lazy val `microsite` = project.in(file("doc/microsite"))
     ),
     scalaVersion := crossScalaVersions.value.head,
     organization := "io.7mind.izumi",
-    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
-    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
-    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
-    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -3295,10 +3414,6 @@ lazy val `sbt-izumi-deps` = project.in(file("sbt-plugins/sbt-izumi-deps"))
     scalaVersion := crossScalaVersions.value.head,
     coverageEnabled := false,
     organization := "io.7mind.izumi",
-    Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
-    Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
-    Test / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/test/scala" ,
-    Test / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/test/resources" ,
     scalacOptions ++= Seq(
       s"-Xmacro-settings:product-name=${name.value}",
       s"-Xmacro-settings:product-version=${version.value}",
@@ -3409,15 +3524,24 @@ lazy val `fundamentals` = (project in file(".agg/fundamentals-fundamentals"))
   )
   .disablePlugins(AssemblyPlugin)
   .aggregate(
-    `fundamentals-collections`,
-    `fundamentals-platform`,
-    `fundamentals-language`,
-    `fundamentals-reflection`,
-    `fundamentals-functional`,
-    `fundamentals-bio`,
-    `fundamentals-json-circe`,
-    `fundamentals-orphans`,
-    `fundamentals-literals`
+    `fundamentals-collectionsJVM`,
+    `fundamentals-collectionsJS`,
+    `fundamentals-platformJVM`,
+    `fundamentals-platformJS`,
+    `fundamentals-languageJVM`,
+    `fundamentals-languageJS`,
+    `fundamentals-reflectionJVM`,
+    `fundamentals-reflectionJS`,
+    `fundamentals-functionalJVM`,
+    `fundamentals-functionalJS`,
+    `fundamentals-bioJVM`,
+    `fundamentals-bioJS`,
+    `fundamentals-json-circeJVM`,
+    `fundamentals-json-circeJS`,
+    `fundamentals-orphansJVM`,
+    `fundamentals-orphansJS`,
+    `fundamentals-literalsJVM`,
+    `fundamentals-literalsJS`
   )
 
 lazy val `fundamentals-jvm` = (project in file(".agg/fundamentals-fundamentals-jvm"))
@@ -3431,15 +3555,37 @@ lazy val `fundamentals-jvm` = (project in file(".agg/fundamentals-fundamentals-j
   )
   .disablePlugins(AssemblyPlugin)
   .aggregate(
-    `fundamentals-collections`,
-    `fundamentals-platform`,
-    `fundamentals-language`,
-    `fundamentals-reflection`,
-    `fundamentals-functional`,
-    `fundamentals-bio`,
-    `fundamentals-json-circe`,
-    `fundamentals-orphans`,
-    `fundamentals-literals`
+    `fundamentals-collectionsJVM`,
+    `fundamentals-platformJVM`,
+    `fundamentals-languageJVM`,
+    `fundamentals-reflectionJVM`,
+    `fundamentals-functionalJVM`,
+    `fundamentals-bioJVM`,
+    `fundamentals-json-circeJVM`,
+    `fundamentals-orphansJVM`,
+    `fundamentals-literalsJVM`
+  )
+
+lazy val `fundamentals-js` = (project in file(".agg/fundamentals-fundamentals-js"))
+  .settings(
+    publish / skip := true,
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head
+  )
+  .disablePlugins(AssemblyPlugin)
+  .aggregate(
+    `fundamentals-collectionsJS`,
+    `fundamentals-platformJS`,
+    `fundamentals-languageJS`,
+    `fundamentals-reflectionJS`,
+    `fundamentals-functionalJS`,
+    `fundamentals-bioJS`,
+    `fundamentals-json-circeJS`,
+    `fundamentals-orphansJS`,
+    `fundamentals-literalsJS`
   )
 
 lazy val `distage` = (project in file(".agg/distage-distage"))
@@ -3453,12 +3599,15 @@ lazy val `distage` = (project in file(".agg/distage-distage"))
   )
   .disablePlugins(AssemblyPlugin)
   .aggregate(
-    `distage-core-api`,
+    `distage-core-apiJVM`,
+    `distage-core-apiJS`,
     `distage-core-proxy-cglib`,
-    `distage-core`,
+    `distage-coreJVM`,
+    `distage-coreJS`,
     `distage-extension-config`,
     `distage-extension-plugins`,
-    `distage-extension-logstage`,
+    `distage-extension-logstageJVM`,
+    `distage-extension-logstageJS`,
     `distage-framework-api`,
     `distage-framework`,
     `distage-framework-docker`,
@@ -3477,12 +3626,36 @@ lazy val `distage-jvm` = (project in file(".agg/distage-distage-jvm"))
   )
   .disablePlugins(AssemblyPlugin)
   .aggregate(
-    `distage-core-api`,
+    `distage-core-apiJVM`,
     `distage-core-proxy-cglib`,
-    `distage-core`,
+    `distage-coreJVM`,
     `distage-extension-config`,
     `distage-extension-plugins`,
-    `distage-extension-logstage`,
+    `distage-extension-logstageJVM`,
+    `distage-framework-api`,
+    `distage-framework`,
+    `distage-framework-docker`,
+    `distage-testkit-core`,
+    `distage-testkit-scalatest`
+  )
+
+lazy val `distage-js` = (project in file(".agg/distage-distage-js"))
+  .settings(
+    publish / skip := true,
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head
+  )
+  .disablePlugins(AssemblyPlugin)
+  .aggregate(
+    `distage-core-apiJS`,
+    `distage-core-proxy-cglib`,
+    `distage-coreJS`,
+    `distage-extension-config`,
+    `distage-extension-plugins`,
+    `distage-extension-logstageJS`,
     `distage-framework-api`,
     `distage-framework`,
     `distage-framework-docker`,
@@ -3501,8 +3674,10 @@ lazy val `logstage` = (project in file(".agg/logstage-logstage"))
   )
   .disablePlugins(AssemblyPlugin)
   .aggregate(
-    `logstage-core`,
-    `logstage-rendering-circe`,
+    `logstage-coreJVM`,
+    `logstage-coreJS`,
+    `logstage-rendering-circeJVM`,
+    `logstage-rendering-circeJS`,
     `logstage-adapter-slf4j`,
     `logstage-sink-slf4j`
   )
@@ -3518,8 +3693,25 @@ lazy val `logstage-jvm` = (project in file(".agg/logstage-logstage-jvm"))
   )
   .disablePlugins(AssemblyPlugin)
   .aggregate(
-    `logstage-core`,
-    `logstage-rendering-circe`,
+    `logstage-coreJVM`,
+    `logstage-rendering-circeJVM`,
+    `logstage-adapter-slf4j`,
+    `logstage-sink-slf4j`
+  )
+
+lazy val `logstage-js` = (project in file(".agg/logstage-logstage-js"))
+  .settings(
+    publish / skip := true,
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head
+  )
+  .disablePlugins(AssemblyPlugin)
+  .aggregate(
+    `logstage-coreJS`,
+    `logstage-rendering-circeJS`,
     `logstage-adapter-slf4j`,
     `logstage-sink-slf4j`
   )
@@ -3539,6 +3731,20 @@ lazy val `doc` = (project in file(".agg/doc-doc"))
   )
 
 lazy val `doc-jvm` = (project in file(".agg/doc-doc-jvm"))
+  .settings(
+    publish / skip := true,
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head
+  )
+  .disablePlugins(AssemblyPlugin)
+  .aggregate(
+    `microsite`
+  )
+
+lazy val `doc-js` = (project in file(".agg/doc-doc-js"))
   .settings(
     publish / skip := true,
     crossScalaVersions := Seq(
@@ -3574,6 +3780,17 @@ lazy val `sbt-plugins-jvm` = (project in file(".agg/sbt-plugins-sbt-plugins-jvm"
     `sbt-izumi-deps`
   )
 
+lazy val `sbt-plugins-js` = (project in file(".agg/sbt-plugins-sbt-plugins-js"))
+  .settings(
+    publish / skip := true,
+    crossScalaVersions := Nil,
+    scalaVersion := "2.12.14"
+  )
+  .disablePlugins(AssemblyPlugin)
+  .aggregate(
+    `sbt-izumi-deps`
+  )
+
 lazy val `izumi-jvm` = (project in file(".agg/.agg-jvm"))
   .settings(
     publish / skip := true,
@@ -3589,6 +3806,23 @@ lazy val `izumi-jvm` = (project in file(".agg/.agg-jvm"))
     `distage-jvm`,
     `logstage-jvm`,
     `sbt-plugins-jvm`
+  )
+
+lazy val `izumi-js` = (project in file(".agg/.agg-js"))
+  .settings(
+    publish / skip := true,
+    crossScalaVersions := Seq(
+      "2.13.6",
+      "2.12.14"
+    ),
+    scalaVersion := crossScalaVersions.value.head
+  )
+  .disablePlugins(AssemblyPlugin)
+  .aggregate(
+    `fundamentals-js`,
+    `distage-js`,
+    `logstage-js`,
+    `sbt-plugins-js`
   )
 
 lazy val `izumi` = (project in file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,6 @@ lazy val `fundamentals-collections` = project.in(file("fundamentals/fundamentals
       "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -163,7 +162,6 @@ lazy val `fundamentals-platform` = project.in(file("fundamentals/fundamentals-pl
       "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -284,7 +282,6 @@ lazy val `fundamentals-language` = project.in(file("fundamentals/fundamentals-la
       "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -427,7 +424,6 @@ lazy val `fundamentals-reflection` = project.in(file("fundamentals/fundamentals-
       "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -564,7 +560,6 @@ lazy val `fundamentals-functional` = project.in(file("fundamentals/fundamentals-
       "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -696,7 +691,6 @@ lazy val `fundamentals-bio` = project.in(file("fundamentals/fundamentals-bio"))
       "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -821,7 +815,6 @@ lazy val `fundamentals-json-circe` = project.in(file("fundamentals/fundamentals-
       "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -945,7 +938,6 @@ lazy val `fundamentals-orphans` = project.in(file("fundamentals/fundamentals-orp
       "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -1063,7 +1055,6 @@ lazy val `fundamentals-literals` = project.in(file("fundamentals/fundamentals-li
       "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -1194,7 +1185,6 @@ lazy val `distage-core-api` = project.in(file("distage/distage-core-api"))
       "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -1315,7 +1305,6 @@ lazy val `distage-core-proxy-cglib` = project.in(file("distage/distage-core-prox
       "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -1444,7 +1433,6 @@ lazy val `distage-core` = project.in(file("distage/distage-core"))
       "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -1568,7 +1556,6 @@ lazy val `distage-extension-config` = project.in(file("distage/distage-extension
       "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -1713,7 +1700,6 @@ lazy val `distage-extension-plugins` = project.in(file("distage/distage-extensio
       "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -1836,7 +1822,6 @@ lazy val `distage-extension-logstage` = project.in(file("distage/distage-extensi
       "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -1957,7 +1942,6 @@ lazy val `distage-framework-api` = project.in(file("distage/distage-framework-ap
       "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -2091,7 +2075,6 @@ lazy val `distage-framework` = project.in(file("distage/distage-framework"))
       "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -2242,7 +2225,6 @@ lazy val `distage-framework-docker` = project.in(file("distage/distage-framework
       "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -2362,7 +2344,6 @@ lazy val `distage-testkit-core` = project.in(file("distage/distage-testkit-core"
       "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -2493,7 +2474,6 @@ lazy val `distage-testkit-scalatest` = project.in(file("distage/distage-testkit-
       "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -2619,7 +2599,6 @@ lazy val `logstage-core` = project.in(file("logstage/logstage-core"))
       "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -2743,7 +2722,6 @@ lazy val `logstage-rendering-circe` = project.in(file("logstage/logstage-renderi
       "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -2864,7 +2842,6 @@ lazy val `logstage-adapter-slf4j` = project.in(file("logstage/logstage-adapter-s
       "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -2989,7 +2966,6 @@ lazy val `logstage-sink-slf4j` = project.in(file("logstage/logstage-sink-slf4j")
       "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -3141,7 +3117,6 @@ lazy val `microsite` = project.in(file("doc/microsite"))
       "2.12.14"
     ),
     scalaVersion := crossScalaVersions.value.head,
-    coverageEnabled := false,
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,

--- a/build.sbt
+++ b/build.sbt
@@ -10,14 +10,14 @@ lazy val `fundamentals-collections` = project.in(file("fundamentals/fundamentals
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
+      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test
     )
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.6-bin-SNAPSHOT",
+      "2.13.6",
       "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -82,7 +82,7 @@ lazy val `fundamentals-collections` = project.in(file("fundamentals/fundamentals
         "-Xsource:3",
         "-P:kind-projector:underscore-placeholders"
       )
-      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (_, "2.13.6") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -118,7 +118,7 @@ lazy val `fundamentals-collections` = project.in(file("fundamentals/fundamentals
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (false, "2.13.6") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -154,7 +154,7 @@ lazy val `fundamentals-platform` = project.in(file("fundamentals/fundamentals-pl
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
+      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided
@@ -162,7 +162,7 @@ lazy val `fundamentals-platform` = project.in(file("fundamentals/fundamentals-pl
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.6-bin-SNAPSHOT",
+      "2.13.6",
       "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -227,7 +227,7 @@ lazy val `fundamentals-platform` = project.in(file("fundamentals/fundamentals-pl
         "-Xsource:3",
         "-P:kind-projector:underscore-placeholders"
       )
-      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (_, "2.13.6") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -263,7 +263,7 @@ lazy val `fundamentals-platform` = project.in(file("fundamentals/fundamentals-pl
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (false, "2.13.6") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -278,7 +278,7 @@ lazy val `fundamentals-language` = project.in(file("fundamentals/fundamentals-la
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
+      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided
@@ -286,7 +286,7 @@ lazy val `fundamentals-language` = project.in(file("fundamentals/fundamentals-la
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.6-bin-SNAPSHOT",
+      "2.13.6",
       "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -351,7 +351,7 @@ lazy val `fundamentals-language` = project.in(file("fundamentals/fundamentals-la
         "-Xsource:3",
         "-P:kind-projector:underscore-placeholders"
       )
-      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (_, "2.13.6") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -387,7 +387,7 @@ lazy val `fundamentals-language` = project.in(file("fundamentals/fundamentals-la
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (false, "2.13.6") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -423,7 +423,7 @@ lazy val `fundamentals-reflection` = project.in(file("fundamentals/fundamentals-
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
+      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "dev.zio" %% "izumi-reflect" % V.izumi_reflect,
@@ -432,7 +432,7 @@ lazy val `fundamentals-reflection` = project.in(file("fundamentals/fundamentals-
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.6-bin-SNAPSHOT",
+      "2.13.6",
       "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -497,7 +497,7 @@ lazy val `fundamentals-reflection` = project.in(file("fundamentals/fundamentals-
         "-Xsource:3",
         "-P:kind-projector:underscore-placeholders"
       )
-      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (_, "2.13.6") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -533,7 +533,7 @@ lazy val `fundamentals-reflection` = project.in(file("fundamentals/fundamentals-
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (false, "2.13.6") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -565,14 +565,14 @@ lazy val `fundamentals-reflection` = project.in(file("fundamentals/fundamentals-
 lazy val `fundamentals-functional` = project.in(file("fundamentals/fundamentals-functional"))
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
+      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test
     )
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.6-bin-SNAPSHOT",
+      "2.13.6",
       "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -637,7 +637,7 @@ lazy val `fundamentals-functional` = project.in(file("fundamentals/fundamentals-
         "-Xsource:3",
         "-P:kind-projector:underscore-placeholders"
       )
-      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (_, "2.13.6") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -673,7 +673,7 @@ lazy val `fundamentals-functional` = project.in(file("fundamentals/fundamentals-
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (false, "2.13.6") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -689,7 +689,7 @@ lazy val `fundamentals-bio` = project.in(file("fundamentals/fundamentals-bio"))
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
+      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.typelevel" %% "cats-core" % V.cats % Optional,
@@ -707,7 +707,7 @@ lazy val `fundamentals-bio` = project.in(file("fundamentals/fundamentals-bio"))
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.6-bin-SNAPSHOT",
+      "2.13.6",
       "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -772,7 +772,7 @@ lazy val `fundamentals-bio` = project.in(file("fundamentals/fundamentals-bio"))
         "-Xsource:3",
         "-P:kind-projector:underscore-placeholders"
       )
-      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (_, "2.13.6") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -808,7 +808,7 @@ lazy val `fundamentals-bio` = project.in(file("fundamentals/fundamentals-bio"))
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (false, "2.13.6") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -823,7 +823,7 @@ lazy val `fundamentals-json-circe` = project.in(file("fundamentals/fundamentals-
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
+      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "io.circe" %% "circe-core" % V.circe,
@@ -835,7 +835,7 @@ lazy val `fundamentals-json-circe` = project.in(file("fundamentals/fundamentals-
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.6-bin-SNAPSHOT",
+      "2.13.6",
       "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -900,7 +900,7 @@ lazy val `fundamentals-json-circe` = project.in(file("fundamentals/fundamentals-
         "-Xsource:3",
         "-P:kind-projector:underscore-placeholders"
       )
-      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (_, "2.13.6") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -936,7 +936,7 @@ lazy val `fundamentals-json-circe` = project.in(file("fundamentals/fundamentals-
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (false, "2.13.6") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -948,7 +948,7 @@ lazy val `fundamentals-json-circe` = project.in(file("fundamentals/fundamentals-
 lazy val `fundamentals-orphans` = project.in(file("fundamentals/fundamentals-orphans"))
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
+      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.typelevel" %% "cats-core" % V.cats % Optional,
@@ -962,7 +962,7 @@ lazy val `fundamentals-orphans` = project.in(file("fundamentals/fundamentals-orp
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.6-bin-SNAPSHOT",
+      "2.13.6",
       "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -1027,7 +1027,7 @@ lazy val `fundamentals-orphans` = project.in(file("fundamentals/fundamentals-orp
         "-Xsource:3",
         "-P:kind-projector:underscore-placeholders"
       )
-      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (_, "2.13.6") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -1063,7 +1063,7 @@ lazy val `fundamentals-orphans` = project.in(file("fundamentals/fundamentals-orp
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (false, "2.13.6") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1075,7 +1075,7 @@ lazy val `fundamentals-orphans` = project.in(file("fundamentals/fundamentals-orp
 lazy val `fundamentals-literals` = project.in(file("fundamentals/fundamentals-literals"))
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
+      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided
@@ -1083,7 +1083,7 @@ lazy val `fundamentals-literals` = project.in(file("fundamentals/fundamentals-li
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.6-bin-SNAPSHOT",
+      "2.13.6",
       "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -1148,7 +1148,7 @@ lazy val `fundamentals-literals` = project.in(file("fundamentals/fundamentals-li
         "-Xsource:3",
         "-P:kind-projector:underscore-placeholders"
       )
-      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (_, "2.13.6") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -1184,7 +1184,7 @@ lazy val `fundamentals-literals` = project.in(file("fundamentals/fundamentals-li
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (false, "2.13.6") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1200,7 +1200,7 @@ lazy val `distage-core-api` = project.in(file("distage/distage-core-api"))
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
+      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.typelevel" %% "cats-core" % V.cats % Optional,
@@ -1217,7 +1217,7 @@ lazy val `distage-core-api` = project.in(file("distage/distage-core-api"))
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.6-bin-SNAPSHOT",
+      "2.13.6",
       "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -1282,7 +1282,7 @@ lazy val `distage-core-api` = project.in(file("distage/distage-core-api"))
         "-Xsource:3",
         "-P:kind-projector:underscore-placeholders"
       )
-      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (_, "2.13.6") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -1318,7 +1318,7 @@ lazy val `distage-core-api` = project.in(file("distage/distage-core-api"))
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (false, "2.13.6") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1333,7 +1333,7 @@ lazy val `distage-core-proxy-cglib` = project.in(file("distage/distage-core-prox
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
+      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "cglib" % "cglib-nodep" % V.cglib_nodep
@@ -1341,7 +1341,7 @@ lazy val `distage-core-proxy-cglib` = project.in(file("distage/distage-core-prox
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.6-bin-SNAPSHOT",
+      "2.13.6",
       "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -1406,7 +1406,7 @@ lazy val `distage-core-proxy-cglib` = project.in(file("distage/distage-core-prox
         "-Xsource:3",
         "-P:kind-projector:underscore-placeholders"
       )
-      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (_, "2.13.6") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -1442,7 +1442,7 @@ lazy val `distage-core-proxy-cglib` = project.in(file("distage/distage-core-prox
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (false, "2.13.6") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1458,7 +1458,7 @@ lazy val `distage-core` = project.in(file("distage/distage-core"))
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
+      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.typelevel" %% "cats-core" % V.cats % Optional,
@@ -1473,7 +1473,7 @@ lazy val `distage-core` = project.in(file("distage/distage-core"))
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.6-bin-SNAPSHOT",
+      "2.13.6",
       "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -1538,7 +1538,7 @@ lazy val `distage-core` = project.in(file("distage/distage-core"))
         "-Xsource:3",
         "-P:kind-projector:underscore-placeholders"
       )
-      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (_, "2.13.6") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -1574,7 +1574,7 @@ lazy val `distage-core` = project.in(file("distage/distage-core"))
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (false, "2.13.6") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1590,7 +1590,7 @@ lazy val `distage-extension-config` = project.in(file("distage/distage-extension
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
+      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "com.github.pureconfig" %% "pureconfig-magnolia" % V.pureconfig,
@@ -1600,7 +1600,7 @@ lazy val `distage-extension-config` = project.in(file("distage/distage-extension
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.6-bin-SNAPSHOT",
+      "2.13.6",
       "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -1665,7 +1665,7 @@ lazy val `distage-extension-config` = project.in(file("distage/distage-extension
         "-Xsource:3",
         "-P:kind-projector:underscore-placeholders"
       )
-      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (_, "2.13.6") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -1701,7 +1701,7 @@ lazy val `distage-extension-config` = project.in(file("distage/distage-extension
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (false, "2.13.6") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1739,7 +1739,7 @@ lazy val `distage-extension-plugins` = project.in(file("distage/distage-extensio
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
+      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "io.github.classgraph" % "classgraph" % V.classgraph,
@@ -1748,7 +1748,7 @@ lazy val `distage-extension-plugins` = project.in(file("distage/distage-extensio
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.6-bin-SNAPSHOT",
+      "2.13.6",
       "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -1813,7 +1813,7 @@ lazy val `distage-extension-plugins` = project.in(file("distage/distage-extensio
         "-Xsource:3",
         "-P:kind-projector:underscore-placeholders"
       )
-      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (_, "2.13.6") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -1849,7 +1849,7 @@ lazy val `distage-extension-plugins` = project.in(file("distage/distage-extensio
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (false, "2.13.6") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1867,14 +1867,14 @@ lazy val `distage-extension-logstage` = project.in(file("distage/distage-extensi
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
+      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test
     )
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.6-bin-SNAPSHOT",
+      "2.13.6",
       "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -1939,7 +1939,7 @@ lazy val `distage-extension-logstage` = project.in(file("distage/distage-extensi
         "-Xsource:3",
         "-P:kind-projector:underscore-placeholders"
       )
-      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (_, "2.13.6") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -1975,7 +1975,7 @@ lazy val `distage-extension-logstage` = project.in(file("distage/distage-extensi
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (false, "2.13.6") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1990,7 +1990,7 @@ lazy val `distage-framework-api` = project.in(file("distage/distage-framework-ap
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
+      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided
@@ -1998,7 +1998,7 @@ lazy val `distage-framework-api` = project.in(file("distage/distage-framework-ap
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.6-bin-SNAPSHOT",
+      "2.13.6",
       "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -2063,7 +2063,7 @@ lazy val `distage-framework-api` = project.in(file("distage/distage-framework-ap
         "-Xsource:3",
         "-P:kind-projector:underscore-placeholders"
       )
-      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (_, "2.13.6") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -2099,7 +2099,7 @@ lazy val `distage-framework-api` = project.in(file("distage/distage-framework-ap
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (false, "2.13.6") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2120,7 +2120,7 @@ lazy val `distage-framework` = project.in(file("distage/distage-framework"))
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
+      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.typelevel" %% "cats-core" % V.cats % Optional,
@@ -2135,7 +2135,7 @@ lazy val `distage-framework` = project.in(file("distage/distage-framework"))
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.6-bin-SNAPSHOT",
+      "2.13.6",
       "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -2200,7 +2200,7 @@ lazy val `distage-framework` = project.in(file("distage/distage-framework"))
         "-Xsource:3",
         "-P:kind-projector:underscore-placeholders"
       )
-      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (_, "2.13.6") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -2236,7 +2236,7 @@ lazy val `distage-framework` = project.in(file("distage/distage-framework"))
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (false, "2.13.6") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2275,7 +2275,7 @@ lazy val `distage-framework-docker` = project.in(file("distage/distage-framework
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
+      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.typelevel" %% "cats-core" % V.cats % Test,
@@ -2289,7 +2289,7 @@ lazy val `distage-framework-docker` = project.in(file("distage/distage-framework
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.6-bin-SNAPSHOT",
+      "2.13.6",
       "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -2354,7 +2354,7 @@ lazy val `distage-framework-docker` = project.in(file("distage/distage-framework
         "-Xsource:3",
         "-P:kind-projector:underscore-placeholders"
       )
-      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (_, "2.13.6") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -2390,7 +2390,7 @@ lazy val `distage-framework-docker` = project.in(file("distage/distage-framework
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (false, "2.13.6") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2405,14 +2405,14 @@ lazy val `distage-testkit-core` = project.in(file("distage/distage-testkit-core"
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
+      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test
     )
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.6-bin-SNAPSHOT",
+      "2.13.6",
       "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -2477,7 +2477,7 @@ lazy val `distage-testkit-core` = project.in(file("distage/distage-testkit-core"
         "-Xsource:3",
         "-P:kind-projector:underscore-placeholders"
       )
-      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (_, "2.13.6") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -2513,7 +2513,7 @@ lazy val `distage-testkit-core` = project.in(file("distage/distage-testkit-core"
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (false, "2.13.6") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2531,7 +2531,7 @@ lazy val `distage-testkit-scalatest` = project.in(file("distage/distage-testkit-
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
+      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.typelevel" %% "cats-core" % V.cats % Optional,
@@ -2546,7 +2546,7 @@ lazy val `distage-testkit-scalatest` = project.in(file("distage/distage-testkit-
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.6-bin-SNAPSHOT",
+      "2.13.6",
       "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -2611,7 +2611,7 @@ lazy val `distage-testkit-scalatest` = project.in(file("distage/distage-testkit-
         "-Xsource:3",
         "-P:kind-projector:underscore-placeholders"
       )
-      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (_, "2.13.6") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -2647,7 +2647,7 @@ lazy val `distage-testkit-scalatest` = project.in(file("distage/distage-testkit-
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (false, "2.13.6") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2663,7 +2663,7 @@ lazy val `logstage-core` = project.in(file("logstage/logstage-core"))
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
+      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided,
@@ -2675,7 +2675,7 @@ lazy val `logstage-core` = project.in(file("logstage/logstage-core"))
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.6-bin-SNAPSHOT",
+      "2.13.6",
       "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -2740,7 +2740,7 @@ lazy val `logstage-core` = project.in(file("logstage/logstage-core"))
         "-Xsource:3",
         "-P:kind-projector:underscore-placeholders"
       )
-      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (_, "2.13.6") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -2776,7 +2776,7 @@ lazy val `logstage-core` = project.in(file("logstage/logstage-core"))
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (false, "2.13.6") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2792,7 +2792,7 @@ lazy val `logstage-rendering-circe` = project.in(file("logstage/logstage-renderi
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
+      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.typelevel" %% "jawn-parser" % V.jawn % Test,
@@ -2802,7 +2802,7 @@ lazy val `logstage-rendering-circe` = project.in(file("logstage/logstage-renderi
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.6-bin-SNAPSHOT",
+      "2.13.6",
       "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -2867,7 +2867,7 @@ lazy val `logstage-rendering-circe` = project.in(file("logstage/logstage-renderi
         "-Xsource:3",
         "-P:kind-projector:underscore-placeholders"
       )
-      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (_, "2.13.6") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -2903,7 +2903,7 @@ lazy val `logstage-rendering-circe` = project.in(file("logstage/logstage-renderi
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (false, "2.13.6") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2918,7 +2918,7 @@ lazy val `logstage-adapter-slf4j` = project.in(file("logstage/logstage-adapter-s
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
+      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.slf4j" % "slf4j-api" % V.slf4j
@@ -2926,7 +2926,7 @@ lazy val `logstage-adapter-slf4j` = project.in(file("logstage/logstage-adapter-s
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.6-bin-SNAPSHOT",
+      "2.13.6",
       "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -2991,7 +2991,7 @@ lazy val `logstage-adapter-slf4j` = project.in(file("logstage/logstage-adapter-s
         "-Xsource:3",
         "-P:kind-projector:underscore-placeholders"
       )
-      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (_, "2.13.6") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -3027,7 +3027,7 @@ lazy val `logstage-adapter-slf4j` = project.in(file("logstage/logstage-adapter-s
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (false, "2.13.6") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -3045,7 +3045,7 @@ lazy val `logstage-sink-slf4j` = project.in(file("logstage/logstage-sink-slf4j")
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
+      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.slf4j" % "slf4j-api" % V.slf4j,
@@ -3054,7 +3054,7 @@ lazy val `logstage-sink-slf4j` = project.in(file("logstage/logstage-sink-slf4j")
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.6-bin-SNAPSHOT",
+      "2.13.6",
       "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -3119,7 +3119,7 @@ lazy val `logstage-sink-slf4j` = project.in(file("logstage/logstage-sink-slf4j")
         "-Xsource:3",
         "-P:kind-projector:underscore-placeholders"
       )
-      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (_, "2.13.6") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -3155,7 +3155,7 @@ lazy val `logstage-sink-slf4j` = project.in(file("logstage/logstage-sink-slf4j")
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (false, "2.13.6") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -3193,7 +3193,7 @@ lazy val `microsite` = project.in(file("doc/microsite"))
   )
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
+      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.typelevel" %% "cats-core" % V.cats,
@@ -3209,7 +3209,7 @@ lazy val `microsite` = project.in(file("doc/microsite"))
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.13.6-bin-SNAPSHOT",
+      "2.13.6",
       "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
@@ -3274,7 +3274,7 @@ lazy val `microsite` = project.in(file("doc/microsite"))
         "-Xsource:3",
         "-P:kind-projector:underscore-placeholders"
       )
-      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (_, "2.13.6") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -3310,7 +3310,7 @@ lazy val `microsite` = project.in(file("doc/microsite"))
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (false, "2.13.6") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -3383,7 +3383,7 @@ lazy val `microsite` = project.in(file("doc/microsite"))
 lazy val `sbt-izumi-deps` = project.in(file("sbt-plugins/sbt-izumi-deps"))
   .settings(
     libraryDependencies ++= Seq(
-      compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
+      compilerPlugin("org.typelevel" % "kind-projector_2.13.5" % V.kind_projector),
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test
     )
@@ -3451,7 +3451,7 @@ lazy val `sbt-izumi-deps` = project.in(file("sbt-plugins/sbt-izumi-deps"))
         "-Xsource:3",
         "-P:kind-projector:underscore-placeholders"
       )
-      case (_, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (_, "2.13.6") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
         "-Wconf:cat=optimizer:warning",
@@ -3487,7 +3487,7 @@ lazy val `sbt-izumi-deps` = project.in(file("sbt-plugins/sbt-izumi-deps"))
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
-      case (false, "2.13.6-bin-SNAPSHOT") => Seq(
+      case (false, "2.13.6") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -3502,7 +3502,7 @@ lazy val `fundamentals` = (project in file(".agg/fundamentals-fundamentals"))
   .settings(
     publish / skip := true,
     crossScalaVersions := Seq(
-      "2.13.6-bin-SNAPSHOT",
+      "2.13.6",
       "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head
@@ -3524,7 +3524,7 @@ lazy val `fundamentals-jvm` = (project in file(".agg/fundamentals-fundamentals-j
   .settings(
     publish / skip := true,
     crossScalaVersions := Seq(
-      "2.13.6-bin-SNAPSHOT",
+      "2.13.6",
       "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head
@@ -3546,7 +3546,7 @@ lazy val `distage` = (project in file(".agg/distage-distage"))
   .settings(
     publish / skip := true,
     crossScalaVersions := Seq(
-      "2.13.6-bin-SNAPSHOT",
+      "2.13.6",
       "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head
@@ -3570,7 +3570,7 @@ lazy val `distage-jvm` = (project in file(".agg/distage-distage-jvm"))
   .settings(
     publish / skip := true,
     crossScalaVersions := Seq(
-      "2.13.6-bin-SNAPSHOT",
+      "2.13.6",
       "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head
@@ -3594,7 +3594,7 @@ lazy val `logstage` = (project in file(".agg/logstage-logstage"))
   .settings(
     publish / skip := true,
     crossScalaVersions := Seq(
-      "2.13.6-bin-SNAPSHOT",
+      "2.13.6",
       "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head
@@ -3611,7 +3611,7 @@ lazy val `logstage-jvm` = (project in file(".agg/logstage-logstage-jvm"))
   .settings(
     publish / skip := true,
     crossScalaVersions := Seq(
-      "2.13.6-bin-SNAPSHOT",
+      "2.13.6",
       "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head
@@ -3628,7 +3628,7 @@ lazy val `doc` = (project in file(".agg/doc-doc"))
   .settings(
     publish / skip := true,
     crossScalaVersions := Seq(
-      "2.13.6-bin-SNAPSHOT",
+      "2.13.6",
       "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head
@@ -3642,7 +3642,7 @@ lazy val `doc-jvm` = (project in file(".agg/doc-doc-jvm"))
   .settings(
     publish / skip := true,
     crossScalaVersions := Seq(
-      "2.13.6-bin-SNAPSHOT",
+      "2.13.6",
       "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head
@@ -3678,7 +3678,7 @@ lazy val `izumi-jvm` = (project in file(".agg/.agg-jvm"))
   .settings(
     publish / skip := true,
     crossScalaVersions := Seq(
-      "2.13.6-bin-SNAPSHOT",
+      "2.13.6",
       "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head
@@ -3725,7 +3725,7 @@ lazy val `izumi` = (project in file("."))
       s"-Xmacro-settings:git-head-commit=${com.typesafe.sbt.SbtGit.GitKeys.gitHeadCommit.value.getOrElse("")}"
     ),
     crossScalaVersions := Nil,
-    scalaVersion := "2.13.6-bin-SNAPSHOT",
+    scalaVersion := "2.13.6",
     ThisBuild / organization := "io.7mind.izumi",
     sonatypeProfileName := "io.7mind",
     sonatypeSessionName := s"[sbt-sonatype] ${name.value} ${version.value} ${java.util.UUID.randomUUID}",

--- a/build.sbt
+++ b/build.sbt
@@ -18,9 +18,13 @@ lazy val `fundamentals-collections` = project.in(file("fundamentals/fundamentals
   .settings(
     crossScalaVersions := Seq(
       "2.13.6-bin-SNAPSHOT",
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
+      case (_, "2.12.14-bin-SNAPSHOT") => false
+      case (_, _) => coverageEnabled.value
+    } },
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -35,7 +39,7 @@ lazy val `fundamentals-collections` = project.in(file("fundamentals/fundamentals
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.13") => Seq(
+      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -74,7 +78,9 @@ lazy val `fundamentals-collections` = project.in(file("fundamentals/fundamentals
         "-Ywarn-unused-import",
         "-Ywarn-value-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
@@ -108,7 +114,7 @@ lazy val `fundamentals-collections` = project.in(file("fundamentals/fundamentals
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.13") => Seq(
+      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -157,9 +163,13 @@ lazy val `fundamentals-platform` = project.in(file("fundamentals/fundamentals-pl
   .settings(
     crossScalaVersions := Seq(
       "2.13.6-bin-SNAPSHOT",
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
+      case (_, "2.12.14-bin-SNAPSHOT") => false
+      case (_, _) => coverageEnabled.value
+    } },
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -174,7 +184,7 @@ lazy val `fundamentals-platform` = project.in(file("fundamentals/fundamentals-pl
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.13") => Seq(
+      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -213,7 +223,9 @@ lazy val `fundamentals-platform` = project.in(file("fundamentals/fundamentals-pl
         "-Ywarn-unused-import",
         "-Ywarn-value-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
@@ -247,7 +259,7 @@ lazy val `fundamentals-platform` = project.in(file("fundamentals/fundamentals-pl
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.13") => Seq(
+      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -275,9 +287,13 @@ lazy val `fundamentals-language` = project.in(file("fundamentals/fundamentals-la
   .settings(
     crossScalaVersions := Seq(
       "2.13.6-bin-SNAPSHOT",
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
+      case (_, "2.12.14-bin-SNAPSHOT") => false
+      case (_, _) => coverageEnabled.value
+    } },
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -292,7 +308,7 @@ lazy val `fundamentals-language` = project.in(file("fundamentals/fundamentals-la
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.13") => Seq(
+      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -331,7 +347,9 @@ lazy val `fundamentals-language` = project.in(file("fundamentals/fundamentals-la
         "-Ywarn-unused-import",
         "-Ywarn-value-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
@@ -365,7 +383,7 @@ lazy val `fundamentals-language` = project.in(file("fundamentals/fundamentals-la
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.13") => Seq(
+      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -415,9 +433,13 @@ lazy val `fundamentals-reflection` = project.in(file("fundamentals/fundamentals-
   .settings(
     crossScalaVersions := Seq(
       "2.13.6-bin-SNAPSHOT",
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
+      case (_, "2.12.14-bin-SNAPSHOT") => false
+      case (_, _) => coverageEnabled.value
+    } },
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -432,7 +454,7 @@ lazy val `fundamentals-reflection` = project.in(file("fundamentals/fundamentals-
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.13") => Seq(
+      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -471,7 +493,9 @@ lazy val `fundamentals-reflection` = project.in(file("fundamentals/fundamentals-
         "-Ywarn-unused-import",
         "-Ywarn-value-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
@@ -505,7 +529,7 @@ lazy val `fundamentals-reflection` = project.in(file("fundamentals/fundamentals-
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.13") => Seq(
+      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -549,9 +573,13 @@ lazy val `fundamentals-functional` = project.in(file("fundamentals/fundamentals-
   .settings(
     crossScalaVersions := Seq(
       "2.13.6-bin-SNAPSHOT",
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
+      case (_, "2.12.14-bin-SNAPSHOT") => false
+      case (_, _) => coverageEnabled.value
+    } },
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -566,7 +594,7 @@ lazy val `fundamentals-functional` = project.in(file("fundamentals/fundamentals-
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.13") => Seq(
+      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -605,7 +633,9 @@ lazy val `fundamentals-functional` = project.in(file("fundamentals/fundamentals-
         "-Ywarn-unused-import",
         "-Ywarn-value-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
@@ -639,7 +669,7 @@ lazy val `fundamentals-functional` = project.in(file("fundamentals/fundamentals-
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.13") => Seq(
+      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -678,9 +708,13 @@ lazy val `fundamentals-bio` = project.in(file("fundamentals/fundamentals-bio"))
   .settings(
     crossScalaVersions := Seq(
       "2.13.6-bin-SNAPSHOT",
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
+      case (_, "2.12.14-bin-SNAPSHOT") => false
+      case (_, _) => coverageEnabled.value
+    } },
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -695,7 +729,7 @@ lazy val `fundamentals-bio` = project.in(file("fundamentals/fundamentals-bio"))
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.13") => Seq(
+      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -734,7 +768,9 @@ lazy val `fundamentals-bio` = project.in(file("fundamentals/fundamentals-bio"))
         "-Ywarn-unused-import",
         "-Ywarn-value-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
@@ -768,7 +804,7 @@ lazy val `fundamentals-bio` = project.in(file("fundamentals/fundamentals-bio"))
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.13") => Seq(
+      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -800,9 +836,13 @@ lazy val `fundamentals-json-circe` = project.in(file("fundamentals/fundamentals-
   .settings(
     crossScalaVersions := Seq(
       "2.13.6-bin-SNAPSHOT",
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
+      case (_, "2.12.14-bin-SNAPSHOT") => false
+      case (_, _) => coverageEnabled.value
+    } },
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -817,7 +857,7 @@ lazy val `fundamentals-json-circe` = project.in(file("fundamentals/fundamentals-
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.13") => Seq(
+      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -856,7 +896,9 @@ lazy val `fundamentals-json-circe` = project.in(file("fundamentals/fundamentals-
         "-Ywarn-unused-import",
         "-Ywarn-value-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
@@ -890,7 +932,7 @@ lazy val `fundamentals-json-circe` = project.in(file("fundamentals/fundamentals-
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.13") => Seq(
+      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -921,9 +963,13 @@ lazy val `fundamentals-orphans` = project.in(file("fundamentals/fundamentals-orp
   .settings(
     crossScalaVersions := Seq(
       "2.13.6-bin-SNAPSHOT",
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
+      case (_, "2.12.14-bin-SNAPSHOT") => false
+      case (_, _) => coverageEnabled.value
+    } },
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -938,7 +984,7 @@ lazy val `fundamentals-orphans` = project.in(file("fundamentals/fundamentals-orp
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.13") => Seq(
+      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -977,7 +1023,9 @@ lazy val `fundamentals-orphans` = project.in(file("fundamentals/fundamentals-orp
         "-Ywarn-unused-import",
         "-Ywarn-value-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
@@ -1011,7 +1059,7 @@ lazy val `fundamentals-orphans` = project.in(file("fundamentals/fundamentals-orp
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.13") => Seq(
+      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1036,9 +1084,13 @@ lazy val `fundamentals-literals` = project.in(file("fundamentals/fundamentals-li
   .settings(
     crossScalaVersions := Seq(
       "2.13.6-bin-SNAPSHOT",
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
+      case (_, "2.12.14-bin-SNAPSHOT") => false
+      case (_, _) => coverageEnabled.value
+    } },
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -1053,7 +1105,7 @@ lazy val `fundamentals-literals` = project.in(file("fundamentals/fundamentals-li
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.13") => Seq(
+      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -1092,7 +1144,9 @@ lazy val `fundamentals-literals` = project.in(file("fundamentals/fundamentals-li
         "-Ywarn-unused-import",
         "-Ywarn-value-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
@@ -1126,7 +1180,7 @@ lazy val `fundamentals-literals` = project.in(file("fundamentals/fundamentals-li
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.13") => Seq(
+      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1164,9 +1218,13 @@ lazy val `distage-core-api` = project.in(file("distage/distage-core-api"))
   .settings(
     crossScalaVersions := Seq(
       "2.13.6-bin-SNAPSHOT",
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
+      case (_, "2.12.14-bin-SNAPSHOT") => false
+      case (_, _) => coverageEnabled.value
+    } },
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -1181,7 +1239,7 @@ lazy val `distage-core-api` = project.in(file("distage/distage-core-api"))
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.13") => Seq(
+      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -1220,7 +1278,9 @@ lazy val `distage-core-api` = project.in(file("distage/distage-core-api"))
         "-Ywarn-unused-import",
         "-Ywarn-value-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
@@ -1254,7 +1314,7 @@ lazy val `distage-core-api` = project.in(file("distage/distage-core-api"))
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.13") => Seq(
+      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1282,9 +1342,13 @@ lazy val `distage-core-proxy-cglib` = project.in(file("distage/distage-core-prox
   .settings(
     crossScalaVersions := Seq(
       "2.13.6-bin-SNAPSHOT",
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
+      case (_, "2.12.14-bin-SNAPSHOT") => false
+      case (_, _) => coverageEnabled.value
+    } },
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -1299,7 +1363,7 @@ lazy val `distage-core-proxy-cglib` = project.in(file("distage/distage-core-prox
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.13") => Seq(
+      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -1338,7 +1402,9 @@ lazy val `distage-core-proxy-cglib` = project.in(file("distage/distage-core-prox
         "-Ywarn-unused-import",
         "-Ywarn-value-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
@@ -1372,7 +1438,7 @@ lazy val `distage-core-proxy-cglib` = project.in(file("distage/distage-core-prox
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.13") => Seq(
+      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1408,9 +1474,13 @@ lazy val `distage-core` = project.in(file("distage/distage-core"))
   .settings(
     crossScalaVersions := Seq(
       "2.13.6-bin-SNAPSHOT",
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
+      case (_, "2.12.14-bin-SNAPSHOT") => false
+      case (_, _) => coverageEnabled.value
+    } },
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -1425,7 +1495,7 @@ lazy val `distage-core` = project.in(file("distage/distage-core"))
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.13") => Seq(
+      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -1464,7 +1534,9 @@ lazy val `distage-core` = project.in(file("distage/distage-core"))
         "-Ywarn-unused-import",
         "-Ywarn-value-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
@@ -1498,7 +1570,7 @@ lazy val `distage-core` = project.in(file("distage/distage-core"))
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.13") => Seq(
+      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1529,9 +1601,13 @@ lazy val `distage-extension-config` = project.in(file("distage/distage-extension
   .settings(
     crossScalaVersions := Seq(
       "2.13.6-bin-SNAPSHOT",
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
+      case (_, "2.12.14-bin-SNAPSHOT") => false
+      case (_, _) => coverageEnabled.value
+    } },
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -1546,7 +1622,7 @@ lazy val `distage-extension-config` = project.in(file("distage/distage-extension
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.13") => Seq(
+      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -1585,7 +1661,9 @@ lazy val `distage-extension-config` = project.in(file("distage/distage-extension
         "-Ywarn-unused-import",
         "-Ywarn-value-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
@@ -1619,7 +1697,7 @@ lazy val `distage-extension-config` = project.in(file("distage/distage-extension
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.13") => Seq(
+      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1671,9 +1749,13 @@ lazy val `distage-extension-plugins` = project.in(file("distage/distage-extensio
   .settings(
     crossScalaVersions := Seq(
       "2.13.6-bin-SNAPSHOT",
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
+      case (_, "2.12.14-bin-SNAPSHOT") => false
+      case (_, _) => coverageEnabled.value
+    } },
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -1688,7 +1770,7 @@ lazy val `distage-extension-plugins` = project.in(file("distage/distage-extensio
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.13") => Seq(
+      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -1727,7 +1809,9 @@ lazy val `distage-extension-plugins` = project.in(file("distage/distage-extensio
         "-Ywarn-unused-import",
         "-Ywarn-value-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
@@ -1761,7 +1845,7 @@ lazy val `distage-extension-plugins` = project.in(file("distage/distage-extensio
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.13") => Seq(
+      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1791,9 +1875,13 @@ lazy val `distage-extension-logstage` = project.in(file("distage/distage-extensi
   .settings(
     crossScalaVersions := Seq(
       "2.13.6-bin-SNAPSHOT",
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
+      case (_, "2.12.14-bin-SNAPSHOT") => false
+      case (_, _) => coverageEnabled.value
+    } },
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -1808,7 +1896,7 @@ lazy val `distage-extension-logstage` = project.in(file("distage/distage-extensi
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.13") => Seq(
+      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -1847,7 +1935,9 @@ lazy val `distage-extension-logstage` = project.in(file("distage/distage-extensi
         "-Ywarn-unused-import",
         "-Ywarn-value-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
@@ -1881,7 +1971,7 @@ lazy val `distage-extension-logstage` = project.in(file("distage/distage-extensi
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.13") => Seq(
+      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -1909,9 +1999,13 @@ lazy val `distage-framework-api` = project.in(file("distage/distage-framework-ap
   .settings(
     crossScalaVersions := Seq(
       "2.13.6-bin-SNAPSHOT",
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
+      case (_, "2.12.14-bin-SNAPSHOT") => false
+      case (_, _) => coverageEnabled.value
+    } },
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -1926,7 +2020,7 @@ lazy val `distage-framework-api` = project.in(file("distage/distage-framework-ap
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.13") => Seq(
+      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -1965,7 +2059,9 @@ lazy val `distage-framework-api` = project.in(file("distage/distage-framework-ap
         "-Ywarn-unused-import",
         "-Ywarn-value-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
@@ -1999,7 +2095,7 @@ lazy val `distage-framework-api` = project.in(file("distage/distage-framework-ap
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.13") => Seq(
+      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2040,9 +2136,13 @@ lazy val `distage-framework` = project.in(file("distage/distage-framework"))
   .settings(
     crossScalaVersions := Seq(
       "2.13.6-bin-SNAPSHOT",
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
+      case (_, "2.12.14-bin-SNAPSHOT") => false
+      case (_, _) => coverageEnabled.value
+    } },
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -2057,7 +2157,7 @@ lazy val `distage-framework` = project.in(file("distage/distage-framework"))
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.13") => Seq(
+      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -2096,7 +2196,9 @@ lazy val `distage-framework` = project.in(file("distage/distage-framework"))
         "-Ywarn-unused-import",
         "-Ywarn-value-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
@@ -2130,7 +2232,7 @@ lazy val `distage-framework` = project.in(file("distage/distage-framework"))
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.13") => Seq(
+      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2188,9 +2290,13 @@ lazy val `distage-framework-docker` = project.in(file("distage/distage-framework
   .settings(
     crossScalaVersions := Seq(
       "2.13.6-bin-SNAPSHOT",
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
+      case (_, "2.12.14-bin-SNAPSHOT") => false
+      case (_, _) => coverageEnabled.value
+    } },
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -2205,7 +2311,7 @@ lazy val `distage-framework-docker` = project.in(file("distage/distage-framework
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.13") => Seq(
+      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -2244,7 +2350,9 @@ lazy val `distage-framework-docker` = project.in(file("distage/distage-framework
         "-Ywarn-unused-import",
         "-Ywarn-value-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
@@ -2278,7 +2386,7 @@ lazy val `distage-framework-docker` = project.in(file("distage/distage-framework
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.13") => Seq(
+      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2305,9 +2413,13 @@ lazy val `distage-testkit-core` = project.in(file("distage/distage-testkit-core"
   .settings(
     crossScalaVersions := Seq(
       "2.13.6-bin-SNAPSHOT",
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
+      case (_, "2.12.14-bin-SNAPSHOT") => false
+      case (_, _) => coverageEnabled.value
+    } },
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -2322,7 +2434,7 @@ lazy val `distage-testkit-core` = project.in(file("distage/distage-testkit-core"
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.13") => Seq(
+      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -2361,7 +2473,9 @@ lazy val `distage-testkit-core` = project.in(file("distage/distage-testkit-core"
         "-Ywarn-unused-import",
         "-Ywarn-value-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
@@ -2395,7 +2509,7 @@ lazy val `distage-testkit-core` = project.in(file("distage/distage-testkit-core"
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.13") => Seq(
+      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2433,9 +2547,13 @@ lazy val `distage-testkit-scalatest` = project.in(file("distage/distage-testkit-
   .settings(
     crossScalaVersions := Seq(
       "2.13.6-bin-SNAPSHOT",
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
+      case (_, "2.12.14-bin-SNAPSHOT") => false
+      case (_, _) => coverageEnabled.value
+    } },
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -2450,7 +2568,7 @@ lazy val `distage-testkit-scalatest` = project.in(file("distage/distage-testkit-
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.13") => Seq(
+      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -2489,7 +2607,9 @@ lazy val `distage-testkit-scalatest` = project.in(file("distage/distage-testkit-
         "-Ywarn-unused-import",
         "-Ywarn-value-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
@@ -2523,7 +2643,7 @@ lazy val `distage-testkit-scalatest` = project.in(file("distage/distage-testkit-
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.13") => Seq(
+      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2556,9 +2676,13 @@ lazy val `logstage-core` = project.in(file("logstage/logstage-core"))
   .settings(
     crossScalaVersions := Seq(
       "2.13.6-bin-SNAPSHOT",
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
+      case (_, "2.12.14-bin-SNAPSHOT") => false
+      case (_, _) => coverageEnabled.value
+    } },
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -2573,7 +2697,7 @@ lazy val `logstage-core` = project.in(file("logstage/logstage-core"))
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.13") => Seq(
+      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -2612,7 +2736,9 @@ lazy val `logstage-core` = project.in(file("logstage/logstage-core"))
         "-Ywarn-unused-import",
         "-Ywarn-value-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
@@ -2646,7 +2772,7 @@ lazy val `logstage-core` = project.in(file("logstage/logstage-core"))
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.13") => Seq(
+      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2677,9 +2803,13 @@ lazy val `logstage-rendering-circe` = project.in(file("logstage/logstage-renderi
   .settings(
     crossScalaVersions := Seq(
       "2.13.6-bin-SNAPSHOT",
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
+      case (_, "2.12.14-bin-SNAPSHOT") => false
+      case (_, _) => coverageEnabled.value
+    } },
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -2694,7 +2824,7 @@ lazy val `logstage-rendering-circe` = project.in(file("logstage/logstage-renderi
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.13") => Seq(
+      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -2733,7 +2863,9 @@ lazy val `logstage-rendering-circe` = project.in(file("logstage/logstage-renderi
         "-Ywarn-unused-import",
         "-Ywarn-value-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
@@ -2767,7 +2899,7 @@ lazy val `logstage-rendering-circe` = project.in(file("logstage/logstage-renderi
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.13") => Seq(
+      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2795,9 +2927,13 @@ lazy val `logstage-adapter-slf4j` = project.in(file("logstage/logstage-adapter-s
   .settings(
     crossScalaVersions := Seq(
       "2.13.6-bin-SNAPSHOT",
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
+      case (_, "2.12.14-bin-SNAPSHOT") => false
+      case (_, _) => coverageEnabled.value
+    } },
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -2812,7 +2948,7 @@ lazy val `logstage-adapter-slf4j` = project.in(file("logstage/logstage-adapter-s
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.13") => Seq(
+      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -2851,7 +2987,9 @@ lazy val `logstage-adapter-slf4j` = project.in(file("logstage/logstage-adapter-s
         "-Ywarn-unused-import",
         "-Ywarn-value-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
@@ -2885,7 +3023,7 @@ lazy val `logstage-adapter-slf4j` = project.in(file("logstage/logstage-adapter-s
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.13") => Seq(
+      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -2917,9 +3055,13 @@ lazy val `logstage-sink-slf4j` = project.in(file("logstage/logstage-sink-slf4j")
   .settings(
     crossScalaVersions := Seq(
       "2.13.6-bin-SNAPSHOT",
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
+      case (_, "2.12.14-bin-SNAPSHOT") => false
+      case (_, _) => coverageEnabled.value
+    } },
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -2934,7 +3076,7 @@ lazy val `logstage-sink-slf4j` = project.in(file("logstage/logstage-sink-slf4j")
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.13") => Seq(
+      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -2973,7 +3115,9 @@ lazy val `logstage-sink-slf4j` = project.in(file("logstage/logstage-sink-slf4j")
         "-Ywarn-unused-import",
         "-Ywarn-value-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
@@ -3007,7 +3151,7 @@ lazy val `logstage-sink-slf4j` = project.in(file("logstage/logstage-sink-slf4j")
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.13") => Seq(
+      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -3066,9 +3210,13 @@ lazy val `microsite` = project.in(file("doc/microsite"))
   .settings(
     crossScalaVersions := Seq(
       "2.13.6-bin-SNAPSHOT",
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
+    coverageEnabled := { (isSnapshot.value, scalaVersion.value) match {
+      case (_, "2.12.14-bin-SNAPSHOT") => false
+      case (_, _) => coverageEnabled.value
+    } },
     organization := "io.7mind.izumi",
     Compile / unmanagedSourceDirectories += baseDirectory.value / ".jvm/src/main/scala" ,
     Compile / unmanagedResourceDirectories += baseDirectory.value / ".jvm/src/main/resources" ,
@@ -3083,7 +3231,7 @@ lazy val `microsite` = project.in(file("doc/microsite"))
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.13") => Seq(
+      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -3122,7 +3270,9 @@ lazy val `microsite` = project.in(file("doc/microsite"))
         "-Ywarn-unused-import",
         "-Ywarn-value-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
@@ -3156,7 +3306,7 @@ lazy val `microsite` = project.in(file("doc/microsite"))
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.13") => Seq(
+      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -3240,7 +3390,7 @@ lazy val `sbt-izumi-deps` = project.in(file("sbt-plugins/sbt-izumi-deps"))
   )
   .settings(
     crossScalaVersions := Seq(
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head,
     coverageEnabled := false,
@@ -3258,7 +3408,7 @@ lazy val `sbt-izumi-deps` = project.in(file("sbt-plugins/sbt-izumi-deps"))
     ),
     Test / testOptions += Tests.Argument("-oDF"),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (_, "2.12.13") => Seq(
+      case (_, "2.12.14-bin-SNAPSHOT") => Seq(
         "-Xsource:2.13",
         "-Ypartial-unification",
         if (insideCI.value) "-Wconf:any:error" else "-Wconf:any:warning",
@@ -3297,7 +3447,9 @@ lazy val `sbt-izumi-deps` = project.in(file("sbt-plugins/sbt-izumi-deps"))
         "-Ywarn-unused-import",
         "-Ywarn-value-discard",
         "-Ycache-plugin-class-loader:always",
-        "-Ycache-macro-class-loader:last-modified"
+        "-Ycache-macro-class-loader:last-modified",
+        "-Xsource:3",
+        "-P:kind-projector:underscore-placeholders"
       )
       case (_, "2.13.6-bin-SNAPSHOT") => Seq(
         "-Xlint:_,-eta-sam,-multiarg-infix,-byname-implicit",
@@ -3331,7 +3483,7 @@ lazy val `sbt-izumi-deps` = project.in(file("sbt-plugins/sbt-izumi-deps"))
       s"-Xmacro-settings:is-ci=${insideCI.value}"
     ),
     scalacOptions ++= { (isSnapshot.value, scalaVersion.value) match {
-      case (false, "2.12.13") => Seq(
+      case (false, "2.12.14-bin-SNAPSHOT") => Seq(
         "-opt:l:inline",
         "-opt-inline-from:izumi.**"
       )
@@ -3351,7 +3503,7 @@ lazy val `fundamentals` = (project in file(".agg/fundamentals-fundamentals"))
     publish / skip := true,
     crossScalaVersions := Seq(
       "2.13.6-bin-SNAPSHOT",
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head
   )
@@ -3373,7 +3525,7 @@ lazy val `fundamentals-jvm` = (project in file(".agg/fundamentals-fundamentals-j
     publish / skip := true,
     crossScalaVersions := Seq(
       "2.13.6-bin-SNAPSHOT",
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head
   )
@@ -3395,7 +3547,7 @@ lazy val `distage` = (project in file(".agg/distage-distage"))
     publish / skip := true,
     crossScalaVersions := Seq(
       "2.13.6-bin-SNAPSHOT",
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head
   )
@@ -3419,7 +3571,7 @@ lazy val `distage-jvm` = (project in file(".agg/distage-distage-jvm"))
     publish / skip := true,
     crossScalaVersions := Seq(
       "2.13.6-bin-SNAPSHOT",
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head
   )
@@ -3443,7 +3595,7 @@ lazy val `logstage` = (project in file(".agg/logstage-logstage"))
     publish / skip := true,
     crossScalaVersions := Seq(
       "2.13.6-bin-SNAPSHOT",
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head
   )
@@ -3460,7 +3612,7 @@ lazy val `logstage-jvm` = (project in file(".agg/logstage-logstage-jvm"))
     publish / skip := true,
     crossScalaVersions := Seq(
       "2.13.6-bin-SNAPSHOT",
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head
   )
@@ -3477,7 +3629,7 @@ lazy val `doc` = (project in file(".agg/doc-doc"))
     publish / skip := true,
     crossScalaVersions := Seq(
       "2.13.6-bin-SNAPSHOT",
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head
   )
@@ -3491,7 +3643,7 @@ lazy val `doc-jvm` = (project in file(".agg/doc-doc-jvm"))
     publish / skip := true,
     crossScalaVersions := Seq(
       "2.13.6-bin-SNAPSHOT",
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head
   )
@@ -3504,7 +3656,7 @@ lazy val `sbt-plugins` = (project in file(".agg/sbt-plugins-sbt-plugins"))
   .settings(
     publish / skip := true,
     crossScalaVersions := Nil,
-    scalaVersion := "2.12.13"
+    scalaVersion := "2.12.14-bin-SNAPSHOT"
   )
   .disablePlugins(AssemblyPlugin)
   .aggregate(
@@ -3515,7 +3667,7 @@ lazy val `sbt-plugins-jvm` = (project in file(".agg/sbt-plugins-sbt-plugins-jvm"
   .settings(
     publish / skip := true,
     crossScalaVersions := Nil,
-    scalaVersion := "2.12.13"
+    scalaVersion := "2.12.14-bin-SNAPSHOT"
   )
   .disablePlugins(AssemblyPlugin)
   .aggregate(
@@ -3527,7 +3679,7 @@ lazy val `izumi-jvm` = (project in file(".agg/.agg-jvm"))
     publish / skip := true,
     crossScalaVersions := Seq(
       "2.13.6-bin-SNAPSHOT",
-      "2.12.13"
+      "2.12.14-bin-SNAPSHOT"
     ),
     scalaVersion := crossScalaVersions.value.head
   )

--- a/distage/distage-core-api/.js/src/main/scala/izumi/distage/model/effect/QuasiIORunner.scala
+++ b/distage/distage-core-api/.js/src/main/scala/izumi/distage/model/effect/QuasiIORunner.scala
@@ -9,7 +9,7 @@ object QuasiIORunner {
 
   def fromCats[F[_]: Effect]: QuasiIORunner[F] = forAny[F]
 
-  class BIOImpl[F[_, _]] extends QuasiIORunner[F[Throwable, ?]]
+  class BIOImpl[F[_, _]] extends QuasiIORunner[F[Throwable, _]]
 
   implicit def forAny[F[_]]: QuasiIORunner[F] = new QuasiIORunner[F] {}
 }

--- a/distage/distage-core-api/.js/src/main/scala/izumi/distage/model/reflection/MirrorProvider.scala
+++ b/distage/distage-core-api/.js/src/main/scala/izumi/distage/model/reflection/MirrorProvider.scala
@@ -3,14 +3,14 @@ package izumi.distage.model.reflection
 import izumi.fundamentals.reflection.TypeUtil
 
 trait MirrorProvider {
-  def runtimeClass(tpe: SafeType): Option[Class[_]]
+  def runtimeClass(tpe: SafeType): Option[Class[?]]
   def runtimeClassCompatible(tpe: SafeType, value: Any): Boolean
   def canBeProxied(tpe: SafeType): Boolean
 }
 
 object MirrorProvider {
   object Impl extends MirrorProvider {
-    override def runtimeClass(tpe: SafeType): Option[Class[_]] = {
+    override def runtimeClass(tpe: SafeType): Option[Class[?]] = {
       if (tpe.hasPreciseClass) Some(tpe.cls) else None
     }
     override def canBeProxied(tpe: SafeType): Boolean = {

--- a/distage/distage-core-api/.jvm/src/main/scala/izumi/distage/model/effect/QuasiIORunner.scala
+++ b/distage/distage-core-api/.jvm/src/main/scala/izumi/distage/model/effect/QuasiIORunner.scala
@@ -25,9 +25,9 @@ object QuasiIORunner extends LowPriorityQuasiIORunnerInstances {
     override def run[A](f: => A): A = f
   }
 
-  implicit def fromBIO[F[_, _]: UnsafeRun2]: QuasiIORunner[F[Throwable, ?]] = new BIOImpl[F]
+  implicit def fromBIO[F[_, _]: UnsafeRun2]: QuasiIORunner[F[Throwable, _]] = new BIOImpl[F]
 
-  final class BIOImpl[F[_, _]: UnsafeRun2] extends QuasiIORunner[F[Throwable, ?]] {
+  final class BIOImpl[F[_, _]: UnsafeRun2] extends QuasiIORunner[F[Throwable, _]] {
     override def run[A](f: => F[Throwable, A]): A = UnsafeRun2[F].unsafeRun(f)
   }
 

--- a/distage/distage-core-api/.jvm/src/main/scala/izumi/distage/model/reflection/MirrorProvider.scala
+++ b/distage/distage-core-api/.jvm/src/main/scala/izumi/distage/model/reflection/MirrorProvider.scala
@@ -5,14 +5,14 @@ import java.lang.reflect.Modifier
 import izumi.fundamentals.reflection.TypeUtil
 
 trait MirrorProvider {
-  def runtimeClass(tpe: SafeType): Option[Class[_]]
+  def runtimeClass(tpe: SafeType): Option[Class[?]]
   def runtimeClassCompatible(tpe: SafeType, value: Any): Boolean
   def canBeProxied(tpe: SafeType): Boolean
 }
 
 object MirrorProvider {
   object Impl extends MirrorProvider {
-    override def runtimeClass(tpe: SafeType): Option[Class[_]] = {
+    override def runtimeClass(tpe: SafeType): Option[Class[?]] = {
       if (tpe.hasPreciseClass) Some(tpe.cls) else None
     }
     override def canBeProxied(tpe: SafeType): Boolean = {

--- a/distage/distage-core-api/src/main/scala/izumi/distage/constructors/macros/AnyConstructorMacro.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/constructors/macros/AnyConstructorMacro.scala
@@ -33,6 +33,7 @@ object AnyConstructorMacro {
     assert(enclosingClass.exists(_.pos == positionOfMakeCall), "enclosingClass must contain macro call position")
 
     def findExprContainingMake(tree: Tree): Option[Tree] = {
+      @nowarn("msg=outer reference")
       val afterLastBlock = Option {
         tree
           .filter(_.exists(_.pos == positionOfMakeCall))

--- a/distage/distage-core-api/src/main/scala/izumi/distage/constructors/macros/ClassConstructorMacro.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/constructors/macros/ClassConstructorMacro.scala
@@ -6,6 +6,7 @@ import izumi.distage.model.reflection.universe.StaticDIUniverse
 import izumi.distage.reflection.ReflectionProviderDefaultImpl
 import izumi.fundamentals.reflection.{ReflectionUtil, TrivialMacroLogger}
 
+import scala.annotation.nowarn
 import scala.reflect.macros.blackbox
 
 object ClassConstructorMacro {
@@ -16,7 +17,7 @@ object ClassConstructorMacro {
     val targetType = ReflectionUtil.norm(c.universe: c.universe.type)(weakTypeOf[T].dealias)
     requireConcreteTypeConstructor(c)("ClassConstructor", targetType)
 
-    targetType match {
+    (targetType match {
       case t: SingletonTypeApi =>
         val functoid = symbolOf[Functoid.type].asClass.module
         val term = t match {
@@ -49,7 +50,7 @@ object ClassConstructorMacro {
         val res = c.Expr[ClassConstructor[T]](q"{ new ${weakTypeOf[ClassConstructor[T]]}($provider) }")
         logger.log(s"Final syntax tree of class for $targetType:\n$res")
         res
-    }
+    }): @nowarn("msg=outer reference")
   }
 
 }

--- a/distage/distage-core-api/src/main/scala/izumi/distage/constructors/macros/ConstructorMacros.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/constructors/macros/ConstructorMacros.scala
@@ -7,7 +7,7 @@ import izumi.distage.model.reflection.universe.StaticDIUniverse
 import izumi.distage.model.reflection.{Provider, ReflectionProvider}
 import izumi.fundamentals.reflection.ReflectionUtil
 
-import scala.annotation.tailrec
+import scala.annotation.{nowarn, tailrec}
 import scala.reflect.macros.blackbox
 
 abstract class ClassConstructorMacros extends ConstructorMacrosBase {
@@ -115,6 +115,7 @@ abstract class FactoryConstructorMacros extends ConstructorMacrosBase {
     val u.Wiring.Factory.FactoryMethod(factoryMethod, productConstructor, _) = factoryMethod0
 
     val (methodArgListDecls, methodArgList) = {
+      @nowarn("msg=outer reference")
       @tailrec def instantiatedMethod(tpe: Type): MethodTypeApi = {
         tpe match {
           case m: MethodTypeApi => m

--- a/distage/distage-core-api/src/main/scala/izumi/distage/constructors/macros/ConstructorMacros.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/constructors/macros/ConstructorMacros.scala
@@ -78,7 +78,7 @@ abstract class TraitConstructorMacros extends ConstructorMacrosBase {
 
   def traitConstructorAssertion(targetType: Type): Unit = {
     ReflectionUtil
-      .deepIntersectionTypeMembers[c.universe.type](targetType)
+      .deepIntersectionTypeMembers(c.universe: c.universe.type)(targetType)
       .find(tpe => tpe.typeSymbol.isParameter || tpe.typeSymbol.isFinal)
       .foreach {
         err =>
@@ -258,7 +258,7 @@ abstract class ConstructorMacrosBase {
     constructorParameters: List[List[Tree]],
     methodImpls: List[Tree],
   ): Tree = {
-    val parents = ReflectionUtil.deepIntersectionTypeMembers[u.u.type](targetType)
+    val parents = ReflectionUtil.deepIntersectionTypeMembers(u.u: u.u.type)(targetType)
     parents match {
       case parent :: Nil if parent.typeSymbol.isClass && !parent.typeSymbol.asClass.isTrait =>
         if (methodImpls.isEmpty) {

--- a/distage/distage-core-api/src/main/scala/izumi/distage/constructors/macros/ConstructorMacros.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/constructors/macros/ConstructorMacros.scala
@@ -78,7 +78,7 @@ abstract class TraitConstructorMacros extends ConstructorMacrosBase {
 
   def traitConstructorAssertion(targetType: Type): Unit = {
     ReflectionUtil
-      .deepIntersectionTypeMembers(c.universe: c.universe.type)(targetType)
+      .deepIntersectionTypeMembers[c.universe.type](targetType)
       .find(tpe => tpe.typeSymbol.isParameter || tpe.typeSymbol.isFinal)
       .foreach {
         err =>
@@ -258,7 +258,7 @@ abstract class ConstructorMacrosBase {
     constructorParameters: List[List[Tree]],
     methodImpls: List[Tree],
   ): Tree = {
-    val parents = ReflectionUtil.deepIntersectionTypeMembers(u.u: u.u.type)(targetType)
+    val parents = ReflectionUtil.deepIntersectionTypeMembers[u.u.type](targetType)
     parents match {
       case parent :: Nil if parent.typeSymbol.isClass && !parent.typeSymbol.asClass.isTrait =>
         if (methodImpls.isEmpty) {

--- a/distage/distage-core-api/src/main/scala/izumi/distage/constructors/macros/HasConstructorMacro.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/constructors/macros/HasConstructorMacro.scala
@@ -20,7 +20,7 @@ object HasConstructorMacro {
     val targetType = ReflectionUtil.norm(c.universe: c.universe.type)(weakTypeOf[T].dealias)
     requireConcreteTypeConstructor(c)("HasConstructor", targetType)
     val deepIntersection = ReflectionUtil
-      .deepIntersectionTypeMembers(c.universe: c.universe.type)(targetType)
+      .deepIntersectionTypeMembers[c.universe.type](targetType)
       .filter(_ ne definitions.AnyTpe)
 
     targetType match {

--- a/distage/distage-core-api/src/main/scala/izumi/distage/constructors/macros/HasConstructorMacro.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/constructors/macros/HasConstructorMacro.scala
@@ -20,7 +20,7 @@ object HasConstructorMacro {
     val targetType = ReflectionUtil.norm(c.universe: c.universe.type)(weakTypeOf[T].dealias)
     requireConcreteTypeConstructor(c)("HasConstructor", targetType)
     val deepIntersection = ReflectionUtil
-      .deepIntersectionTypeMembers[c.universe.type](targetType)
+      .deepIntersectionTypeMembers(c.universe: c.universe.type)(targetType)
       .filter(_ ne definitions.AnyTpe)
 
     targetType match {

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/PlannerInput.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/PlannerInput.scala
@@ -33,14 +33,14 @@ object PlannerInput {
     *
     * Effectively, this selects and creates a *sub-graph* of the largest possible object graph that can be described by `bindings`
     */
-  def apply(bindings: ModuleBase, activation: Activation, roots: NonEmptySet[_ <: DIKey]): PlannerInput = PlannerInput(bindings, activation, Roots(roots))
+  def apply(bindings: ModuleBase, activation: Activation, roots: NonEmptySet[? <: DIKey]): PlannerInput = PlannerInput(bindings, activation, Roots(roots))
 
   /**
     * Instantiate `roots` and the dependencies of `roots`, discarding bindings that are unrelated.
     *
     * Effectively, this selects and creates a *sub-graph* of the largest possible object graph that can be described by `bindings`
     */
-  def apply(bindings: ModuleBase, activation: Activation, roots: Set[_ <: DIKey])(implicit d: DummyImplicit): PlannerInput =
+  def apply(bindings: ModuleBase, activation: Activation, roots: Set[? <: DIKey])(implicit d: DummyImplicit): PlannerInput =
     PlannerInput(bindings, activation, Roots(roots))
 
   /** Instantiate `root`, `roots` and their dependencies, discarding bindings that are unrelated.

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/Lifecycle.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/Lifecycle.scala
@@ -332,12 +332,12 @@ object Lifecycle extends LifecycleCatsInstances {
     *
     * @return The [[izumi.functional.bio.Fiber2 fiber]] running `f` action
     */
-  def fork[F[+_, +_]: Fork2, E, A](f: F[E, A]): Lifecycle[F[Nothing, ?], Fiber2[F, E, A]] = {
+  def fork[F[+_, +_]: Fork2, E, A](f: F[E, A]): Lifecycle[F[Nothing, _], Fiber2[F, E, A]] = {
     Lifecycle.make(f.fork)(_.interrupt)
   }
 
   /** @see [[fork]] */
-  def fork_[F[+_, +_]: Fork2: Functor2, E, A](f: F[E, A]): Lifecycle[F[Nothing, ?], Unit] = {
+  def fork_[F[+_, +_]: Fork2: Functor2, E, A](f: F[E, A]): Lifecycle[F[Nothing, _], Unit] = {
     Lifecycle.fork(f).void
   }
 
@@ -440,8 +440,8 @@ object Lifecycle extends LifecycleCatsInstances {
     }
   }
 
-  implicit final class SyntaxWidenError[F[+_, +_], +E, +A](private val resource: Lifecycle[F[E, ?], A]) extends AnyVal {
-    def widenError[E1 >: E]: Lifecycle[F[E1, ?], A] = resource
+  implicit final class SyntaxWidenError[F[+_, +_], +E, +A](private val resource: Lifecycle[F[E, _], A]) extends AnyVal {
+    def widenError[E1 >: E]: Lifecycle[F[E1, _], A] = resource
   }
 
   /** Convert [[cats.effect.Resource]] to [[Lifecycle]] */
@@ -539,7 +539,7 @@ object Lifecycle extends LifecycleCatsInstances {
     }
   }
 
-  implicit final class SyntaxLifecycleZIO[-R, +E, +A](private val resource: Lifecycle[ZIO[R, E, ?], A]) extends AnyVal {
+  implicit final class SyntaxLifecycleZIO[-R, +E, +A](private val resource: Lifecycle[ZIO[R, E, _], A]) extends AnyVal {
     /** Convert [[Lifecycle]] to [[zio.ZManaged]] */
     def toZIO: ZManaged[R, E, A] = {
       ZManaged.makeReserve(
@@ -558,12 +558,12 @@ object Lifecycle extends LifecycleCatsInstances {
     }
   }
 
-  implicit final def functor2ForLifecycle[F[+_, +_]: Functor2]: Functor2[Lifecycle2[F, +?, +?]] = new Functor2[Lifecycle2[F, +?, +?]] {
-    override def map[R, E, A, B](r: Lifecycle[F[E, ?], A])(f: A => B): Lifecycle[F[E, ?], B] = r.map(f)
+  implicit final def functor2ForLifecycle[F[+_, +_]: Functor2]: Functor2[Lifecycle2[F, +_, +_]] = new Functor2[Lifecycle2[F, +_, +_]] {
+    override def map[R, E, A, B](r: Lifecycle[F[E, _], A])(f: A => B): Lifecycle[F[E, _], B] = r.map(f)
   }
 
-  implicit final def functor3ForLifecycle[F[-_, +_, +_]: Functor3]: Functor3[Lifecycle3[F, -?, +?, +?]] = new Functor3[Lifecycle3[F, -?, +?, +?]] {
-    override def map[R, E, A, B](r: Lifecycle[F[R, E, ?], A])(f: A => B): Lifecycle[F[R, E, ?], B] = r.map(f)
+  implicit final def functor3ForLifecycle[F[-_, +_, +_]: Functor3]: Functor3[Lifecycle3[F, -_, +_, +_]] = new Functor3[Lifecycle3[F, -_, +_, +_]] {
+    override def map[R, E, A, B](r: Lifecycle[F[R, E, _], A])(f: A => B): Lifecycle[F[R, E, _], B] = r.map(f)
   }
 
   /**
@@ -623,7 +623,7 @@ object Lifecycle extends LifecycleCatsInstances {
     *   }
     * }}}
     */
-  @open class OfZIO[-R, +E, +A](inner: => ZManaged[R, E, A]) extends Lifecycle.Of[ZIO[R, E, ?], A](fromZIO(inner))
+  @open class OfZIO[-R, +E, +A](inner: => ZManaged[R, E, A]) extends Lifecycle.Of[ZIO[R, E, _], A](fromZIO(inner))
 
   /**
     * Class-based variant of [[make]]:
@@ -803,7 +803,7 @@ object Lifecycle extends LifecycleCatsInstances {
     override final type InnerResource = concurrent.Ref[F, List[ExitCase[Throwable] => F[Unit]]]
   }
 
-  trait FromZIO[R, E, A] extends Lifecycle[ZIO[R, E, ?], A] {
+  trait FromZIO[R, E, A] extends Lifecycle[ZIO[R, E, _], A] {
     override final type InnerResource = ReleaseMap
     override final def acquire: ZIO[R, E, ReleaseMap] = ReleaseMap.make
     override final def release(releaseMap: ReleaseMap): ZIO[R, Nothing, Unit] = releaseMap.releaseAll(zio.Exit.succeed(()), zio.ExecutionStrategy.Sequential).unit
@@ -1062,11 +1062,11 @@ object Lifecycle extends LifecycleCatsInstances {
 private[definition] sealed trait LifecycleCatsInstances extends LifecycleCatsInstancesLowPriority {
   implicit final def catsMonadForLifecycle[Monad[_[_]]: `cats.Monad`, F[_]](
     implicit F: QuasiIO[F]
-  ): Monad[Lifecycle[F, ?]] = {
-    new cats.StackSafeMonad[Lifecycle[F, ?]] {
+  ): Monad[Lifecycle[F, _]] = {
+    new cats.StackSafeMonad[Lifecycle[F, _]] {
       override def pure[A](x: A): Lifecycle[F, A] = Lifecycle.pure[F](x)
       override def flatMap[A, B](fa: Lifecycle[F, A])(f: A => Lifecycle[F, B]): Lifecycle[F, B] = fa.flatMap(f)
-    }.asInstanceOf[Monad[Lifecycle[F, ?]]]
+    }.asInstanceOf[Monad[Lifecycle[F, _]]]
   }
 
   implicit final def catsMonoidForLifecycle[Monoid[_]: `cats.kernel.Monoid`, F[_], A](
@@ -1090,10 +1090,10 @@ private[definition] sealed trait LifecycleCatsInstances extends LifecycleCatsIns
 private[definition] sealed trait LifecycleCatsInstancesLowPriority {
   implicit final def catsFunctorForLifecycle[F[_], Functor[_[_]]: `cats.Functor`](
     implicit F: QuasiFunctor[F]
-  ): Functor[Lifecycle[F, ?]] = {
-    new cats.Functor[Lifecycle[F, ?]] {
+  ): Functor[Lifecycle[F, _]] = {
+    new cats.Functor[Lifecycle[F, _]] {
       override def map[A, B](fa: Lifecycle[F, A])(f: A => B): Lifecycle[F, B] = fa.map(f)
-    }.asInstanceOf[Functor[Lifecycle[F, ?]]]
+    }.asInstanceOf[Functor[Lifecycle[F, _]]]
   }
 }
 
@@ -1228,22 +1228,22 @@ private[definition] trait TrifunctorHasLifecycleTagImpl[R0, T] {
   type E
   type A <: T
   implicit def tagLocal3: Tag[Local3[F]]
-  implicit def tagFull: Tag[Lifecycle[F[Any, E, ?], A]]
+  implicit def tagFull: Tag[Lifecycle[F[Any, E, _], A]]
   implicit def ctorR: HasConstructor[R]
-  implicit def ev: R0 <:< Lifecycle[F[R, E, ?], A]
-  implicit def resourceTag: LifecycleTagImpl[Lifecycle[F[Any, E, ?], A]]
+  implicit def ev: R0 <:< Lifecycle[F[R, E, _], A]
+  implicit def resourceTag: LifecycleTagImpl[Lifecycle[F[Any, E, _], A]]
 }
 private[definition] object TrifunctorHasLifecycleTagImpl extends TrifunctorHasLifecycleTagLowPriority {
   import scala.annotation.unchecked.{uncheckedVariance => v}
 
   implicit def trifunctorResourceTag[
-    R1 <: Lifecycle[F0[R0, E0, ?], A0],
+    R1 <: Lifecycle[F0[R0, E0, _], A0],
     F0[_, _, _]: TagK3,
     R0: HasConstructor,
     E0: Tag,
     A0 <: A1: Tag,
     A1,
-  ]: TrifunctorHasLifecycleTagImpl[R1 with Lifecycle[F0[R0, E0, ?], A0], A1] {
+  ]: TrifunctorHasLifecycleTagImpl[R1 with Lifecycle[F0[R0, E0, _], A0], A1] {
     type R = R0
     type E = E0
     type A = A0
@@ -1255,13 +1255,13 @@ private[definition] object TrifunctorHasLifecycleTagImpl extends TrifunctorHasLi
     type A = A0
     val tagLocal3: Tag[Local3[F]] = implicitly
     val ctorR: HasConstructor[R0] = implicitly
-    val tagFull: Tag[Lifecycle[F0[Any, E0, ?], A0]] = implicitly
-    val ev: R1 <:< Lifecycle[F0[R0, E0, ?], A0] = implicitly
-    val resourceTag: LifecycleTagImpl[Lifecycle[F0[Any, E0, ?], A0]] = new LifecycleTagImpl[Lifecycle[F0[Any, E0, ?], A0]] {
+    val tagFull: Tag[Lifecycle[F0[Any, E0, _], A0]] = implicitly
+    val ev: R1 <:< Lifecycle[F0[R0, E0, _], A0] = implicitly
+    val resourceTag: LifecycleTagImpl[Lifecycle[F0[Any, E0, _], A0]] = new LifecycleTagImpl[Lifecycle[F0[Any, E0, _], A0]] {
       type F[AA] = F0[Any, E0, AA]
       type A = A0
-      val tagFull: Tag[Lifecycle[F0[Any, E0, ?], A0]] = self.tagFull
-      val tagK: TagK[F0[Any, E0, ?]] = TagK[F0[Any, E0, ?]]
+      val tagFull: Tag[Lifecycle[F0[Any, E0, _], A0]] = self.tagFull
+      val tagK: TagK[F0[Any, E0, _]] = TagK[F0[Any, E0, _]]
       val tagA: Tag[A0] = implicitly
     }
   }
@@ -1270,12 +1270,12 @@ sealed trait TrifunctorHasLifecycleTagLowPriority extends TrifunctorHasLifecycle
   import scala.annotation.unchecked.{uncheckedVariance => v}
 
   implicit def trifunctorResourceTagNothing[
-    R1 <: Lifecycle[F0[R0, Nothing, ?], A0],
+    R1 <: Lifecycle[F0[R0, Nothing, _], A0],
     F0[_, _, _]: TagK3,
     R0: HasConstructor,
     A0 <: A1: Tag,
     A1,
-  ]: TrifunctorHasLifecycleTagImpl[R1 with Lifecycle[F0[R0, Nothing, ?], A0], A1] {
+  ]: TrifunctorHasLifecycleTagImpl[R1 with Lifecycle[F0[R0, Nothing, _], A0], A1] {
     type R = R0
     type E = Nothing
     type A = A0

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/LocatorDef.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/LocatorDef.scala
@@ -97,7 +97,7 @@ object LocatorDef {
       addOp(SetImpl(impl))(new BindDSLUnnamedAfterFrom[T](_, key))
   }
 
-  final class BindNamedDSL[T](protected val mutableState: SingletonRef, protected val key: DIKey.IdKey[_])
+  final class BindNamedDSL[T](protected val mutableState: SingletonRef, protected val key: DIKey.IdKey[?])
     extends BindDSLBase[T, BindDSLNamedAfterFrom[T]]
     with BindDSLMutBase[T] {
     override protected def bind(impl: ImplDef): BindDSLNamedAfterFrom[T] =
@@ -109,7 +109,7 @@ object LocatorDef {
       addOp(SetId(name))(new BindNamedDSL[T](_, key.named(name)))
   }
 
-  final class BindDSLNamedAfterFrom[T](override protected val mutableState: SingletonRef, override protected val key: DIKey.IdKey[_]) extends BindDSLMutBase[T]
+  final class BindDSLNamedAfterFrom[T](override protected val mutableState: SingletonRef, override protected val key: DIKey.IdKey[?]) extends BindDSLMutBase[T]
   final class BindDSLAfterAlias[T](override protected val mutableState: SingletonRef, override protected val key: DIKey) extends BindDSLMutBase[T]
 
   sealed trait BindDSLMutBase[T] {

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/dsl/ModuleDefDSL.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/dsl/ModuleDefDSL.scala
@@ -415,25 +415,25 @@ object ModuleDefDSL {
       *   many[T].addSet(Set(new T, new T, new T))
       * }}}
       */
-    final def addSet[I <: Set[_ <: T]: Tag](function: => I)(implicit pos: CodePositionMaterializer): AfterMultiAdd =
+    final def addSet[I <: Set[? <: T]: Tag](function: => I)(implicit pos: CodePositionMaterializer): AfterMultiAdd =
       addSet(Functoid.lift(function))
 
-    final def addSet[I <: Set[_ <: T]](function: Functoid[I])(implicit pos: CodePositionMaterializer): AfterMultiAdd =
+    final def addSet[I <: Set[? <: T]](function: Functoid[I])(implicit pos: CodePositionMaterializer): AfterMultiAdd =
       multiSetAdd(ImplDef.ProviderImpl(function.get.ret, function.get), pos)
 
-    final def addSetValue[I <: Set[_ <: T]: Tag](instance: I)(implicit pos: CodePositionMaterializer): AfterMultiAdd =
+    final def addSetValue[I <: Set[? <: T]: Tag](instance: I)(implicit pos: CodePositionMaterializer): AfterMultiAdd =
       multiSetAdd(ImplDef.InstanceImpl(SafeType.get[I], instance), pos)
 
-    final def refSet[I <: Set[_ <: T]: Tag](implicit pos: CodePositionMaterializer): AfterAdd =
+    final def refSet[I <: Set[? <: T]: Tag](implicit pos: CodePositionMaterializer): AfterAdd =
       appendElement(ImplDef.ReferenceImpl(SafeType.get[I], DIKey.get[I], weak = false), pos)
 
-    final def refSet[I <: Set[_ <: T]: Tag](name: Identifier)(implicit pos: CodePositionMaterializer): AfterAdd =
+    final def refSet[I <: Set[? <: T]: Tag](name: Identifier)(implicit pos: CodePositionMaterializer): AfterAdd =
       appendElement(ImplDef.ReferenceImpl(SafeType.get[I], DIKey.get[I].named(name), weak = false), pos)
 
-    final def weakSet[I <: Set[_ <: T]: Tag](implicit pos: CodePositionMaterializer): AfterAdd =
+    final def weakSet[I <: Set[? <: T]: Tag](implicit pos: CodePositionMaterializer): AfterAdd =
       appendElement(ImplDef.ReferenceImpl(SafeType.get[I], DIKey.get[I], weak = true), pos)
 
-    final def weakSet[I <: Set[_ <: T]: Tag](name: Identifier)(implicit pos: CodePositionMaterializer): AfterAdd =
+    final def weakSet[I <: Set[? <: T]: Tag](name: Identifier)(implicit pos: CodePositionMaterializer): AfterAdd =
       appendElement(ImplDef.ReferenceImpl(SafeType.get[I], DIKey.get[I].named(name), weak = true), pos)
 
     protected[this] def multiSetAdd(newImpl: ImplDef, pos: CodePositionMaterializer): AfterMultiAdd
@@ -443,10 +443,10 @@ object ModuleDefDSL {
   object MakeDSLBase {
     implicit final class MakeFromZIOHas[T, AfterBind](protected val dsl: MakeDSLBase[T, AfterBind]) extends AnyVal with MakeFromHasLowPriorityOverloads[T, AfterBind] {
       def fromHas[R: HasConstructor, E: Tag, I <: T: Tag](effect: ZIO[R, E, I]): AfterBind = {
-        dsl.fromEffect[IO[E, ?], I](HasConstructor[R].map(effect.provide))
+        dsl.fromEffect[IO[E, _], I](HasConstructor[R].map(effect.provide))
       }
       def fromHas[R: HasConstructor, E: Tag, I <: T: Tag](function: Functoid[ZIO[R, E, I]]): AfterBind = {
-        dsl.fromEffect[IO[E, ?], I](function.map2(HasConstructor[R])(_.provide(_)))
+        dsl.fromEffect[IO[E, _], I](function.map2(HasConstructor[R])(_.provide(_)))
       }
 
       def fromHas[R: HasConstructor, E: Tag, I <: T: Tag](resource: ZManaged[R, E, I]): AfterBind = {
@@ -471,7 +471,7 @@ object ModuleDefDSL {
         */
       def fromHas[R1 <: Lifecycle[Any, T]: AnyConstructor](implicit tag: TrifunctorHasLifecycleTag[R1, T]): AfterBind = {
         import tag._
-        val provider: Functoid[Lifecycle[F[Any, E, ?], A]] =
+        val provider: Functoid[Lifecycle[F[Any, E, _], A]] =
           AnyConstructor[R1].zip(HasConstructor[R]).map2(Functoid.identity[Local3[F]](tagLocal3)) {
             case ((resource, r), f) => provideLifecycle(f)(resource, r)
           }
@@ -483,14 +483,14 @@ object ModuleDefDSL {
 
       /** Adds a dependency on `Local3[F]` */
       final def fromHas[F[-_, +_, +_]: TagK3, R: HasConstructor, E: Tag, I <: T: Tag](effect: F[R, E, I]): AfterBind = {
-        dsl.fromEffect[F[Any, E, ?], I](HasConstructor[R].map2(Functoid.identity[Local3[F]]) {
+        dsl.fromEffect[F[Any, E, _], I](HasConstructor[R].map2(Functoid.identity[Local3[F]]) {
           (r, F: Local3[F]) => F.provide(effect)(r)
         })
       }
 
       /** Adds a dependency on `Local3[F]` */
       final def fromHas[F[-_, +_, +_]: TagK3, R: HasConstructor, E: Tag, I <: T: Tag](function: Functoid[F[R, E, I]]): AfterBind = {
-        dsl.fromEffect[F[Any, E, ?], I](function.zip(HasConstructor[R]).map2(Functoid.identity[Local3[F]]) {
+        dsl.fromEffect[F[Any, E, _], I](function.zip(HasConstructor[R]).map2(Functoid.identity[Local3[F]]) {
           case ((effect, r), f) => f.provide(effect)(r)
         })
       }
@@ -501,8 +501,8 @@ object ModuleDefDSL {
         * Warning: removes the precise subtype of Lifecycle because of `Lifecycle.map`:
         * Integration checks on mixed-in as a trait onto a Lifecycle value result here will be lost
         */
-      final def fromHas[F[-_, +_, +_]: TagK3, R: HasConstructor, E: Tag, I <: T: Tag](resource: Lifecycle[F[R, E, ?], I]): AfterBind = {
-        dsl.fromResource[Lifecycle[F[Any, E, ?], I]](HasConstructor[R].map2(Functoid.identity[Local3[F]]) {
+      final def fromHas[F[-_, +_, +_]: TagK3, R: HasConstructor, E: Tag, I <: T: Tag](resource: Lifecycle[F[R, E, _], I]): AfterBind = {
+        dsl.fromResource[Lifecycle[F[Any, E, _], I]](HasConstructor[R].map2(Functoid.identity[Local3[F]]) {
           (r: R, F: Local3[F]) => provideLifecycle(F)(resource, r)
         })
       }
@@ -514,10 +514,10 @@ object ModuleDefDSL {
         * Integration checks on mixed-in as a trait onto a Lifecycle value result here will be lost
         */
       final def fromHas[F[-_, +_, +_]: TagK3, R: HasConstructor, E: Tag, I <: T: Tag](
-        function: Functoid[Lifecycle[F[R, E, ?], I]]
+        function: Functoid[Lifecycle[F[R, E, _], I]]
       )(implicit d1: DummyImplicit
       ): AfterBind = {
-        dsl.fromResource[Lifecycle[F[Any, E, ?], I]](function.zip(HasConstructor[R]).map2(Functoid.identity[Local3[F]]) {
+        dsl.fromResource[Lifecycle[F[Any, E, _], I]](function.zip(HasConstructor[R]).map2(Functoid.identity[Local3[F]]) {
           case ((resource, r), f) => provideLifecycle(f)(resource, r)
         })
       }
@@ -525,12 +525,12 @@ object ModuleDefDSL {
   }
 
   object SetDSLBase {
-    implicit final class AddFromZIOHas[T, AfterAdd](protected val dsl: SetDSLBase[T, AfterAdd, _]) extends AnyVal with AddFromHasLowPriorityOverloads[T, AfterAdd] {
+    implicit final class AddFromZIOHas[T, AfterAdd](protected val dsl: SetDSLBase[T, AfterAdd, ?]) extends AnyVal with AddFromHasLowPriorityOverloads[T, AfterAdd] {
       def addHas[R: HasConstructor, E: Tag, I <: T: Tag](effect: ZIO[R, E, I])(implicit pos: CodePositionMaterializer): AfterAdd = {
-        dsl.addEffect[IO[E, ?], I](HasConstructor[R].map(effect.provide))
+        dsl.addEffect[IO[E, _], I](HasConstructor[R].map(effect.provide))
       }
       def addHas[R: HasConstructor, E: Tag, I <: T: Tag](function: Functoid[ZIO[R, E, I]])(implicit pos: CodePositionMaterializer): AfterAdd = {
-        dsl.addEffect[IO[E, ?], I](function.map2(HasConstructor[R])(_.provide(_)))
+        dsl.addEffect[IO[E, _], I](function.map2(HasConstructor[R])(_.provide(_)))
       }
 
       def addHas[R: HasConstructor, E: Tag, I <: T: Tag](resource: ZManaged[R, E, I])(implicit pos: CodePositionMaterializer): AfterAdd = {
@@ -564,7 +564,7 @@ object ModuleDefDSL {
         */
       final def addHas[R1 <: Lifecycle[Any, T]: AnyConstructor](implicit tag: TrifunctorHasLifecycleTag[R1, T], pos: CodePositionMaterializer): AfterAdd = {
         import tag._
-        val provider: Functoid[Lifecycle[F[Any, E, ?], A]] =
+        val provider: Functoid[Lifecycle[F[Any, E, _], A]] =
           AnyConstructor[R1].zip(HasConstructor[R]).map2(Functoid.identity[Local3[F]](tagLocal3)) {
             case ((resource, r), f) => provideLifecycle(f)(resource, r)
           }
@@ -572,11 +572,11 @@ object ModuleDefDSL {
       }
     }
     sealed trait AddFromHasLowPriorityOverloads[T, AfterAdd] extends Any {
-      protected[this] def dsl: SetDSLBase[T, AfterAdd, _]
+      protected[this] def dsl: SetDSLBase[T, AfterAdd, ?]
 
       /** Adds a dependency on `Local3[F]` */
       final def addHas[F[-_, +_, +_]: TagK3, R: HasConstructor, E: Tag, I <: T: Tag](effect: F[R, E, I])(implicit pos: CodePositionMaterializer): AfterAdd = {
-        dsl.addEffect[F[Any, E, ?], I](HasConstructor[R].map2(Functoid.identity[Local3[F]]) {
+        dsl.addEffect[F[Any, E, _], I](HasConstructor[R].map2(Functoid.identity[Local3[F]]) {
           (r, F: Local3[F]) => F.provide(effect)(r)
         })
       }
@@ -586,7 +586,7 @@ object ModuleDefDSL {
         function: Functoid[F[R, E, I]]
       )(implicit pos: CodePositionMaterializer
       ): AfterAdd = {
-        dsl.addEffect[F[Any, E, ?], I](function.zip(HasConstructor[R]).map2(Functoid.identity[Local3[F]]) {
+        dsl.addEffect[F[Any, E, _], I](function.zip(HasConstructor[R]).map2(Functoid.identity[Local3[F]]) {
           case ((effect, r), f) => f.provide(effect)(r)
         })
       }
@@ -598,10 +598,10 @@ object ModuleDefDSL {
         * Integration checks on mixed-in as a trait onto a Lifecycle value result here will be lost
         */
       final def addHas[F[-_, +_, +_]: TagK3, R: HasConstructor, E: Tag, I <: T: Tag](
-        resource: Lifecycle[F[R, E, ?], I]
+        resource: Lifecycle[F[R, E, _], I]
       )(implicit pos: CodePositionMaterializer
       ): AfterAdd = {
-        dsl.addResource[Lifecycle[F[Any, E, ?], I]](HasConstructor[R].map2(Functoid.identity[Local3[F]]) {
+        dsl.addResource[Lifecycle[F[Any, E, _], I]](HasConstructor[R].map2(Functoid.identity[Local3[F]]) {
           (r: R, F: Local3[F]) => provideLifecycle(F)(resource, r)
         })
       }
@@ -613,11 +613,11 @@ object ModuleDefDSL {
         * Integration checks on mixed-in as a trait onto a Lifecycle value result here will be lost
         */
       final def addHas[F[-_, +_, +_]: TagK3, R: HasConstructor, E: Tag, I <: T: Tag](
-        function: Functoid[Lifecycle[F[R, E, ?], I]]
+        function: Functoid[Lifecycle[F[R, E, _], I]]
       )(implicit pos: CodePositionMaterializer,
         d1: DummyImplicit,
       ): AfterAdd = {
-        dsl.addResource[Lifecycle[F[Any, E, ?], I]](function.zip(HasConstructor[R]).map2(Functoid.identity[Local3[F]]) {
+        dsl.addResource[Lifecycle[F[Any, E, _], I]](function.zip(HasConstructor[R]).map2(Functoid.identity[Local3[F]]) {
           case ((resource, r), f) => provideLifecycle(f)(resource, r)
         })
       }
@@ -625,8 +625,8 @@ object ModuleDefDSL {
     }
   }
 
-  @inline private[this] def provideLifecycle[F[-_, +_, +_], R, E, A](F: Local3[F])(resource: Lifecycle[F[R, E, ?], A], r: R): Lifecycle[F[Any, E, ?], A] = {
-    resource.mapK(Morphism1[F[R, E, ?], F[Any, E, ?]](F.provide(_)(r)))
+  @inline private[this] def provideLifecycle[F[-_, +_, +_], R, E, A](F: Local3[F])(resource: Lifecycle[F[R, E, _], A], r: R): Lifecycle[F[Any, E, _], A] = {
+    resource.mapK(Morphism1[F[R, E, _], F[Any, E, _]](F.provide(_)(r)))
   }
 
   // DSL state machine

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/package.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/package.scala
@@ -1,8 +1,8 @@
 package izumi.distage.model
 
 package object definition {
-  type Lifecycle2[+F[+_, +_], +E, +A] = Lifecycle[F[E, ?], A]
-  type Lifecycle3[+F[-_, +_, +_], -R, +E, +A] = Lifecycle[F[R, E, ?], A]
+  type Lifecycle2[+F[+_, +_], +E, +A] = Lifecycle[F[E, _], A]
+  type Lifecycle3[+F[-_, +_, +_], -R, +E, +A] = Lifecycle[F[R, E, _], A]
 
   @deprecated("Use distage.Lifecycle.Basic", "1.0")
   type DIResource[+F[_], A] = Lifecycle.Basic[F, A]

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/effect/QuasiAsync.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/effect/QuasiAsync.scala
@@ -80,9 +80,9 @@ object QuasiAsync extends LowPriorityQuasiAsyncInstances {
     Await.result(future, Duration.Inf).toList
   }
 
-  implicit def fromBIO[F[+_, +_]: Async2: Temporal2]: QuasiAsync[F[Throwable, ?]] = {
+  implicit def fromBIO[F[+_, +_]: Async2: Temporal2]: QuasiAsync[F[Throwable, _]] = {
     import scala.collection.compat._
-    new QuasiAsync[F[Throwable, ?]] {
+    new QuasiAsync[F[Throwable, _]] {
       override def async[A](effect: (Either[Throwable, A] => Unit) => Unit): F[Throwable, A] = {
         F.async(effect)
       }

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/effect/QuasiIO.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/effect/QuasiIO.scala
@@ -150,9 +150,9 @@ object QuasiIO extends LowPriorityQuasiIOInstances {
     override def traverse_[A](l: Iterable[A])(f: A => Identity[Unit]): Identity[Unit] = l.foreach(f)
   }
 
-  implicit def fromBIO[F[+_, +_]](implicit F: IO2[F]): QuasiIO[F[Throwable, ?]] = {
+  implicit def fromBIO[F[+_, +_]](implicit F: IO2[F]): QuasiIO[F[Throwable, _]] = {
     type E = Throwable
-    new QuasiIO[F[Throwable, ?]] {
+    new QuasiIO[F[Throwable, _]] {
       override def pure[A](a: A): F[E, A] = F.pure(a)
       override def map[A, B](fa: F[E, A])(f: A => B): F[E, B] = F.map(fa)(f)
       override def map2[A, B, C](fa: F[E, A], fb: => F[E, B])(f: (A, B) => C): F[E, C] = F.map2(fa, fb)(f)
@@ -269,8 +269,8 @@ object QuasiApplicative extends LowPriorityQuasiApplicativeInstances {
 
   @inline implicit def quasiApplicativeIdentity: QuasiApplicative[Identity] = QuasiIOIdentity
 
-  implicit def fromBIO[F[+_, +_], E](implicit F: Applicative2[F]): QuasiApplicative[F[E, ?]] = {
-    new QuasiApplicative[F[E, ?]] {
+  implicit def fromBIO[F[+_, +_], E](implicit F: Applicative2[F]): QuasiApplicative[F[E, _]] = {
+    new QuasiApplicative[F[E, _]] {
       override def pure[A](a: A): F[E, A] = F.pure(a)
       override def map[A, B](fa: F[E, A])(f: A => B): F[E, B] = F.map(fa)(f)
       override def map2[A, B, C](fa: F[E, A], fb: => F[E, B])(f: (A, B) => C): F[E, C] = F.map2(fa, fb)(f)
@@ -315,8 +315,8 @@ object QuasiFunctor extends LowPriorityQuasiFunctorInstances {
 
   @inline implicit def quasiFunctorIdentity: QuasiApplicative[Identity] = QuasiIOIdentity
 
-  implicit def fromBIO[F[+_, +_], E](implicit F: Functor2[F]): QuasiFunctor[F[E, ?]] = {
-    new QuasiFunctor[F[E, ?]] {
+  implicit def fromBIO[F[+_, +_], E](implicit F: Functor2[F]): QuasiFunctor[F[E, _]] = {
+    new QuasiFunctor[F[E, _]] {
       override def map[A, B](fa: F[E, A])(f: A => B): F[E, B] = F.map(fa)(f)
     }
   }

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/effect/package.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/effect/package.scala
@@ -1,51 +1,51 @@
 package izumi.distage.model
 
 package object effect {
-  type QuasiIO2[F[_, _]] = QuasiIO[F[Throwable, ?]]
-  type QuasiIO3[F[_, _, _]] = QuasiIO[F[Any, Throwable, ?]]
+  type QuasiIO2[F[_, _]] = QuasiIO[F[Throwable, _]]
+  type QuasiIO3[F[_, _, _]] = QuasiIO[F[Any, Throwable, _]]
 
-  type QuasiApplicative2[F[_, _]] = QuasiApplicative[F[Throwable, ?]]
-  type QuasiApplicative3[F[_, _, _]] = QuasiApplicative[F[Any, Throwable, ?]]
+  type QuasiApplicative2[F[_, _]] = QuasiApplicative[F[Throwable, _]]
+  type QuasiApplicative3[F[_, _, _]] = QuasiApplicative[F[Any, Throwable, _]]
 
-  type QuasiAsync2[F[_, _]] = QuasiAsync[F[Throwable, ?]]
-  type QuasiAsync3[F[_, _, _]] = QuasiAsync[F[Any, Throwable, ?]]
+  type QuasiAsync2[F[_, _]] = QuasiAsync[F[Throwable, _]]
+  type QuasiAsync3[F[_, _, _]] = QuasiAsync[F[Any, Throwable, _]]
 
-  type QuasiIORunner2[F[_, _]] = QuasiIORunner[F[Throwable, ?]]
-  type QuasiIORunner3[F[_, _, _]] = QuasiIORunner[F[Any, Throwable, ?]]
+  type QuasiIORunner2[F[_, _]] = QuasiIORunner[F[Throwable, _]]
+  type QuasiIORunner3[F[_, _, _]] = QuasiIORunner[F[Any, Throwable, _]]
 
   @deprecated("Renamed to QuasiIO", "1.0")
   type DIEffect[F[_]] = QuasiIO[F]
   @deprecated("Renamed to QuasiIO", "1.0")
   lazy val DIEffect: QuasiIO.type = QuasiIO
   @deprecated("Renamed to QuasiIO2", "1.0")
-  type DIEffect2[F[_, _]] = QuasiIO[F[Throwable, ?]]
+  type DIEffect2[F[_, _]] = QuasiIO[F[Throwable, _]]
   @deprecated("Renamed to QuasiIO3", "1.0")
-  type DIEffect3[F[_, _, _]] = QuasiIO[F[Any, Throwable, ?]]
+  type DIEffect3[F[_, _, _]] = QuasiIO[F[Any, Throwable, _]]
 
   @deprecated("Renamed to QuasiApplicative", "1.0")
   type DIApplicative[F[_]] = QuasiApplicative[F]
   @deprecated("Renamed to QuasiApplicative", "1.0")
   lazy val DIApplicative: QuasiApplicative.type = QuasiApplicative
   @deprecated("Renamed to QuasiApplicative2", "1.0")
-  type DIApplicative2[F[_, _]] = QuasiApplicative[F[Throwable, ?]]
+  type DIApplicative2[F[_, _]] = QuasiApplicative[F[Throwable, _]]
   @deprecated("Renamed to QuasiApplicative3", "1.0")
-  type DIApplicative3[F[_, _, _]] = QuasiApplicative[F[Any, Throwable, ?]]
+  type DIApplicative3[F[_, _, _]] = QuasiApplicative[F[Any, Throwable, _]]
 
   @deprecated("Renamed to QuasiAsync", "1.0")
   type DIEffectAsync[F[_]] = QuasiAsync[F]
   @deprecated("Renamed to QuasiAsync", "1.0")
   lazy val DIEffectAsync: QuasiAsync.type = QuasiAsync
   @deprecated("Renamed to QuasiAsync2", "1.0")
-  type DIEffectAsync2[F[_, _]] = QuasiAsync[F[Throwable, ?]]
+  type DIEffectAsync2[F[_, _]] = QuasiAsync[F[Throwable, _]]
   @deprecated("Renamed to QuasiAsync3", "1.0")
-  type DIEffectAsync3[F[_, _, _]] = QuasiAsync[F[Any, Throwable, ?]]
+  type DIEffectAsync3[F[_, _, _]] = QuasiAsync[F[Any, Throwable, _]]
 
   @deprecated("Renamed to QuasiIORunner", "1.0")
   type DIEffectRunner[F[_]] = QuasiIORunner[F]
   @deprecated("Renamed to QuasiAsync", "1.0")
   lazy val DIEffectRunner: QuasiIORunner.type = QuasiIORunner
   @deprecated("Renamed to QuasiIORunner2", "1.0")
-  type DIEffectRunner2[F[_, _]] = QuasiIORunner[F[Throwable, ?]]
+  type DIEffectRunner2[F[_, _]] = QuasiIORunner[F[Throwable, _]]
   @deprecated("Renamed to QuasiIORunner3", "1.0")
-  type DIEffectRunner3[F[_, _, _]] = QuasiIORunner[F[Any, Throwable, ?]]
+  type DIEffectRunner3[F[_, _, _]] = QuasiIORunner[F[Any, Throwable, _]]
 }

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/exceptions/IncompatibleRuntimeClassException.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/exceptions/IncompatibleRuntimeClassException.scala
@@ -4,7 +4,7 @@ import izumi.distage.model.reflection.DIKey
 
 class IncompatibleRuntimeClassException(
   val expected: DIKey,
-  val got: Class[_],
+  val got: Class[?],
   val clue: String,
 ) extends DIException(
     s"Instance of type `$got` supposed to be assigned to incompatible key $expected. Context: $clue"

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/exceptions/ProvisionerIssue.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/exceptions/ProvisionerIssue.scala
@@ -18,7 +18,7 @@ object IncompatibleEffectTypesException {
        |Can't execute an effect in `$actionEffectType` which is neither equivalent to `izumi.fundamentals.platform.Identity`, nor a subtype of the Injector's effect type: `$provisionerEffectType`
        |
        |  - To execute `make[_].fromEffect` and `make[_].fromResource` bindings for effects other than `Identity`, you must parameterize the `Injector` with the corresponding effect type when creating it, as in `Injector[F]()`.
-       |  - Subtype type constructors are allowed. e.g. when using ZIO you can execute effects in `IO[Nothing, ?]` when using an `Injector[IO[Throwable, ?]]()`.
+       |  - Subtype type constructors are allowed. e.g. when using ZIO you can execute effects in `IO[Nothing, _]` when using an `Injector[IO[Throwable, _]]()`.
        """.stripMargin
   }
 }

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/plan/Roots.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/plan/Roots.scala
@@ -35,10 +35,10 @@ object Roots {
   def apply(root: DIKey, roots: DIKey*): Roots = {
     Roots.Of(NonEmptySet(root, roots: _*))
   }
-  def apply(roots: NonEmptySet[_ <: DIKey]): Roots = {
+  def apply(roots: NonEmptySet[? <: DIKey]): Roots = {
     Roots.Of(roots.widen)
   }
-  def apply(roots: Set[_ <: DIKey])(implicit d: DummyImplicit): Roots = {
+  def apply(roots: Set[? <: DIKey])(implicit d: DummyImplicit): Roots = {
     require(roots.nonEmpty, "GC roots set cannot be empty")
     Roots.Of(NonEmptySet.from(roots).get.widen)
   }

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/providers/Functoid.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/providers/Functoid.scala
@@ -127,28 +127,28 @@ final case class Functoid[+A](get: Provider) {
 
 object Functoid {
   implicit def apply[R](fun: () => R): Functoid[R] = macro FunctoidMacro.impl[R]
-  implicit def apply[R](fun: (_) => R): Functoid[R] = macro FunctoidMacro.impl[R]
-  implicit def apply[R](fun: (_, _) => R): Functoid[R] = macro FunctoidMacro.impl[R]
-  implicit def apply[R](fun: (_, _, _) => R): Functoid[R] = macro FunctoidMacro.impl[R]
-  implicit def apply[R](fun: (_, _, _, _) => R): Functoid[R] = macro FunctoidMacro.impl[R]
-  implicit def apply[R](fun: (_, _, _, _, _) => R): Functoid[R] = macro FunctoidMacro.impl[R]
-  implicit def apply[R](fun: (_, _, _, _, _, _) => R): Functoid[R] = macro FunctoidMacro.impl[R]
-  implicit def apply[R](fun: (_, _, _, _, _, _, _) => R): Functoid[R] = macro FunctoidMacro.impl[R]
-  implicit def apply[R](fun: (_, _, _, _, _, _, _, _) => R): Functoid[R] = macro FunctoidMacro.impl[R]
-  implicit def apply[R](fun: (_, _, _, _, _, _, _, _, _) => R): Functoid[R] = macro FunctoidMacro.impl[R]
-  implicit def apply[R](fun: (_, _, _, _, _, _, _, _, _, _) => R): Functoid[R] = macro FunctoidMacro.impl[R]
-  implicit def apply[R](fun: (_, _, _, _, _, _, _, _, _, _, _) => R): Functoid[R] = macro FunctoidMacro.impl[R]
-  implicit def apply[R](fun: (_, _, _, _, _, _, _, _, _, _, _, _) => R): Functoid[R] = macro FunctoidMacro.impl[R]
-  implicit def apply[R](fun: (_, _, _, _, _, _, _, _, _, _, _, _, _) => R): Functoid[R] = macro FunctoidMacro.impl[R]
-  implicit def apply[R](fun: (_, _, _, _, _, _, _, _, _, _, _, _, _, _) => R): Functoid[R] = macro FunctoidMacro.impl[R]
-  implicit def apply[R](fun: (_, _, _, _, _, _, _, _, _, _, _, _, _, _, _) => R): Functoid[R] = macro FunctoidMacro.impl[R]
-  implicit def apply[R](fun: (_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _) => R): Functoid[R] = macro FunctoidMacro.impl[R]
-  implicit def apply[R](fun: (_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _) => R): Functoid[R] = macro FunctoidMacro.impl[R]
-  implicit def apply[R](fun: (_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _) => R): Functoid[R] = macro FunctoidMacro.impl[R]
-  implicit def apply[R](fun: (_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _) => R): Functoid[R] = macro FunctoidMacro.impl[R]
-  implicit def apply[R](fun: (_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _) => R): Functoid[R] = macro FunctoidMacro.impl[R]
-  implicit def apply[R](fun: (_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _) => R): Functoid[R] = macro FunctoidMacro.impl[R]
-  implicit def apply[R](fun: (_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _) => R): Functoid[R] = macro FunctoidMacro.impl[R]
+  implicit def apply[R](fun: (?) => R): Functoid[R] = macro FunctoidMacro.impl[R]
+  implicit def apply[R](fun: (?, ?) => R): Functoid[R] = macro FunctoidMacro.impl[R]
+  implicit def apply[R](fun: (?, ?, ?) => R): Functoid[R] = macro FunctoidMacro.impl[R]
+  implicit def apply[R](fun: (?, ?, ?, ?) => R): Functoid[R] = macro FunctoidMacro.impl[R]
+  implicit def apply[R](fun: (?, ?, ?, ?, ?) => R): Functoid[R] = macro FunctoidMacro.impl[R]
+  implicit def apply[R](fun: (?, ?, ?, ?, ?, ?) => R): Functoid[R] = macro FunctoidMacro.impl[R]
+  implicit def apply[R](fun: (?, ?, ?, ?, ?, ?, ?) => R): Functoid[R] = macro FunctoidMacro.impl[R]
+  implicit def apply[R](fun: (?, ?, ?, ?, ?, ?, ?, ?) => R): Functoid[R] = macro FunctoidMacro.impl[R]
+  implicit def apply[R](fun: (?, ?, ?, ?, ?, ?, ?, ?, ?) => R): Functoid[R] = macro FunctoidMacro.impl[R]
+  implicit def apply[R](fun: (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) => R): Functoid[R] = macro FunctoidMacro.impl[R]
+  implicit def apply[R](fun: (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) => R): Functoid[R] = macro FunctoidMacro.impl[R]
+  implicit def apply[R](fun: (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) => R): Functoid[R] = macro FunctoidMacro.impl[R]
+  implicit def apply[R](fun: (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) => R): Functoid[R] = macro FunctoidMacro.impl[R]
+  implicit def apply[R](fun: (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) => R): Functoid[R] = macro FunctoidMacro.impl[R]
+  implicit def apply[R](fun: (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) => R): Functoid[R] = macro FunctoidMacro.impl[R]
+  implicit def apply[R](fun: (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) => R): Functoid[R] = macro FunctoidMacro.impl[R]
+  implicit def apply[R](fun: (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) => R): Functoid[R] = macro FunctoidMacro.impl[R]
+  implicit def apply[R](fun: (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) => R): Functoid[R] = macro FunctoidMacro.impl[R]
+  implicit def apply[R](fun: (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) => R): Functoid[R] = macro FunctoidMacro.impl[R]
+  implicit def apply[R](fun: (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) => R): Functoid[R] = macro FunctoidMacro.impl[R]
+  implicit def apply[R](fun: (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) => R): Functoid[R] = macro FunctoidMacro.impl[R]
+  implicit def apply[R](fun: (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) => R): Functoid[R] = macro FunctoidMacro.impl[R]
 
   implicit final class SyntaxMapSame[A](private val functoid: Functoid[A]) extends AnyVal {
     def mapSame(f: A => A): Functoid[A] = functoid.map(f)(functoid.getRetTag)
@@ -211,7 +211,7 @@ object Functoid {
     )
   }
 
-  def identityKey(key: DIKey): Functoid[_] = {
+  def identityKey(key: DIKey): Functoid[?] = {
     val tpe = key.tpe
     val symbolInfo = firstParamSymbolInfo(tpe)
 

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/provisioning/proxies/ProxyProvider.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/provisioning/proxies/ProxyProvider.scala
@@ -16,12 +16,12 @@ object ProxyProvider {
     }
   }
 
-  final case class ProxyContext(runtimeClass: Class[_], op: ExecutableOp, params: ProxyParams)
+  final case class ProxyContext(runtimeClass: Class[?], op: ExecutableOp, params: ProxyParams)
 
   sealed trait ProxyParams
   object ProxyParams {
     final case object Empty extends ProxyParams
-    final case class Params(types: Array[Class[_]], values: Array[Any]) extends ProxyParams {
+    final case class Params(types: Array[Class[?]], values: Array[Any]) extends ProxyParams {
       override def toString: String = s"Params(${types.mkString("[", ",", "]")}, ${values.mkString("[", ",", "]")})"
     }
   }

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/reflection/Provider.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/reflection/Provider.scala
@@ -13,12 +13,12 @@ trait Provider {
   def fun: Seq[Any] => Any
   def providerType: ProviderType
 
-  def unsafeApply(refs: Seq[TypedRef[_]]): Any = {
+  def unsafeApply(refs: Seq[TypedRef[?]]): Any = {
     val args = verifyArgs(refs)
     fun(args)
   }
 
-  def unsafeMap(newRet: SafeType, f: Any => _): Provider
+  def unsafeMap(newRet: SafeType, f: Any => ?): Provider
   def unsafeZip(newRet: SafeType, that: Provider): Provider
   def addUnused(keys: Iterable[DIKey]): Provider
   def replaceKeys(f: DIKey => DIKey): Provider
@@ -40,7 +40,7 @@ trait Provider {
     "π:" + providerType.toString
   }
 
-  protected[this] def verifyArgs(refs: Seq[TypedRef[_]]): Seq[Any] = {
+  protected[this] def verifyArgs(refs: Seq[TypedRef[?]]): Seq[Any] = {
     val (newArgs, types, typesCmp) = parameters
       .zip(refs).map {
         case (param, TypedRef(v, tpe, isByName)) =>
@@ -95,10 +95,10 @@ object Provider {
     def this(parameters: Seq[LinkedParameter], ret: SafeType, fun: Seq[Any] => Any, providerType: ProviderType) =
       this(parameters, ret, fun, fun, providerType)
 
-    override def unsafeApply(refs: Seq[TypedRef[_]]): A =
+    override def unsafeApply(refs: Seq[TypedRef[?]]): A =
       super.unsafeApply(refs).asInstanceOf[A]
 
-    override def unsafeMap(newRet: SafeType, f: Any => _): ProviderImpl[_] =
+    override def unsafeMap(newRet: SafeType, f: Any => ?): ProviderImpl[?] =
       copy(
         ret = newRet,
         originalFun = f,

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/reflection/SafeType.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/reflection/SafeType.scala
@@ -6,7 +6,7 @@ import izumi.reflect.{Tag, TagK, WeakTag}
 
 final case class SafeType private (
   tag: LightTypeTag,
-  /*private[distage] val */ cls: Class[_],
+  /*private[distage] val */ cls: Class[?],
 ) {
   override def toString: String = tag.repr
 

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/reflection/SafeType.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/reflection/SafeType.scala
@@ -4,7 +4,7 @@ import izumi.fundamentals.platform.functional.Identity
 import izumi.reflect.macrortti.LightTypeTag
 import izumi.reflect.{Tag, TagK, WeakTag}
 
-final case class SafeType private (
+final case class SafeType private[izumi] (
   tag: LightTypeTag,
   /*private[distage] val */ cls: Class[?],
 ) {

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/reflection/macros/DIUniverseLiftables.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/reflection/macros/DIUniverseLiftables.scala
@@ -21,8 +21,8 @@ class DIUniverseLiftables[D <: StaticDIUniverse](val u: D) {
       """
   }
 
-  protected[this] implicit val liftableIdKey: Liftable[DIKey.IdKey[_]] = {
-    case idKey: DIKey.IdKey[_] =>
+  protected[this] implicit val liftableIdKey: Liftable[DIKey.IdKey[?]] = {
+    case idKey: DIKey.IdKey[?] =>
       val lifted = idKey.idContract.liftable(idKey.id)
       q"""{ new $modelReflectionPkg.DIKey.IdKey(${liftTypeToSafeType(idKey.tpe.typeNative)}, $lifted) }"""
   }

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/reflection/macros/FunctoidMacro.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/reflection/macros/FunctoidMacro.scala
@@ -9,6 +9,7 @@ import izumi.distage.model.reflection.universe.StaticDIUniverse.Aux
 import izumi.distage.reflection.ReflectionProviderDefaultImpl
 import izumi.fundamentals.reflection.TrivialMacroLogger
 
+import scala.annotation.nowarn
 import scala.reflect.macros.blackbox
 
 /**
@@ -189,12 +190,12 @@ class FunctoidMacro(val c: blackbox.Context) {
   }
 
   protected[this] def widenFunctionObject(sig: Type): Type = {
-    sig match {
+    (sig match {
       case s: SingleTypeApi =>
         sig.baseType(s.sym.typeSignature.baseClasses.find(definitions.FunctionClass.seq.contains(_)).get)
       case _ =>
         sig
-    }
+    }): @nowarn("msg=outer reference")
   }
 
 }

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/reflection/universe/WithDISymbolInfo.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/reflection/universe/WithDISymbolInfo.scala
@@ -85,7 +85,7 @@ trait WithDISymbolInfo { this: DIUniverseBase with WithDISafeType =>
         SymbolInfo.Static(
           name = transformName(tpe.typeSymbol.name.toString),
           finalResultType = tpe,
-          annotations = AnnotationTools.getAllTypeAnnotations(u)(tpe),
+          annotations = AnnotationTools.getAllTypeAnnotations[u.type](tpe),
           isByName = tpe.typeSymbol.isClass && tpe.typeSymbol.asClass == u.definitions.ByNameParamClass,
           wasGeneric = tpe.typeSymbol.isParameter,
         )

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/reflection/universe/WithDISymbolInfo.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/reflection/universe/WithDISymbolInfo.scala
@@ -85,7 +85,7 @@ trait WithDISymbolInfo { this: DIUniverseBase with WithDISafeType =>
         SymbolInfo.Static(
           name = transformName(tpe.typeSymbol.name.toString),
           finalResultType = tpe,
-          annotations = AnnotationTools.getAllTypeAnnotations[u.type](tpe),
+          annotations = AnnotationTools.getAllTypeAnnotations(u)(tpe),
           isByName = tpe.typeSymbol.isClass && tpe.typeSymbol.asClass == u.definitions.ByNameParamClass,
           wasGeneric = tpe.typeSymbol.isParameter,
         )

--- a/distage/distage-core-api/src/main/scala/izumi/distage/reflection/ReflectionProviderDefaultImpl.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/reflection/ReflectionProviderDefaultImpl.scala
@@ -128,7 +128,7 @@ trait ReflectionProviderDefaultImpl extends ReflectionProvider {
     if (tpe.typeSymbol.isStatic) {
       None
     } else {
-      val typeRef = ReflectionUtil.toTypeRef[u.u.type](tpe)
+      val typeRef = ReflectionUtil.toTypeRef(u.u: u.u.type)(tpe)
       typeRef
         .map(_.pre)
         .filterNot(m => m.termSymbol.isModule && m.termSymbol.isStatic)

--- a/distage/distage-core-api/src/main/scala/izumi/distage/reflection/ReflectionProviderDefaultImpl.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/reflection/ReflectionProviderDefaultImpl.scala
@@ -128,7 +128,7 @@ trait ReflectionProviderDefaultImpl extends ReflectionProvider {
     if (tpe.typeSymbol.isStatic) {
       None
     } else {
-      val typeRef = ReflectionUtil.toTypeRef(u.u: u.u.type)(tpe)
+      val typeRef = ReflectionUtil.toTypeRef[u.u.type](tpe)
       typeRef
         .map(_.pre)
         .filterNot(m => m.termSymbol.isModule && m.termSymbol.isStatic)

--- a/distage/distage-core-api/src/main/scala/izumi/distage/reflection/ReflectionProviderDefaultImpl.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/reflection/ReflectionProviderDefaultImpl.scala
@@ -6,6 +6,9 @@ import izumi.distage.model.reflection.ReflectionProvider
 import izumi.distage.model.reflection.universe.DIUniverse
 import izumi.fundamentals.reflection.{JSRAnnotationTools, ReflectionUtil}
 
+import scala.annotation.nowarn
+
+@nowarn("msg=outer reference")
 trait ReflectionProviderDefaultImpl extends ReflectionProvider {
 
   import u.u.{Annotation, LiteralApi}

--- a/distage/distage-core-api/src/test/scala/izumi/LifecycleIzumiInstancesTest.scala
+++ b/distage/distage-core-api/src/test/scala/izumi/LifecycleIzumiInstancesTest.scala
@@ -6,12 +6,12 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class LifecycleIzumiInstancesTest extends AnyWordSpec {
   "Summon Functor2/Functor3 instances for Lifecycle" in {
-    def t2[F[+_, +_]: Functor2]: Functor2[Lifecycle2[F, +?, +?]] = {
-      Functor2[Lifecycle2[F, +?, +?]]
+    def t2[F[+_, +_]: Functor2]: Functor2[Lifecycle2[F, +_, +_]] = {
+      Functor2[Lifecycle2[F, +_, +_]]
     }
 
-    def t3[F[-_, +_, +_]: Functor3]: Functor3[Lifecycle3[F, -?, +?, +?]] = {
-      Functor3[Lifecycle3[F, -?, +?, +?]]
+    def t3[F[-_, +_, +_]: Functor3]: Functor3[Lifecycle3[F, -_, +_, +_]] = {
+      Functor3[Lifecycle3[F, -_, +_, +_]]
     }
 
     t2[zio.IO]

--- a/distage/distage-core-proxy-cglib/src/main/scala/izumi/distage/provisioning/strategies/cglib/CglibProxyProvider.scala
+++ b/distage/distage-core-proxy-cglib/src/main/scala/izumi/distage/provisioning/strategies/cglib/CglibProxyProvider.scala
@@ -27,7 +27,7 @@ class CglibProxyProvider extends ProxyProvider {
     val enhancer = new Enhancer()
 
     if (clazz.isInterface) {
-      enhancer.setInterfaces(Array[Class[_]](clazz, classOf[DistageProxy]))
+      enhancer.setInterfaces(Array[Class[?]](clazz, classOf[DistageProxy]))
     } else if (clazz == classOf[Any]) {
       enhancer.setInterfaces(Array(classOf[DistageProxy]))
     } else {

--- a/distage/distage-core-proxy-cglib/src/main/scala/izumi/distage/provisioning/strategies/cglib/exceptions/CgLibInstantiationOpException.scala
+++ b/distage/distage-core-proxy-cglib/src/main/scala/izumi/distage/provisioning/strategies/cglib/exceptions/CgLibInstantiationOpException.scala
@@ -4,5 +4,5 @@ import izumi.distage.model.exceptions.DIException
 import izumi.distage.model.plan.ExecutableOp
 import izumi.distage.model.provisioning.proxies.ProxyProvider.ProxyParams
 
-class CgLibInstantiationOpException(message: String, val target: Class[_], val params: ProxyParams, val op: ExecutableOp, cause: Throwable)
+class CgLibInstantiationOpException(message: String, val target: Class[?], val params: ProxyParams, val op: ExecutableOp, cause: Throwable)
   extends DIException(message, cause)

--- a/distage/distage-core/.jvm/src/main/scala/izumi/distage/provisioning/strategies/ProxyStrategyDefaultImplPlatformSpecific.scala
+++ b/distage/distage-core/.jvm/src/main/scala/izumi/distage/provisioning/strategies/ProxyStrategyDefaultImplPlatformSpecific.scala
@@ -21,7 +21,7 @@ abstract class ProxyStrategyDefaultImplPlatformSpecific(
     val classConstructorParams = if (noArgsConstructor(tpe)) {
       ProxyParams.Empty
     } else {
-      val allArgsAsNull: Array[(Class[_], Any)] = {
+      val allArgsAsNull: Array[(Class[?], Any)] = {
         op.op match {
           case WiringOp.CallProvider(_, f: Wiring.SingletonWiring.Function, _) if f.provider.providerType eq ProviderType.Class =>
             // for class constructors, try to fetch known dependencies from the object graph
@@ -45,9 +45,9 @@ abstract class ProxyStrategyDefaultImplPlatformSpecific(
     throw new UnsupportedOpException(s"Tried to make proxy of non-proxyable (final?) $tpe", op)
   }
 
-  private def fetchNonforwardRefParamWithClass(context: ProvisioningKeyProvider, forwardRefs: Set[DIKey], param: LinkedParameter): (Class[_], Any) = {
-    val clazz: Class[_] = if (param.isByName) {
-      classOf[Function0[_]]
+  private def fetchNonforwardRefParamWithClass(context: ProvisioningKeyProvider, forwardRefs: Set[DIKey], param: LinkedParameter): (Class[?], Any) = {
+    val clazz: Class[?] = if (param.isByName) {
+      classOf[Function0[?]]
     } else if (param.wasGeneric) {
       classOf[Any]
     } else {

--- a/distage/distage-core/.jvm/src/test/scala/izumi/distage/compat/ZIOResourcesTestJvm.scala
+++ b/distage/distage-core/.jvm/src/test/scala/izumi/distage/compat/ZIOResourcesTestJvm.scala
@@ -91,7 +91,7 @@ final class ZIOResourcesTestJvm extends AnyWordSpec with GivenWhenThen {
         IO(assert(!i1.initialized && !i2.initialized))
       }
 
-      def produceBIO[F[+_, +_]: TagKK: IO2] = injector.produceCustomF[F[Throwable, ?]](plan)
+      def produceBIO[F[+_, +_]: TagKK: IO2] = injector.produceCustomF[F[Throwable, _]](plan)
 
       val ctxResource = produceBIO[IO]
 
@@ -195,7 +195,7 @@ final class ZIOResourcesTestJvm extends AnyWordSpec with GivenWhenThen {
         IO(assert(!i1.initialized && !i2.initialized))
       }
 
-      def produceBIO[F[+_, +_]: TagKK: IO2] = injector.produceCustomF[F[Throwable, ?]](plan)
+      def produceBIO[F[+_, +_]: TagKK: IO2] = injector.produceCustomF[F[Throwable, _]](plan)
 
       val ctxResource = produceBIO[IO]
 

--- a/distage/distage-core/.jvm/src/test/scala/izumi/distage/injector/CglibProxiesTestJvm.scala
+++ b/distage/distage-core/.jvm/src/test/scala/izumi/distage/injector/CglibProxiesTestJvm.scala
@@ -344,7 +344,7 @@ class CglibProxiesTestJvm extends AnyWordSpec with MkInjector {
 
       val injector = mkInjector()
       val plan = injector.plan(definition)
-      val context = injector.produceCustomF[Suspend2[Throwable, ?]](plan).unsafeGet().unsafeRun()
+      val context = injector.produceCustomF[Suspend2[Throwable, _]](plan).unsafeGet().unsafeRun()
 
       val instance = context.get[SelfReference]
 
@@ -372,7 +372,7 @@ class CglibProxiesTestJvm extends AnyWordSpec with MkInjector {
       val plan = injector.plan(definition)
 
       val context = injector
-        .produceCustomF[Suspend2[Nothing, ?]](plan).use {
+        .produceCustomF[Suspend2[Nothing, _]](plan).use {
           Suspend2(_)
         }.unsafeRun()
 

--- a/distage/distage-core/src/main/scala/distage/Distage.scala
+++ b/distage/distage-core/src/main/scala/distage/Distage.scala
@@ -52,9 +52,9 @@ trait Distage {
   type Lifecycle[+F[_], +A] = model.definition.Lifecycle[F, A]
   val Lifecycle: model.definition.Lifecycle.type = model.definition.Lifecycle
 
-  type Lifecycle2[+F[+_, +_], +E, +A] = model.definition.Lifecycle[F[E, ?], A]
+  type Lifecycle2[+F[+_, +_], +E, +A] = model.definition.Lifecycle[F[E, _], A]
 
-  type Lifecycle3[+F[-_, +_, +_], -R, +E, +A] = model.definition.Lifecycle[F[R, E, ?], A]
+  type Lifecycle3[+F[-_, +_, +_], -R, +E, +A] = model.definition.Lifecycle[F[R, E, _], A]
 
   type Axis = model.definition.Axis
   val Axis: model.definition.Axis.type = model.definition.Axis

--- a/distage/distage-core/src/main/scala/distage/package.scala
+++ b/distage/distage-core/src/main/scala/distage/package.scala
@@ -48,9 +48,9 @@ package object distage extends Distage {
   override type Lifecycle[+F[_], +Resource] = model.definition.Lifecycle[F, Resource]
   override val Lifecycle: model.definition.Lifecycle.type = model.definition.Lifecycle
 
-  override type Lifecycle2[+F[+_, +_], +E, +A] = model.definition.Lifecycle[F[E, ?], A]
+  override type Lifecycle2[+F[+_, +_], +E, +A] = model.definition.Lifecycle[F[E, _], A]
 
-  override type Lifecycle3[+F[-_, +_, +_], -R, +E, +A] = model.definition.Lifecycle[F[R, E, ?], A]
+  override type Lifecycle3[+F[-_, +_, +_], -R, +E, +A] = model.definition.Lifecycle[F[R, E, _], A]
 
   override type Axis = model.definition.Axis
   override val Axis: model.definition.Axis.type = model.definition.Axis

--- a/distage/distage-core/src/main/scala/izumi/distage/modules/DefaultModule.scala
+++ b/distage/distage-core/src/main/scala/izumi/distage/modules/DefaultModule.scala
@@ -60,7 +60,7 @@ sealed trait LowPriorityDefaultModulesInstances1 extends LowPriorityDefaultModul
     implicit
     @unused ensureInteropCatsOnClasspath: `cats.effect.IO`[K],
     @unused l: `zio.ZIO`[ZIO],
-  ): DefaultModule2[ZIO[R, ?, ?]] = {
+  ): DefaultModule2[ZIO[R, _, _]] = {
     DefaultModule(ZIOSupportModule ++ ZIOCatsEffectInstancesModule)
   }
 }
@@ -74,7 +74,7 @@ sealed trait LowPriorityDefaultModulesInstances2 extends LowPriorityDefaultModul
     *
     * @see [[izumi.distage.modules.support.ZIOSupportModule]]
     */
-  implicit final def forZIO[ZIO[_, _, _]: `zio.ZIO`, R]: DefaultModule2[ZIO[R, ?, ?]] = {
+  implicit final def forZIO[ZIO[_, _, _]: `zio.ZIO`, R]: DefaultModule2[ZIO[R, _, _]] = {
     DefaultModule(ZIOSupportModule)
   }
 
@@ -125,7 +125,7 @@ sealed trait LowPriorityDefaultModulesInstances3 extends LowPriorityDefaultModul
 sealed trait LowPriorityDefaultModulesInstances4 extends LowPriorityDefaultModulesInstances5 {
   /** @see [[izumi.distage.modules.support.AnyBIO3SupportModule]] */
   implicit final def fromBIO3[F[-_, +_, +_]: TagK3: Async3: Temporal3: Local3: UnsafeRun3: Fork3: Primitives3](
-    implicit tagBIO: TagKK[F[Any, +?, +?]]
+    implicit tagBIO: TagKK[F[Any, +_, +_]]
   ): DefaultModule3[F] = {
     DefaultModule(AnyBIO3SupportModule.withImplicits[F])
   }

--- a/distage/distage-core/src/main/scala/izumi/distage/modules/package.scala
+++ b/distage/distage-core/src/main/scala/izumi/distage/modules/package.scala
@@ -3,14 +3,14 @@ package izumi.distage
 import izumi.distage.model.definition.Module
 
 package object modules {
-  type DefaultModule2[F[_, _]] = DefaultModule[F[Throwable, ?]]
+  type DefaultModule2[F[_, _]] = DefaultModule[F[Throwable, _]]
   object DefaultModule2 {
     @inline def apply[F[_, _]](module: Module): DefaultModule2[F] = DefaultModule(module)
 
     @inline def apply[F[_, _]](implicit modules: DefaultModule2[F], d: DummyImplicit): Module = modules.module
   }
 
-  type DefaultModule3[F[_, _, _]] = DefaultModule[F[Any, Throwable, ?]]
+  type DefaultModule3[F[_, _, _]] = DefaultModule[F[Any, Throwable, _]]
   object DefaultModule3 {
     @inline def apply[F[_, _, _]](module: Module): DefaultModule3[F] = DefaultModule(module)
 

--- a/distage/distage-core/src/main/scala/izumi/distage/modules/support/AnyBIO2SupportModule.scala
+++ b/distage/distage-core/src/main/scala/izumi/distage/modules/support/AnyBIO2SupportModule.scala
@@ -36,11 +36,11 @@ class AnyBIO2SupportModule[F[+_, +_]: TagKK] extends ModuleDef {
   make[SyncSafe2[F]].from {
     SyncSafe.fromBIO(_: IO2[F])
   }
-  make[SyncSafe[F[Throwable, ?]]].from((_: SyncSafe2[F]).widen[F[Throwable, ?]])
-  make[Clock2[F]].aliased[Clock[F[Throwable, ?]]].from {
+  make[SyncSafe[F[Throwable, _]]].from((_: SyncSafe2[F]).widen[F[Throwable, _]])
+  make[Clock2[F]].aliased[Clock[F[Throwable, _]]].from {
     Clock.fromImpure(_: Clock[Identity])(_: SyncSafe2[F])
   }
-  make[Entropy2[F]].aliased[Entropy[F[Throwable, ?]]].from {
+  make[Entropy2[F]].aliased[Entropy[F[Throwable, _]]].from {
     Entropy.fromImpure(_: Entropy[Identity])(_: SyncSafe2[F])
   }
 }

--- a/distage/distage-core/src/main/scala/izumi/distage/modules/support/AnyBIO3SupportModule.scala
+++ b/distage/distage-core/src/main/scala/izumi/distage/modules/support/AnyBIO3SupportModule.scala
@@ -18,32 +18,32 @@ import scala.annotation.unchecked.{uncheckedVariance => v}
   *
   * Depends on `make[Async3[F]]`, `make[Temporal3[F]]`, `make[Local3[F]]`, `make[Fork3[F]]` & `make[UnsafeRun3[F]]`
   */
-class AnyBIO3SupportModule[F[-_, +_, +_]: TagK3](implicit tagBIO: TagKK[F[Any, +?, +?]]) extends ModuleDef {
+class AnyBIO3SupportModule[F[-_, +_, +_]: TagK3](implicit tagBIO: TagKK[F[Any, +_, +_]]) extends ModuleDef {
   // QuasiIO & bifunctor bio instances
-  include(AnyBIO2SupportModule[F[Any, +?, +?]])
+  include(AnyBIO2SupportModule[F[Any, +_, +_]])
   // trifunctor bio instances
   include(BIO3InstancesModule[F])
-  addConverted3To2[F[Any, +?, +?]]
+  addConverted3To2[F[Any, +_, +_]]
 
   // workaround for
   // - https://github.com/zio/izumi-reflect/issues/82
   // - https://github.com/zio/izumi-reflect/issues/83
   def addConverted3To2[G[+e, +a] >: F[Any, e @v, a @v] <: F[Any, e @v, a @v]: TagKK]: Unit = {
     make[Async2[G]].from {
-      implicit F: Async3[F] => Async2[F[Any, +?, +?]]
+      implicit F: Async3[F] => Async2[F[Any, +_, +_]]
     }
     make[Temporal2[G]].from {
-      implicit F: Temporal3[F] => Temporal2[F[Any, +?, +?]]
+      implicit F: Temporal3[F] => Temporal2[F[Any, +_, +_]]
     }
     make[Fork2[G]].from {
-      implicit Fork: Fork3[F] => Fork2[F[Any, +?, +?]]
+      implicit Fork: Fork3[F] => Fork2[F[Any, +_, +_]]
     }
     ()
   }
 }
 
 object AnyBIO3SupportModule extends App with ModuleDef {
-  @inline def apply[F[-_, +_, +_]: TagK3](implicit tagBIO: TagKK[F[Any, +?, +?]]): AnyBIO3SupportModule[F] = new AnyBIO3SupportModule
+  @inline def apply[F[-_, +_, +_]: TagK3](implicit tagBIO: TagKK[F[Any, +_, +_]]): AnyBIO3SupportModule[F] = new AnyBIO3SupportModule
 
   /**
     * Make [[AnyBIO3SupportModule]], binding the required dependencies in place to values from implicit scope
@@ -51,7 +51,7 @@ object AnyBIO3SupportModule extends App with ModuleDef {
     * `make[Fork3[F]]` and `make[Primitives3[F]]` are not required by [[AnyBIO3SupportModule]]
     * but are added for completeness
     */
-  def withImplicits[F[-_, +_, +_]: TagK3: Async3: Temporal3: Local3: UnsafeRun3: Fork3: Primitives3](implicit tagBIO: TagKK[F[Any, +?, +?]]): ModuleDef =
+  def withImplicits[F[-_, +_, +_]: TagK3: Async3: Temporal3: Local3: UnsafeRun3: Fork3: Primitives3](implicit tagBIO: TagKK[F[Any, +_, +_]]): ModuleDef =
     new ModuleDef {
       include(AnyBIO3SupportModule[F])
 
@@ -62,16 +62,16 @@ object AnyBIO3SupportModule extends App with ModuleDef {
       addImplicit[Primitives3[F]]
       addImplicit[UnsafeRun3[F]]
 
-      // no corresponding bifunctor (`F[Any, +?, +?]`) instances need to be added for these types because they already match
+      // no corresponding bifunctor (`F[Any, +_, +_]`) instances need to be added for these types because they already match
       private[this] def aliasingCheck(): Unit = {
         lazy val _ = aliasingCheck()
-        implicitly[UnsafeRun3[F] =:= UnsafeRun2[F[Any, +?, +?]]]
-        implicitly[Primitives3[F] =:= Primitives2[F[Any, +?, +?]]]
-        implicitly[SyncSafe3[F] =:= SyncSafe2[F[Any, +?, +?]]]
-        implicitly[QuasiIORunner3[F] =:= QuasiIORunner2[F[Any, +?, +?]]]
-        implicitly[QuasiIO3[F] =:= QuasiIO2[F[Any, +?, +?]]]
-        implicitly[QuasiApplicative3[F] =:= QuasiApplicative2[F[Any, +?, +?]]]
-        implicitly[QuasiAsync3[F] =:= QuasiAsync2[F[Any, +?, +?]]]
+        implicitly[UnsafeRun3[F] =:= UnsafeRun2[F[Any, +_, +_]]]
+        implicitly[Primitives3[F] =:= Primitives2[F[Any, +_, +_]]]
+        implicitly[SyncSafe3[F] =:= SyncSafe2[F[Any, +_, +_]]]
+        implicitly[QuasiIORunner3[F] =:= QuasiIORunner2[F[Any, +_, +_]]]
+        implicitly[QuasiIO3[F] =:= QuasiIO2[F[Any, +_, +_]]]
+        implicitly[QuasiApplicative3[F] =:= QuasiApplicative2[F[Any, +_, +_]]]
+        implicitly[QuasiAsync3[F] =:= QuasiAsync2[F[Any, +_, +_]]]
         ()
       }
     }

--- a/distage/distage-core/src/main/scala/izumi/distage/modules/typeclass/ZIOCatsEffectInstancesModule.scala
+++ b/distage/distage-core/src/main/scala/izumi/distage/modules/typeclass/ZIOCatsEffectInstancesModule.scala
@@ -41,8 +41,8 @@ trait ZIOCatsEffectInstancesModule extends ModuleDef {
   }
 }
 
-final class ZIOClockTimer[E](zioClock: zio.clock.Clock.Service) extends effect.Timer[IO[E, ?]] {
-  override lazy val clock: effect.Clock[IO[E, ?]] = new effect.Clock[IO[E, ?]] {
+final class ZIOClockTimer[E](zioClock: zio.clock.Clock.Service) extends effect.Timer[IO[E, _]] {
+  override lazy val clock: effect.Clock[IO[E, _]] = new effect.Clock[IO[E, _]] {
     override def monotonic(unit: TimeUnit): IO[E, Long] =
       zioClock.nanoTime.map(unit.convert(_, NANOSECONDS))
 

--- a/distage/distage-core/src/main/scala/izumi/distage/planning/extensions/GraphDumpBootstrapModule.scala
+++ b/distage/distage-core/src/main/scala/izumi/distage/planning/extensions/GraphDumpBootstrapModule.scala
@@ -9,7 +9,7 @@ import izumi.distage.model.planning.PlanningObserver
   * @see [[https://izumi.7mind.io/distage/debugging#graphviz-rendering GraphViz Rendering]]
   */
 class GraphDumpBootstrapModule extends BootstrapModuleDef {
-  // note: GraphDumpObserver doesn't work on Scala.js [due to file IO?]
+  // note: GraphDumpObserver doesn't work on Scala.js [due to file IO_]
   many[PlanningObserver]
     .add[GraphDumpObserver]
 }

--- a/distage/distage-core/src/main/scala/izumi/distage/planning/extensions/GraphDumpBootstrapModule.scala
+++ b/distage/distage-core/src/main/scala/izumi/distage/planning/extensions/GraphDumpBootstrapModule.scala
@@ -9,7 +9,7 @@ import izumi.distage.model.planning.PlanningObserver
   * @see [[https://izumi.7mind.io/distage/debugging#graphviz-rendering GraphViz Rendering]]
   */
 class GraphDumpBootstrapModule extends BootstrapModuleDef {
-  // note: GraphDumpObserver doesn't work on Scala.js [due to file IO_]
+  // note: GraphDumpObserver doesn't work on Scala.js [due to file IO?]
   many[PlanningObserver]
     .add[GraphDumpObserver]
 }

--- a/distage/distage-core/src/main/scala/izumi/distage/provisioning/strategies/ProviderStrategyDefaultImpl.scala
+++ b/distage/distage-core/src/main/scala/izumi/distage/provisioning/strategies/ProviderStrategyDefaultImpl.scala
@@ -9,7 +9,7 @@ import izumi.fundamentals.platform.language.unused
 
 class ProviderStrategyDefaultImpl extends ProviderStrategy {
   def callProvider(context: ProvisioningKeyProvider, @unused executor: WiringExecutor, op: WiringOp.CallProvider): Seq[NewObjectOp.NewInstance] = {
-    val args: Vector[TypedRef[_]] = op.wiring.associations.map {
+    val args: Vector[TypedRef[?]] = op.wiring.associations.map {
       param =>
         context.fetchKey(param.key, param.isByName) match {
           case Some(dep) =>

--- a/distage/distage-core/src/main/scala/izumi/distage/provisioning/strategies/ProxyStrategyDefaultImpl.scala
+++ b/distage/distage-core/src/main/scala/izumi/distage/provisioning/strategies/ProxyStrategyDefaultImpl.scala
@@ -81,7 +81,7 @@ class ProxyStrategyDefaultImpl(
     makeProxy.op match {
       case _: CreateSet =>
         // CGLIB-CLASSLOADER: when we work under sbt cglib fails to instantiate set
-        SafeType.get[FakeSet[_]]
+        SafeType.get[FakeSet[?]]
       case op: WiringOp.CallProvider =>
         op.target.tpe
       case op: MonadicOp.AllocateResource =>

--- a/distage/distage-core/src/main/scala/izumi/distage/provisioning/strategies/SetStrategyDefaultImpl.scala
+++ b/distage/distage-core/src/main/scala/izumi/distage/provisioning/strategies/SetStrategyDefaultImpl.scala
@@ -13,7 +13,7 @@ import scala.collection.Iterable
 class SetStrategyDefaultImpl extends SetStrategy {
   def makeSet(context: ProvisioningKeyProvider, @unused executor: WiringExecutor, op: CreateSet): Seq[NewObjectOp.NewInstance] = {
     // target is guaranteed to be a Set
-    val scalaCollectionSetType = SafeType.get[collection.Set[_]]
+    val scalaCollectionSetType = SafeType.get[collection.Set[?]]
 
     val keyType = op.target.tpe.tag.typeArgs.headOption.getOrElse {
       throw new IncompatibleTypesException("Expected to be a set type but has no parameters", scalaCollectionSetType, op.target.tpe)

--- a/distage/distage-core/src/test/scala/izumi/distage/compat/CatsResourcesTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/compat/CatsResourcesTest.scala
@@ -114,8 +114,8 @@ final class CatsResourcesTest extends AnyWordSpec with GivenWhenThen {
   "cats instances for Lifecycle" in {
     def failImplicit[A](implicit a: A = null): A = a
     def request[F[_]: cats.effect.Sync] = {
-      val F = cats.Functor[Lifecycle[F, ?]]
-      val M = cats.Monad[Lifecycle[F, ?]]
+      val F = cats.Functor[Lifecycle[F, _]]
+      val M = cats.Monad[Lifecycle[F, _]]
       val m = cats.Monoid[Lifecycle[F, Int]]
       val _ = (F, m, M)
       val fail = failImplicit[cats.kernel.Order[Lifecycle[F, Int]]]

--- a/distage/distage-core/src/test/scala/izumi/distage/fixtures/HigherKindCases.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/fixtures/HigherKindCases.scala
@@ -21,13 +21,13 @@ object HigherKindCases {
           override def point[A](a: A): List[A] = List(a)
         }
 
-      implicit final def pointedOptionT[F[_]: Pointed]: Pointed[OptionT[F, ?]] =
-        new Pointed[OptionT[F, ?]] {
+      implicit final def pointedOptionT[F[_]: Pointed]: Pointed[OptionT[F, _]] =
+        new Pointed[OptionT[F, _]] {
           override def point[A](a: A): OptionT[F, A] = OptionT(Pointed[F].point(Some(a)))
         }
 
-      implicit final def pointedEither[E]: Pointed[Either[E, ?]] =
-        new Pointed[Either[E, ?]] {
+      implicit final def pointedEither[E]: Pointed[Either[E, _]] =
+        new Pointed[Either[E, _]] {
           override def point[A](a: A): Either[E, A] = Right(a)
         }
 
@@ -48,7 +48,7 @@ object HigherKindCases {
 
     // TODO: @Id(this)
     class TestServiceClass[F[_]: Pointed](@Id("TestService") getResult: Int) extends TestTrait {
-      override type R[_] = F[_]
+      override type R[_] = F[?]
 
       override def get: F[Int] = {
         Pointed[F].point(getResult)
@@ -56,13 +56,13 @@ object HigherKindCases {
     }
 
     trait TestServiceTrait[F[_]] extends TestTrait {
-      override type R[_] = F[_]
+      override type R[_] = F[?]
 
       implicit protected val pointed: Pointed[F]
 
       protected val getResult: Int @Id("TestService")
 
-      override def get: F[_] = Pointed[F].point(getResult * 2)
+      override def get: F[?] = Pointed[F].point(getResult * 2)
     }
 
     class TestProvider[A, F[_]: Pointed]

--- a/distage/distage-core/src/test/scala/izumi/distage/fixtures/ResourceCases.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/fixtures/ResourceCases.scala
@@ -30,7 +30,7 @@ object ResourceCases {
 
     val queueEffect = Suspend2(mutable.Queue.empty[Ops])
 
-    class XResource(queue: mutable.Queue[Ops]) extends Lifecycle.Basic[Suspend2[Nothing, ?], X] {
+    class XResource(queue: mutable.Queue[Ops]) extends Lifecycle.Basic[Suspend2[Nothing, _], X] {
       override def acquire: Suspend2[Nothing, X] = Suspend2 {
         queue += XStart
         new X
@@ -43,7 +43,7 @@ object ResourceCases {
       }.void
     }
 
-    class YResource(x: X, queue: mutable.Queue[Ops]) extends Lifecycle.Basic[Suspend2[Nothing, ?], Y] {
+    class YResource(x: X, queue: mutable.Queue[Ops]) extends Lifecycle.Basic[Suspend2[Nothing, _], Y] {
       x.discard()
 
       override def acquire: Suspend2[Nothing, Y] = Suspend2 {
@@ -58,7 +58,7 @@ object ResourceCases {
       }.void
     }
 
-    class ZFaultyResource(y: Y) extends Lifecycle.Basic[Suspend2[Throwable, ?], Z] {
+    class ZFaultyResource(y: Y) extends Lifecycle.Basic[Suspend2[Throwable, _], Z] {
       y.discard()
 
       override def acquire: Suspend2[Throwable, Z] = throw new RuntimeException()
@@ -110,7 +110,7 @@ object ResourceCases {
       }
     }
 
-    class SuspendResource extends Lifecycle.Basic[Suspend2[Nothing, ?], Res] {
+    class SuspendResource extends Lifecycle.Basic[Suspend2[Nothing, _], Res] {
       override def acquire: Suspend2[Nothing, Res] = Suspend2(new Res).flatMap(r => Suspend2(r.initialized = true).map(_ => r))
 
       override def release(resource: Res): Suspend2[Nothing, Unit] = Suspend2(resource.initialized = false)
@@ -159,7 +159,7 @@ object ResourceCases {
   object Suspend2 {
     def apply[A](a: => A)(implicit dummy: DummyImplicit): Suspend2[Nothing, A] = new Suspend2(() => Right(a))
 
-    implicit def QuasiIOSuspend2[E <: Throwable]: QuasiIO[Suspend2[E, ?]] = new QuasiIO[Suspend2[E, ?]] {
+    implicit def QuasiIOSuspend2[E <: Throwable]: QuasiIO[Suspend2[E, _]] = new QuasiIO[Suspend2[E, _]] {
       override def flatMap[A, B](fa: Suspend2[E, A])(f: A => Suspend2[E, B]): Suspend2[E, B] = fa.flatMap(f)
       override def map[A, B](fa: Suspend2[E, A])(f: A => B): Suspend2[E, B] = fa.map(f)
       override def map2[A, B, C](fa: Suspend2[E, A], fb: => Suspend2[E, B])(f: (A, B) => C): Suspend2[E, C] = fa.flatMap(a => fb.map(f(a, _)))

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/BasicTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/BasicTest.scala
@@ -212,7 +212,7 @@ class BasicTest extends AnyWordSpec with MkInjector {
     assert(
       exc.conflicts.exists(
         e =>
-          e.isInstanceOf[ConflictResolutionError.ConflictingDefs[_, _]] &&
+          e.isInstanceOf[ConflictResolutionError.ConflictingDefs[?, ?]] &&
           e.asInstanceOf[ConflictResolutionError.ConflictingDefs[DIKey, Nothing]].defs.keySet.exists(_.key == DIKey.get[Dependency])
       )
     )

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/CircularDependenciesTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/CircularDependenciesTest.scala
@@ -153,7 +153,7 @@ class CircularDependenciesTest extends AnyWordSpec with MkInjector {
     assert(instanceTypes == planTypes)
 
     // whitebox test: ensure that plan ops are in a non-lazy collection
-    assert(plan.steps.isInstanceOf[Vector[_]])
+    assert(plan.steps.isInstanceOf[Vector[?]])
   }
 
   "support by-name circular dependencies" in {

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/CompactPlanFormatterTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/CompactPlanFormatterTest.scala
@@ -27,7 +27,7 @@ class CompactPlanFormatterTest extends AnyWordSpec with MkInjector {
     val injector = mkInjector()
     val plan = injector.plan(PlannerInput.everything(new ModuleDef {
       make[JustTrait].from[Impl1]
-      make[OptionT[scala.Either[Nothing, ?], Unit]].from(OptionT[Either[Nothing, ?], Unit](Right(None)))
+      make[OptionT[scala.Either[Nothing, _], Unit]].from(OptionT[Either[Nothing, _], Unit](Right(None)))
       make[K1[T1]].from(new K1[T1] {})
       make[W1.T2]
       make[W2.T2]

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/HigherKindsTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/HigherKindsTest.scala
@@ -48,22 +48,22 @@ class HigherKindsTest extends AnyWordSpec with MkInjector {
     assert(listContext.get[List[Either[Int, List[String]]]] == List(Right(List("hello"))))
 
     val optionTInjector = mkInjector()
-    val optionTPlan = optionTInjector.plan(PlannerInput.everything(Definition[OptionT[List, ?]](5)))
+    val optionTPlan = optionTInjector.plan(PlannerInput.everything(Definition[OptionT[List, _]](5)))
     val optionTContext = optionTInjector.produce(optionTPlan).unsafeGet()
 
     assert(optionTContext.get[TestTrait].get == OptionT(List(Option(5))))
-    assert(optionTContext.get[TestServiceClass[OptionT[List, ?]]].get == OptionT(List(Option(5))))
-    assert(optionTContext.get[TestServiceTrait[OptionT[List, ?]]].get == OptionT(List(Option(10))))
+    assert(optionTContext.get[TestServiceClass[OptionT[List, _]]].get == OptionT(List(Option(5))))
+    assert(optionTContext.get[TestServiceTrait[OptionT[List, _]]].get == OptionT(List(Option(10))))
     assert(optionTContext.get[OptionT[List, String]] == OptionT(List(Option("Hello 5!"))))
 
     val eitherInjector = mkInjector()
-    val eitherPlan = eitherInjector.plan(PlannerInput.everything(Definition[Either[String, ?]](5)))
+    val eitherPlan = eitherInjector.plan(PlannerInput.everything(Definition[Either[String, _]](5)))
 
     val eitherContext = eitherInjector.produce(eitherPlan).unsafeGet()
 
     assert(eitherContext.get[TestTrait].get == Right(5))
-    assert(eitherContext.get[TestServiceClass[Either[String, ?]]].get == Right(5))
-    assert(eitherContext.get[TestServiceTrait[Either[String, ?]]].get == Right(10))
+    assert(eitherContext.get[TestServiceClass[Either[String, _]]].get == Right(5))
+    assert(eitherContext.get[TestServiceTrait[Either[String, _]]].get == Right(10))
     assert(eitherContext.get[Either[String, String]] == Right("Hello 5!"))
     assert(
       eitherContext.get[Either[Either[String, String], Either[String, Either[String, Either[String, Either[String, String]]]]]]

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/ResourceEffectBindingsTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/ResourceEffectBindingsTest.scala
@@ -60,7 +60,7 @@ class ResourceEffectBindingsTest extends AnyWordSpec with MkInjector with GivenW
       val injector = mkInjector()
       val plan = injector.plan(definition)
 
-      val context = injector.produceCustomF[Suspend2[Throwable, ?]](plan).unsafeGet().unsafeRun()
+      val context = injector.produceCustomF[Suspend2[Throwable, _]](plan).unsafeGet().unsafeRun()
 
       assert(context.get[Int] == 12)
     }
@@ -80,7 +80,7 @@ class ResourceEffectBindingsTest extends AnyWordSpec with MkInjector with GivenW
       val injector = mkInjector()
       val plan = injector.plan(definition)
 
-      val context = injector.produceCustomF[Suspend2[Nothing, ?]](plan).unsafeGet().unsafeRun()
+      val context = injector.produceCustomF[Suspend2[Nothing, _]](plan).unsafeGet().unsafeRun()
 
       assert(context.get[Int]("1") != context.get[Int]("2"))
       assert(Set(context.get[Int]("1"), context.get[Int]("2")) == Set(1, 2))
@@ -101,7 +101,7 @@ class ResourceEffectBindingsTest extends AnyWordSpec with MkInjector with GivenW
 
       val injector = mkInjector()
       val plan = injector.plan(definition)
-      val context = injector.produceCustomF[Suspend2[Throwable, ?]](plan).unsafeGet().unsafeRun()
+      val context = injector.produceCustomF[Suspend2[Throwable, _]](plan).unsafeGet().unsafeRun()
 
       assert(context.get[Int] == 12)
     }
@@ -130,7 +130,7 @@ class ResourceEffectBindingsTest extends AnyWordSpec with MkInjector with GivenW
 
       val injector = mkInjector()
       val plan = injector.plan(definition)
-      val context = injector.produceCustomF[Suspend2[Throwable, ?]](plan).unsafeGet().unsafeRun()
+      val context = injector.produceCustomF[Suspend2[Throwable, _]](plan).unsafeGet().unsafeRun()
 
       assert(context.get[Set[Char]] == "ab".toSet)
       assert(context.get[Ref[Fn, Set[Char]]].get.unsafeRun() == "ABZ".toSet)
@@ -320,7 +320,7 @@ class ResourceEffectBindingsTest extends AnyWordSpec with MkInjector with GivenW
       val plan = injector.plan(definition)
 
       val instance = injector
-        .produceCustomF[Suspend2[Throwable, ?]](plan).use {
+        .produceCustomF[Suspend2[Throwable, _]](plan).use {
           context =>
             val instance = context.get[Res]
             assert(instance.initialized)
@@ -342,7 +342,7 @@ class ResourceEffectBindingsTest extends AnyWordSpec with MkInjector with GivenW
       val injector = mkInjector()
       val plan = injector.plan(definition)
 
-      val resource = injector.produceCustomF[Suspend2[Throwable, ?]](plan)
+      val resource = injector.produceCustomF[Suspend2[Throwable, _]](plan)
 
       val set = resource
         .use {
@@ -379,7 +379,7 @@ class ResourceEffectBindingsTest extends AnyWordSpec with MkInjector with GivenW
       val injector = mkInjector()
       val plan = injector.plan(definition)
 
-      val resource = injector.produceDetailedCustomF[Suspend2[Throwable, ?]](plan)
+      val resource = injector.produceDetailedCustomF[Suspend2[Throwable, _]](plan)
 
       val failure = resource
         .use {
@@ -415,7 +415,7 @@ class ResourceEffectBindingsTest extends AnyWordSpec with MkInjector with GivenW
       val plan = injector.plan(definition)
 
       val resource = injector
-        .produceDetailedCustomF[Suspend2[Throwable, ?]](plan)
+        .produceDetailedCustomF[Suspend2[Throwable, _]](plan)
         .evalMap {
           case Left(failure) =>
             Suspend2 {
@@ -461,9 +461,9 @@ class ResourceEffectBindingsTest extends AnyWordSpec with MkInjector with GivenW
     }
 
     "obtain QuasiApplicative for BIO Free/FreeError/FreePanic" in {
-      implicitly[QuasiApplicative[Free[Suspend2, Throwable, +?]]]
-      implicitly[QuasiApplicative[FreeError[Suspend2, Throwable, +?]]]
-      implicitly[QuasiApplicative[FreePanic[Suspend2, Throwable, +?]]]
+      implicitly[QuasiApplicative[Free[Suspend2, Throwable, +_]]]
+      implicitly[QuasiApplicative[FreeError[Suspend2, Throwable, +_]]]
+      implicitly[QuasiApplicative[FreePanic[Suspend2, Throwable, +_]]]
     }
 
   }

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/ZIOHasInjectionTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/ZIOHasInjectionTest.scala
@@ -35,7 +35,7 @@ class ZIOHasInjectionTest extends AnyWordSpec with MkInjector {
 
   final class ResourceEmptyHasImpl[F[+_, +_]: Applicative2](
     d1: Dependency1
-  ) extends Lifecycle.LiftF[F[Throwable, ?], Trait1](
+  ) extends Lifecycle.LiftF[F[Throwable, _], Trait1](
       F.pure(trait1(d1))
     )
 
@@ -221,7 +221,7 @@ class ZIOHasInjectionTest extends AnyWordSpec with MkInjector {
         make[Dependency2]
         make[Dependency3]
         addImplicit[Local3[F]]
-        addImplicit[Applicative2[F[Any, +?, +?]]]
+        addImplicit[Applicative2[F[Any, +_, +_]]]
         make[Trait3 { def dep1: Dependency1 }].fromHas(
           (d3: Dependency3) =>
             (for {
@@ -234,10 +234,10 @@ class ZIOHasInjectionTest extends AnyWordSpec with MkInjector {
             }): F[Has[Dependency1] with Has[Dependency2], Nothing, Trait3]
         )
         make[Trait2].fromHas[ResourceHasImpl[F]]
-        make[Trait1].fromHas[ResourceEmptyHasImpl[F[Any, +?, +?]]]
+        make[Trait1].fromHas[ResourceEmptyHasImpl[F[Any, +_, +_]]]
 
         many[Trait2].addHas[ResourceHasImpl[F]]
-        many[Trait1].addHas[ResourceEmptyHasImpl[F[Any, +?, +?]]]
+        many[Trait1].addHas[ResourceEmptyHasImpl[F[Any, +_, +_]]]
       })
 
       val injector = mkNoCyclesInjector()

--- a/distage/distage-extension-config/src/test/scala/izumi/distage/config/ConfigTest.scala
+++ b/distage/distage-extension-config/src/test/scala/izumi/distage/config/ConfigTest.scala
@@ -50,8 +50,8 @@ final class ConfigTest extends AnyWordSpec {
       val context = injector.produce(plan).unsafeGet()
 
       // FIXME: pureconfig can't read specialized map types
-//      assert(context.get[Service[MapCaseClass]].conf.mymap.isInstanceOf[mutable.LinkedHashMap[_, _]])
-      assert(context.get[Service[MapCaseClass]].conf.mymap.isInstanceOf[Map[_, _]])
+//      assert(context.get[Service[MapCaseClass]].conf.mymap.isInstanceOf[mutable.LinkedHashMap[?, ?]])
+      assert(context.get[Service[MapCaseClass]].conf.mymap.isInstanceOf[Map[?, ?]])
       assert(context.get[Service[MapCaseClass]].conf.mymap.keySet == Set("service1", "service2", "service3", "service4", "service5", "service6"))
       assert(context.get[Service[MapCaseClass]].conf.mymap.values.forall(_.host == "localhost"))
     }
@@ -69,8 +69,8 @@ final class ConfigTest extends AnyWordSpec {
 
       val context = injector.produce(plan).unsafeGet()
 
-      assert(context.get[Service[ListCaseClass]].conf.mylist.isInstanceOf[IndexedSeq[_]])
-      assert(context.get[Service[ListCaseClass]].conf.mylist.head.isInstanceOf[ListSet[_]])
+      assert(context.get[Service[ListCaseClass]].conf.mylist.isInstanceOf[IndexedSeq[?]])
+      assert(context.get[Service[ListCaseClass]].conf.mylist.head.isInstanceOf[ListSet[?]])
       assert(
         context.get[Service[ListCaseClass]].conf.mylist.head ==
         Set(

--- a/distage/distage-extension-config/src/test/scala/izumi/distage/impl/OptionalDependencyTest.scala
+++ b/distage/distage-extension-config/src/test/scala/izumi/distage/impl/OptionalDependencyTest.scala
@@ -72,7 +72,7 @@ class OptionalDependencyTest extends AnyWordSpec with GivenWhenThen {
     type SomeBIO3[-R, +E, +A] = R => SomeBIO[E, A]
 
     def threeTo2[FR[-_, +_, +_]](implicit FR: IO3[FR]): FR[Any, Nothing, Unit] = {
-      val F: IO2[FR[Any, +?, +?]] = implicitly // must use `BIOConvert3To2` instance to convert FR -> F
+      val F: IO2[FR[Any, +_, +_]] = implicitly // must use `BIOConvert3To2` instance to convert FR -> F
       F.unit
     }
 
@@ -138,7 +138,7 @@ class OptionalDependencyTest extends AnyWordSpec with GivenWhenThen {
 
     And("Methods that use `No More Orphans` trick can be called with nulls, but will error")
     intercept[NoClassDefFoundError] {
-      QuasiIO.fromCats[Option, Lifecycle[?[_], Int]](null, null)
+      QuasiIO.fromCats[Option, Lifecycle[_[_], Int]](null, null)
     }
 
     And("Methods that mention cats types only in generics will error on call")

--- a/distage/distage-extension-logstage/src/main/scala/izumi/logstage/distage/LogIOModule.scala
+++ b/distage/distage-extension-logstage/src/main/scala/izumi/logstage/distage/LogIOModule.scala
@@ -32,7 +32,7 @@ object LogIOModule {
 }
 
 /** [[LogIOModule]] for bifunctors */
-class LogIO2Module[F[_, _]: TagKK] extends LogIOModule[F[Nothing, ?]]
+class LogIO2Module[F[_, _]: TagKK] extends LogIOModule[F[Nothing, _]]
 
 object LogIO2Module {
   @inline def apply[F[_, _]: TagKK](): LogIO2Module[F] = new LogIO2Module
@@ -42,7 +42,7 @@ object LogIO2Module {
 }
 
 /** [[LogIOModule]] for trifunctors */
-class LogIO3Module[F[_, _, _]: TagK3] extends LogIOModule[F[Any, Nothing, ?]]
+class LogIO3Module[F[_, _, _]: TagK3] extends LogIOModule[F[Any, Nothing, _]]
 
 object LogIO3Module {
   @inline def apply[F[_, _, _]: TagK3](): LogIO3Module[F] = new LogIO3Module

--- a/distage/distage-extension-plugins/src/main/scala/izumi/distage/plugins/load/PluginLoaderDefaultImpl.scala
+++ b/distage/distage-extension-plugins/src/main/scala/izumi/distage/plugins/load/PluginLoaderDefaultImpl.scala
@@ -25,7 +25,7 @@ class PluginLoaderDefaultImpl extends PluginLoader {
     val disabledPackages = config.packagesDisabled
 
     val pluginBase = classOf[PluginBase]
-    val pluginDef = classOf[PluginDef[_]]
+    val pluginDef = classOf[PluginDef[?]]
     val whitelistedClasses = Seq(pluginDef.getName)
 
     def loadPkgs(pkgs: Seq[String]): Seq[PluginBase] = {

--- a/distage/distage-framework-api/src/main/scala/izumi/distage/roles/model/AbstractRole.scala
+++ b/distage/distage-framework-api/src/main/scala/izumi/distage/roles/model/AbstractRole.scala
@@ -27,7 +27,7 @@ trait RoleService[+F[_]] extends AbstractRole[F] {
     * import logstage.LogIO2.log
     *
     * final class HelloService[F[+_, +_]: IO2: LogIO2] extends RoleService[F] {
-    *   def start(roleParameters: RawEntrypointParams, freeArgs: Vector[String]): Lifecycle[F[Nothing, ?], Unit] = {
+    *   def start(roleParameters: RawEntrypointParams, freeArgs: Vector[String]): Lifecycle[F[Nothing, _], Unit] = {
     *     Lifecycle.fork_(helloServer).void
     *   }
     *

--- a/distage/distage-framework-api/src/main/scala/izumi/distage/roles/model/meta/RoleBinding.scala
+++ b/distage/distage-framework-api/src/main/scala/izumi/distage/roles/model/meta/RoleBinding.scala
@@ -6,7 +6,7 @@ import izumi.distage.roles.model.RoleDescriptor
 
 final case class RoleBinding(
   binding: Binding,
-  runtimeClass: Class[_],
+  runtimeClass: Class[?],
   tpe: SafeType,
   descriptor: RoleDescriptor,
 )

--- a/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/Docker.scala
+++ b/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/Docker.scala
@@ -163,7 +163,7 @@ object Docker {
     cwd: Option[String] = None,
     user: Option[String] = None,
     mounts: Seq[Mount] = Seq.empty,
-    networks: Set[ContainerNetwork[_]] = Set.empty,
+    networks: Set[ContainerNetwork[?]] = Set.empty,
     reuse: DockerReusePolicy = DockerReusePolicy.ReuseEnabled,
     autoRemove: Boolean = true,
     healthCheckInterval: FiniteDuration = FiniteDuration(1, TimeUnit.SECONDS),

--- a/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/healthcheck/ContainerHealthCheck.scala
+++ b/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/healthcheck/ContainerHealthCheck.scala
@@ -7,17 +7,17 @@ import izumi.fundamentals.collections.nonempty.{NonEmptyList, NonEmptyMap}
 import izumi.logstage.api.IzLogger
 
 trait ContainerHealthCheck {
-  def check(logger: IzLogger, container: DockerContainer[_], state: ContainerState): HealthCheckResult
+  def check(logger: IzLogger, container: DockerContainer[?], state: ContainerState): HealthCheckResult
 
   final def ++(next: HealthCheckResult => ContainerHealthCheck): ContainerHealthCheck = {
     this.combine(next)
   }
   final def combine(next: HealthCheckResult => ContainerHealthCheck): ContainerHealthCheck = {
-    (logger: IzLogger, container: DockerContainer[_], state: ContainerState) =>
+    (logger: IzLogger, container: DockerContainer[?], state: ContainerState) =>
       next(check(logger, container, state)).check(logger, container, state)
   }
   final def combineOnPorts(next: HealthCheckResult.AvailableOnPorts => ContainerHealthCheck): ContainerHealthCheck = {
-    (logger: IzLogger, container: DockerContainer[_], state: ContainerState) =>
+    (logger: IzLogger, container: DockerContainer[?], state: ContainerState) =>
       check(logger, container, state) match {
         case thisCheckResult: HealthCheckResult.AvailableOnPorts =>
           next(thisCheckResult).check(logger, container, state) match {

--- a/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/healthcheck/ContainerHealthCheckBase.scala
+++ b/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/healthcheck/ContainerHealthCheckBase.scala
@@ -11,12 +11,12 @@ import izumi.logstage.api.IzLogger
 abstract class ContainerHealthCheckBase extends ContainerHealthCheck {
   protected def perform(
     logger: IzLogger,
-    container: DockerContainer[_],
+    container: DockerContainer[?],
     tcpPorts: Map[DockerPort.TCPBase, NonEmptyList[ServicePort]],
     udpPorts: Map[DockerPort.UDPBase, NonEmptyList[ServicePort]],
   ): HealthCheckResult
 
-  override final def check(logger: IzLogger, container: DockerContainer[_], state: ContainerState): HealthCheckResult = {
+  override final def check(logger: IzLogger, container: DockerContainer[?], state: ContainerState): HealthCheckResult = {
     HealthCheckResult.onRunning(state) {
       val tcpPorts: Map[DockerPort.TCPBase, NonEmptyList[ServicePort]] =
         container.connectivity.dockerPorts.collect {
@@ -34,7 +34,7 @@ abstract class ContainerHealthCheckBase extends ContainerHealthCheck {
     }
   }
 
-  protected def findContainerInternalCandidates[P <: DockerPort](container: DockerContainer[_], ports: Map[P, NonEmptyList[ServicePort]]): Seq[PortCandidate[P]] = {
+  protected def findContainerInternalCandidates[P <: DockerPort](container: DockerContainer[?], ports: Map[P, NonEmptyList[ServicePort]]): Seq[PortCandidate[P]] = {
     val labels = container.labels
     val addresses = container.connectivity.containerAddresses
     ports.toSeq.flatMap {
@@ -54,7 +54,7 @@ abstract class ContainerHealthCheckBase extends ContainerHealthCheck {
     }
   }
 
-  protected def findDockerHostCandidates[P <: DockerPort](container: DockerContainer[_], ports: Map[P, NonEmptyList[ServicePort]]): Seq[PortCandidate[P]] = {
+  protected def findDockerHostCandidates[P <: DockerPort](container: DockerContainer[?], ports: Map[P, NonEmptyList[ServicePort]]): Seq[PortCandidate[P]] = {
     ports.toSeq.flatMap {
       case (mappedPort, internalBindings) =>
         internalBindings.toList.flatMap {
@@ -67,7 +67,7 @@ abstract class ContainerHealthCheckBase extends ContainerHealthCheck {
     }
   }
 
-  protected def tcpPortsGood(container: DockerContainer[_], good: AvailablePorts): Boolean = {
+  protected def tcpPortsGood(container: DockerContainer[?], good: AvailablePorts): Boolean = {
     val tcpPorts = container.containerConfig.tcpPorts
     tcpPorts.diff(good.availablePorts.toMap.keySet).isEmpty
   }

--- a/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/healthcheck/ExitSuccessCheck.scala
+++ b/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/healthcheck/ExitSuccessCheck.scala
@@ -6,7 +6,7 @@ import izumi.distage.docker.{Docker, DockerContainer}
 import izumi.logstage.api.IzLogger
 
 final class ExitSuccessCheck(exitCode: Int) extends ContainerHealthCheck {
-  override def check(logger: IzLogger, container: DockerContainer[_], state: Docker.ContainerState): HealthCheckResult = {
+  override def check(logger: IzLogger, container: DockerContainer[?], state: Docker.ContainerState): HealthCheckResult = {
     state match {
       case ContainerState.Exited(code) if code == exitCode =>
         logger.info(s"$container successfully exited, health check passed.")

--- a/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/healthcheck/HttpGetCheck.scala
+++ b/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/healthcheck/HttpGetCheck.scala
@@ -12,7 +12,7 @@ final class HttpGetCheck(
   port: DockerPort,
   useHttps: Boolean,
 ) extends ContainerHealthCheck {
-  override def check(logger: IzLogger, container: DockerContainer[_], state: ContainerState): HealthCheckResult = {
+  override def check(logger: IzLogger, container: DockerContainer[?], state: ContainerState): HealthCheckResult = {
     HealthCheckResult.onRunning(state) {
       portStatus.availablePorts.firstOption(port) match {
         case Some(availablePort) if portStatus.allTCPPortsAccessible =>

--- a/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/healthcheck/PostgreSqlProtocolCheck.scala
+++ b/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/healthcheck/PostgreSqlProtocolCheck.scala
@@ -15,7 +15,7 @@ final class PostgreSqlProtocolCheck(
   userName: String,
   databaseName: String,
 ) extends ContainerHealthCheck {
-  override def check(logger: IzLogger, container: DockerContainer[_], state: ContainerState): HealthCheckResult = {
+  override def check(logger: IzLogger, container: DockerContainer[?], state: ContainerState): HealthCheckResult = {
     HealthCheckResult.onRunning(state) {
       portStatus.availablePorts.firstOption(port) match {
         case Some(availablePort) if portStatus.allTCPPortsAccessible =>

--- a/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/healthcheck/TCPContainerHealthCheck.scala
+++ b/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/healthcheck/TCPContainerHealthCheck.scala
@@ -15,7 +15,7 @@ class TCPContainerHealthCheck extends ContainerHealthCheckBase {
 
   override protected def perform(
     logger: IzLogger,
-    container: DockerContainer[_],
+    container: DockerContainer[?],
     tcpPorts: Map[DockerPort.TCPBase, NonEmptyList[ServicePort]],
     udpPorts: Map[DockerPort.UDPBase, NonEmptyList[ServicePort]],
   ): HealthCheckResult = {

--- a/distage/distage-framework-docker/src/test/scala/izumi/distage/testkit/docker/DistageTestDockerBIO.scala
+++ b/distage/distage-framework-docker/src/test/scala/izumi/distage/testkit/docker/DistageTestDockerBIO.scala
@@ -29,7 +29,7 @@ abstract class DistageTestDockerBIO extends Spec2[IO] {
 
       "support docker resources" in {
         // TODO: additionally check flyway outcome with doobie
-        (service: PgSvcExample, verifier: Lifecycle[IO[Throwable, ?], ReuseCheckContainer.Container], log: LogIO2[IO]) =>
+        (service: PgSvcExample, verifier: Lifecycle[IO[Throwable, _], ReuseCheckContainer.Container], log: LogIO2[IO]) =>
           for {
             _ <- log.info(s"ports/1: pg=${service.pg} pgfw=${service.pgfw} ddb=${service.ddb} kafka=${service.kafka} cs=${service.cs}")
             _ <- verifier.use(_ => IO.unit)
@@ -37,7 +37,7 @@ abstract class DistageTestDockerBIO extends Spec2[IO] {
       }
 
       "support memoization" in {
-        (service: PgSvcExample, verifier: Lifecycle[IO[Throwable, ?], ReuseCheckContainer.Container], log: LogIO2[IO]) =>
+        (service: PgSvcExample, verifier: Lifecycle[IO[Throwable, _], ReuseCheckContainer.Container], log: LogIO2[IO]) =>
           for {
             _ <- log.info(s"ports/2: pg=${service.pg} pgfw=${service.pgfw} ddb=${service.ddb} kafka=${service.kafka} cs=${service.cs}")
             _ <- verifier.use(_ => IO.unit)

--- a/distage/distage-framework-docker/src/test/scala/izumi/distage/testkit/docker/ExitCodeCheckTest.scala
+++ b/distage/distage-framework-docker/src/test/scala/izumi/distage/testkit/docker/ExitCodeCheckTest.scala
@@ -11,13 +11,13 @@ final class ExitCodeCheckTest extends Spec2[IO] with AssertZIO {
   "Exit code check" should {
 
     "Succeed on correct exit code" in {
-      (checkingContainer: ContainerResource[IO[Throwable, ?], ExitCodeCheckContainer.Tag]) =>
+      (checkingContainer: ContainerResource[IO[Throwable, _], ExitCodeCheckContainer.Tag]) =>
         checkingContainer
           .use(_ => IO.unit)
     }
 
     "Fail on incorrect exit code" in {
-      (checkingContainer: ContainerResource[IO[Throwable, ?], ExitCodeCheckContainer.Tag]) =>
+      (checkingContainer: ContainerResource[IO[Throwable, _], ExitCodeCheckContainer.Tag]) =>
         for {
           Left(error) <- checkingContainer
             .copy(config =

--- a/distage/distage-framework/src/main/scala/izumi/distage/roles/RoleAppMain.scala
+++ b/distage/distage-framework/src/main/scala/izumi/distage/roles/RoleAppMain.scala
@@ -141,19 +141,19 @@ abstract class RoleAppMain[F[_]](
 
 object RoleAppMain {
 
-  abstract class LauncherBIO2[F[+_, +_]: TagKK: Async2: DefaultModule2](implicit artifact: IzArtifactMaterializer) extends RoleAppMain[F[Throwable, ?]] {
-    override protected def shutdownStrategy: AppShutdownStrategy[F[Throwable, ?]] = new BIOShutdownStrategy[F]
+  abstract class LauncherBIO2[F[+_, +_]: TagKK: Async2: DefaultModule2](implicit artifact: IzArtifactMaterializer) extends RoleAppMain[F[Throwable, _]] {
+    override protected def shutdownStrategy: AppShutdownStrategy[F[Throwable, _]] = new BIOShutdownStrategy[F]
 
-    // add LogIO2[F] for bifunctor convenience to match existing LogIO[F[Throwable, ?]]
+    // add LogIO2[F] for bifunctor convenience to match existing LogIO[F[Throwable, _]]
     override protected def roleAppBootOverrides(argv: ArgV): Module = super.roleAppBootOverrides(argv) ++ new ModuleDef {
       modify[ModuleProvider](_.mapApp(LogIO2Module[F]() +: _))
     }
   }
 
-  abstract class LauncherBIO3[F[-_, +_, +_]: TagK3: Async3: DefaultModule3](implicit artifact: IzArtifactMaterializer) extends RoleAppMain[F[Any, Throwable, ?]] {
-    override protected def shutdownStrategy: AppShutdownStrategy[F[Any, Throwable, ?]] = new BIOShutdownStrategy[F[Any, +?, +?]]
+  abstract class LauncherBIO3[F[-_, +_, +_]: TagK3: Async3: DefaultModule3](implicit artifact: IzArtifactMaterializer) extends RoleAppMain[F[Any, Throwable, _]] {
+    override protected def shutdownStrategy: AppShutdownStrategy[F[Any, Throwable, _]] = new BIOShutdownStrategy[F[Any, +_, +_]]
 
-    // add LogIO2[F] for trifunctor convenience to match existing LogIO[F[Throwable, ?]]
+    // add LogIO2[F] for trifunctor convenience to match existing LogIO[F[Throwable, _]]
     override protected def roleAppBootOverrides(argv: ArgV): Module = super.roleAppBootOverrides(argv) ++ new ModuleDef {
       modify[ModuleProvider](_.mapApp(LogIO3Module[F]() +: _))
     }

--- a/distage/distage-framework/src/main/scala/izumi/distage/roles/launcher/AppShutdownStrategy.scala
+++ b/distage/distage-framework/src/main/scala/izumi/distage/roles/launcher/AppShutdownStrategy.scala
@@ -139,7 +139,7 @@ object AppShutdownStrategy {
     }
   }
 
-  class BIOShutdownStrategy[F[+_, +_]: Async2] extends AppShutdownStrategy[F[Throwable, ?]] {
+  class BIOShutdownStrategy[F[+_, +_]: Async2] extends AppShutdownStrategy[F[Throwable, _]] {
     private val primaryLatch: Promise[Unit] = Promise[Unit]()
     private val postShutdownLatch: CountDownLatch = new CountDownLatch(1)
 

--- a/distage/distage-framework/src/main/scala_2.12/izumi/distage/framework/PlanCheckConfig.scala
+++ b/distage/distage-framework/src/main/scala_2.12/izumi/distage/framework/PlanCheckConfig.scala
@@ -112,7 +112,7 @@ object PlanCheckConfig {
 
   def empty = PlanCheckConfig()
 
-  type Any = PlanCheckConfig[_ <: String, _ <: String, _ <: String, _ <: Boolean, _ <: Boolean, _ <: Boolean]
+  type Any = PlanCheckConfig[? <: String, ? <: String, ? <: String, ? <: Boolean, ? <: Boolean, ? <: Boolean]
 
   type Unset <: Boolean with Singleton
 

--- a/distage/distage-framework/src/main/scala_2.13/izumi/distage/framework/PlanCheckConfig.scala
+++ b/distage/distage-framework/src/main/scala_2.13/izumi/distage/framework/PlanCheckConfig.scala
@@ -66,7 +66,7 @@ object PlanCheckConfig {
 
   def empty: PlanCheckConfig["*", "", "*", Unset, Unset, Unset] = PlanCheckConfig()
 
-  type Any = PlanCheckConfig[_ <: String, _ <: String, _ <: String, _ <: Boolean, _ <: Boolean, _ <: Boolean]
+  type Any = PlanCheckConfig[? <: String, ? <: String, ? <: String, ? <: Boolean, ? <: Boolean, ? <: Boolean]
 
   type Unset <: Boolean with Singleton
 

--- a/distage/distage-framework/src/test/scala/com/github/pshirshov/test/plugins/StaticTestMain.scala
+++ b/distage/distage-framework/src/test/scala/com/github/pshirshov/test/plugins/StaticTestMain.scala
@@ -32,9 +32,9 @@ class StaticTestMainLogIO2[F[+_, +_]: TagKK: Async2: DefaultModule2] extends Rol
   override protected def pluginConfig: PluginConfig =
     PluginConfig
       .cached("com.github.pshirshov.test.plugins")
-      .++(staticTestMainPlugin[F[Throwable, ?], F[Throwable, ?]])
+      .++(staticTestMainPlugin[F[Throwable, _], F[Throwable, _]])
       .++(new PluginDef {
-        modify[StaticTestRole[F[Throwable, ?]]]
+        modify[StaticTestRole[F[Throwable, _]]]
           .addDependency[LogIO2[F]]
       })
 }

--- a/distage/distage-framework/src/test/scala/izumi/distage/roles/test/ManualTestEntrypoint.scala
+++ b/distage/distage-framework/src/test/scala/izumi/distage/roles/test/ManualTestEntrypoint.scala
@@ -6,7 +6,7 @@ import izumi.distage.roles.launcher.AppFailureHandler
 import izumi.distage.roles.test.fixtures.{ExitAfterSleepRole, TestPluginBase}
 import izumi.fundamentals.platform.cli.model.raw.RawRoleParams
 
-class TestPluginZIO extends TestPluginBase[zio.IO[Throwable, *]]
+class TestPluginZIO extends TestPluginBase[zio.IO[Throwable, _]]
 
 class ManualTestEntrypointBase extends RoleAppMain.LauncherBIO2[zio.IO] {
 

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/TestConfig.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/TestConfig.scala
@@ -102,7 +102,7 @@ final case class TestConfig(
   debugOutput: Boolean = false,
 )
 object TestConfig {
-  def forSuite(clazz: Class[_]): TestConfig = {
+  def forSuite(clazz: Class[?]): TestConfig = {
     val packageName = clazz.getPackage.getName
     TestConfig(
       pluginConfig = PluginConfig.cached(Seq(packageName)),
@@ -157,19 +157,19 @@ object TestConfig {
   object AxisDIKeys {
     def empty: AxisDIKeys = AxisDIKeys(Map.empty)
 
-    @inline implicit def fromSet(set: Set[_ <: DIKey]): AxisDIKeys =
+    @inline implicit def fromSet(set: Set[? <: DIKey]): AxisDIKeys =
       AxisDIKeys(Map(Set.empty -> set.toSet[DIKey]))
 
-    @inline implicit def fromSetMap(map: Iterable[(Set[_ <: AxisChoice], Set[_ <: DIKey])]): AxisDIKeys =
+    @inline implicit def fromSetMap(map: Iterable[(Set[? <: AxisChoice], Set[? <: DIKey])]): AxisDIKeys =
       AxisDIKeys(map.iterator.map { case (k, v) => k.toSet[AxisChoice] -> v.toSet[DIKey] }.toMap)
 
     @inline implicit def fromSingleMap(map: Iterable[(AxisChoice, DIKey)]): AxisDIKeys =
       AxisDIKeys(map.iterator.map { case (k, v) => Set(k) -> Set(v) }.toMap)
 
-    @inline implicit def fromSingleToSetMap(map: Iterable[(AxisChoice, Set[_ <: DIKey])]): AxisDIKeys =
+    @inline implicit def fromSingleToSetMap(map: Iterable[(AxisChoice, Set[? <: DIKey])]): AxisDIKeys =
       AxisDIKeys(map.iterator.map { case (k, v) => Set(k) -> v.toSet[DIKey] }.toMap)
 
-    @inline implicit def fromSetToSingleMap(map: Iterable[(Set[_ <: AxisChoice], DIKey)]): AxisDIKeys =
+    @inline implicit def fromSetToSingleMap(map: Iterable[(Set[? <: AxisChoice], DIKey)]): AxisDIKeys =
       AxisDIKeys(map.iterator.map { case (k, v) => k.toSet[AxisChoice] -> Set(v) }.toMap)
   }
 
@@ -198,10 +198,10 @@ object TestConfig {
 
     final val MaxLevel = Int.MaxValue
 
-    @inline implicit def fromSet(set: Set[_ <: DIKey]): PriorAxisDIKeys =
+    @inline implicit def fromSet(set: Set[? <: DIKey]): PriorAxisDIKeys =
       PriorAxisDIKeys(Map(MaxLevel -> AxisDIKeys.fromSet(set)))
 
-    @inline implicit def fromPriorSet(map: Map[Int, Set[_ <: DIKey]]): PriorAxisDIKeys =
+    @inline implicit def fromPriorSet(map: Map[Int, Set[? <: DIKey]]): PriorAxisDIKeys =
       PriorAxisDIKeys(map.map { case (i, v) => i -> AxisDIKeys.fromSet(v) })
 
     @inline implicit def fromAxisDIKeys[A](set: A)(implicit toAxisDIKeys: A => AxisDIKeys): PriorAxisDIKeys =

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/services/DISyntaxBIOBase.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/services/DISyntaxBIOBase.scala
@@ -5,11 +5,11 @@ import izumi.distage.model.providers.Functoid
 import izumi.functional.bio.{ApplicativeError2, TypedError}
 import izumi.fundamentals.platform.language.SourceFilePosition
 
-trait DISyntaxBIOBase[F[+_, +_]] extends DISyntaxBase[F[Throwable, ?]] {
+trait DISyntaxBIOBase[F[+_, +_]] extends DISyntaxBase[F[Throwable, _]] {
   implicit def tagBIO: TagKK[F]
 
-  protected final def takeBIO(function: Functoid[F[_, _]], pos: SourceFilePosition): Unit = {
-    val fAsThrowable: Functoid[F[Throwable, _]] = function
+  protected final def takeBIO(function: Functoid[F[?, ?]], pos: SourceFilePosition): Unit = {
+    val fAsThrowable: Functoid[F[Throwable, ?]] = function
       .map2(Functoid.identity[ApplicativeError2[F]]) {
         (effect, F) =>
           F.leftMap(effect) {
@@ -21,7 +21,7 @@ trait DISyntaxBIOBase[F[+_, +_]] extends DISyntaxBase[F[Throwable, ?]] {
     takeIO(fAsThrowable, pos)
   }
 
-  protected final def takeFunBIO[T: Tag](function: T => F[_, _], pos: SourceFilePosition): Unit = {
+  protected final def takeFunBIO[T: Tag](function: T => F[?, ?], pos: SourceFilePosition): Unit = {
     takeBIO(function, pos)
   }
 

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/services/DISyntaxBase.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/services/DISyntaxBase.scala
@@ -8,7 +8,7 @@ import izumi.fundamentals.platform.language.SourceFilePosition
 trait DISyntaxBase[F[_]] {
   implicit def tagMonoIO: TagK[F]
 
-  protected def takeIO(function: Functoid[F[_]], pos: SourceFilePosition): Unit
+  protected def takeIO(function: Functoid[F[?]], pos: SourceFilePosition): Unit
 
   protected final def takeAny(function: Functoid[Any], pos: SourceFilePosition): Unit = {
     val f: Functoid[F[Any]] = function.flatAp {
@@ -19,7 +19,7 @@ trait DISyntaxBase[F[_]] {
     takeIO(f, pos)
   }
 
-  protected final def takeFunIO[T: Tag](function: T => F[_], pos: SourceFilePosition): Unit = {
+  protected final def takeFunIO[T: Tag](function: T => F[?], pos: SourceFilePosition): Unit = {
     takeIO(function, pos)
   }
 

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/services/dstest/DistageTestRunner.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/services/dstest/DistageTestRunner.scala
@@ -615,7 +615,7 @@ object DistageTestRunner {
   final case class TestId(name: String, suiteName: String, suiteId: String, suiteClassName: String) {
     override def toString: String = s"$suiteName: $name"
   }
-  final case class DistageTest[F[_]](test: Functoid[F[_]], environment: TestEnvironment, meta: TestMeta)
+  final case class DistageTest[F[_]](test: Functoid[F[?]], environment: TestEnvironment, meta: TestMeta)
   final case class TestMeta(id: TestId, pos: SourceFilePosition, uid: Long)
   final case class SuiteData(suiteName: String, suiteId: String, suiteClassName: String)
 

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/services/dstest/TestRegistration.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/services/dstest/TestRegistration.scala
@@ -5,5 +5,5 @@ import izumi.distage.testkit.services.dstest.DistageTestRunner.TestId
 import izumi.fundamentals.platform.language.SourceFilePosition
 
 trait TestRegistration[F[_]] {
-  def registerTest(function: Functoid[F[_]], env: TestEnvironment, pos: SourceFilePosition, id: TestId): Unit
+  def registerTest(function: Functoid[F[?]], env: TestEnvironment, pos: SourceFilePosition, id: TestId): Unit
 }

--- a/distage/distage-testkit-scalatest/src/main/scala/izumi/distage/testkit/scalatest/Spec2.scala
+++ b/distage/distage-testkit-scalatest/src/main/scala/izumi/distage/testkit/scalatest/Spec2.scala
@@ -10,8 +10,8 @@ import org.scalatest.distage.DistageScalatestTestSuiteRunner
 import scala.language.implicitConversions
 
 abstract class Spec2[F[+_, +_]: DefaultModule2](implicit val tagBIO: TagKK[F])
-  extends DistageScalatestTestSuiteRunner[F[Throwable, ?]]
-  with DistageAbstractScalatestSpec[F[Throwable, ?]] {
+  extends DistageScalatestTestSuiteRunner[F[Throwable, _]]
+  with DistageAbstractScalatestSpec[F[Throwable, _]] {
 
   protected implicit def convertToWordSpecStringWrapperDS2(s: String): DSWordSpecStringWrapper2[F] = {
     new DSWordSpecStringWrapper2(context, distageSuiteName, distageSuiteId, s, this, testEnv)

--- a/distage/distage-testkit-scalatest/src/main/scala/izumi/distage/testkit/scalatest/Spec3.scala
+++ b/distage/distage-testkit-scalatest/src/main/scala/izumi/distage/testkit/scalatest/Spec3.scala
@@ -24,10 +24,10 @@ import scala.language.implicitConversions
   *   type PetStoreEnv = Has[PetStore[IO]]
   *   type PetsEnv = Has[Pets[IO]]
   *
-  *   val store = new PetStore[ZIO[PetStoreEnv, ?, ?]] {
+  *   val store = new PetStore[ZIO[PetStoreEnv, _, _]] {
   *     def purchasePet(name: String, cost: Int): RIO[PetStoreEnv, Boolean] = ZIO.accessM(_.get.purchasePet(name, cost))
   *   }
-  *   val pets = new Pets[ZIO[PetsEnv, ?, ?]] {
+  *   val pets = new Pets[ZIO[PetsEnv, _, _]] {
   *     def myPets: RIO[PetsEnv, List[String]] = ZIO.accessM(_.get.myPets)
   *   }
   *
@@ -55,15 +55,15 @@ import scala.language.implicitConversions
   *   }
   * }}}
   */
-abstract class Spec3[FR[-_, +_, +_]: DefaultModule3](implicit val tagBIO3: TagK3[FR], implicit val tagBIO: TagKK[FR[Any, ?, ?]])
-  extends DistageScalatestTestSuiteRunner[FR[Any, Throwable, ?]]
-  with DistageAbstractScalatestSpec[FR[Any, Throwable, ?]] {
+abstract class Spec3[FR[-_, +_, +_]: DefaultModule3](implicit val tagBIO3: TagK3[FR], implicit val tagBIO: TagKK[FR[Any, _, _]])
+  extends DistageScalatestTestSuiteRunner[FR[Any, Throwable, _]]
+  with DistageAbstractScalatestSpec[FR[Any, Throwable, _]] {
 
   protected implicit def convertToWordSpecStringWrapperDS3(s: String): DSWordSpecStringWrapper3[FR] = {
     new DSWordSpecStringWrapper3(context, distageSuiteName, distageSuiteId, s, this, testEnv)
   }
 
   override protected def config: TestConfig = super.config.copy(
-    moduleOverrides = LogIO2Module[FR[Any, ?, ?]]()(tagBIO)
+    moduleOverrides = LogIO2Module[FR[Any, _, _]]()(tagBIO)
   )
 }

--- a/distage/distage-testkit-scalatest/src/main/scala/izumi/distage/testkit/services/scalatest/dstest/DistageAbstractScalatestSpec.scala
+++ b/distage/distage-testkit-scalatest/src/main/scala/izumi/distage/testkit/services/scalatest/dstest/DistageAbstractScalatestSpec.scala
@@ -20,7 +20,7 @@ import org.scalatest.verbs.{CanVerb, MustVerb, ShouldVerb, StringVerbBlockRegist
 trait WithSingletonTestRegistration[F[_]] extends AbstractDistageSpec[F] {
   private[this] lazy val firstRegistration: Boolean = DistageTestsRegistrySingleton.registerSuite[F](this.getClass.getName)
 
-  override def registerTest(function: Functoid[F[_]], env: TestEnvironment, pos: SourceFilePosition, id: TestId): Unit = {
+  override def registerTest(function: Functoid[F[?]], env: TestEnvironment, pos: SourceFilePosition, id: TestId): Unit = {
     if (firstRegistration) {
       DistageTestsRegistrySingleton.register[F](DistageTest(function, env, TestMeta(id, pos, System.identityHashCode(function).toLong)))
     }
@@ -118,7 +118,7 @@ object DistageAbstractScalatestSpec {
       takeIO(() => value, pos.get)
     }
 
-    override protected def takeIO(function: Functoid[F[_]], pos: SourceFilePosition): Unit = {
+    override protected def takeIO(function: Functoid[F[?]], pos: SourceFilePosition): Unit = {
       val id = TestId(
         context.fold(testname)(_.toName(testname)),
         suiteName,
@@ -134,30 +134,30 @@ object DistageAbstractScalatestSpec {
     suiteName: String,
     suiteId: String,
     testname: String,
-    reg: TestRegistration[F[Throwable, ?]],
+    reg: TestRegistration[F[Throwable, _]],
     env: TestEnvironment,
   )(implicit override val tagBIO: TagKK[F],
-    implicit override val tagMonoIO: TagK[F[Throwable, ?]],
+    implicit override val tagMonoIO: TagK[F[Throwable, _]],
   ) extends DISyntaxBIOBase[F]
-    with LowPriorityIdentityOverloads[F[Throwable, ?]] {
+    with LowPriorityIdentityOverloads[F[Throwable, _]] {
 
-    def in(function: Functoid[F[_, Unit]])(implicit pos: SourceFilePositionMaterializer): Unit = {
+    def in(function: Functoid[F[?, Unit]])(implicit pos: SourceFilePositionMaterializer): Unit = {
       takeBIO(function, pos.get)
     }
 
-    def in(function: Functoid[F[_, Assertion]])(implicit pos: SourceFilePositionMaterializer, d1: DummyImplicit): Unit = {
+    def in(function: Functoid[F[?, Assertion]])(implicit pos: SourceFilePositionMaterializer, d1: DummyImplicit): Unit = {
       takeBIO(function, pos.get)
     }
 
-    def in(value: => F[_, Unit])(implicit pos: SourceFilePositionMaterializer): Unit = {
+    def in(value: => F[?, Unit])(implicit pos: SourceFilePositionMaterializer): Unit = {
       takeBIO(() => value, pos.get)
     }
 
-    def in(value: => F[_, Assertion])(implicit pos: SourceFilePositionMaterializer, d1: DummyImplicit): Unit = {
+    def in(value: => F[?, Assertion])(implicit pos: SourceFilePositionMaterializer, d1: DummyImplicit): Unit = {
       takeBIO(() => value, pos.get)
     }
 
-    override protected def takeIO(fAsThrowable: Functoid[F[Throwable, _]], pos: SourceFilePosition): Unit = {
+    override protected def takeIO(fAsThrowable: Functoid[F[Throwable, ?]], pos: SourceFilePosition): Unit = {
       val id = TestId(
         context.fold(testname)(_.toName(testname)),
         suiteName,
@@ -173,14 +173,14 @@ object DistageAbstractScalatestSpec {
     suiteName: String,
     suiteId: String,
     testname: String,
-    reg: TestRegistration[F[Any, Throwable, ?]],
+    reg: TestRegistration[F[Any, Throwable, _]],
     env: TestEnvironment,
-  )(implicit override val tagBIO: TagKK[F[Any, ?, ?]],
-    implicit override val tagMonoIO: TagK[F[Any, Throwable, ?]],
-  ) extends DISyntaxBIOBase[F[Any, +?, +?]]
-    with LowPriorityIdentityOverloads[F[Any, Throwable, ?]] {
+  )(implicit override val tagBIO: TagKK[F[Any, _, _]],
+    implicit override val tagMonoIO: TagK[F[Any, Throwable, _]],
+  ) extends DISyntaxBIOBase[F[Any, +_, +_]]
+    with LowPriorityIdentityOverloads[F[Any, Throwable, _]] {
 
-    def in[R: HasConstructor](function: Functoid[F[R, _, Unit]])(implicit pos: SourceFilePositionMaterializer): Unit = {
+    def in[R: HasConstructor](function: Functoid[F[R, ?, Unit]])(implicit pos: SourceFilePositionMaterializer): Unit = {
       takeBIO(
         function.zip(HasConstructor[R]).map2(Functoid.identity[Local3[F]]) {
           case ((eff, r), f) => f.provide(eff)(r)
@@ -189,7 +189,7 @@ object DistageAbstractScalatestSpec {
       )
     }
 
-    def in[R: HasConstructor](function: Functoid[F[R, _, Assertion]])(implicit pos: SourceFilePositionMaterializer, d1: DummyImplicit): Unit = {
+    def in[R: HasConstructor](function: Functoid[F[R, ?, Assertion]])(implicit pos: SourceFilePositionMaterializer, d1: DummyImplicit): Unit = {
       takeBIO(
         function.zip(HasConstructor[R]).map2(Functoid.identity[Local3[F]]) {
           case ((eff, r), f) => f.provide(eff)(r)
@@ -198,31 +198,31 @@ object DistageAbstractScalatestSpec {
       )
     }
 
-    def in[R: HasConstructor](value: => F[R, _, Unit])(implicit pos: SourceFilePositionMaterializer): Unit = {
+    def in[R: HasConstructor](value: => F[R, ?, Unit])(implicit pos: SourceFilePositionMaterializer): Unit = {
       takeBIO(Functoid.identity[Local3[F]].map2(HasConstructor[R])(_.provide(value)(_)), pos.get)
     }
 
-    def in[R: HasConstructor](value: => F[R, _, Assertion])(implicit pos: SourceFilePositionMaterializer, d1: DummyImplicit): Unit = {
+    def in[R: HasConstructor](value: => F[R, ?, Assertion])(implicit pos: SourceFilePositionMaterializer, d1: DummyImplicit): Unit = {
       takeBIO(Functoid.identity[Local3[F]].map2(HasConstructor[R])(_.provide(value)(_)), pos.get)
     }
 
-    def in(function: Functoid[F[Any, _, Unit]])(implicit pos: SourceFilePositionMaterializer): Unit = {
+    def in(function: Functoid[F[Any, ?, Unit]])(implicit pos: SourceFilePositionMaterializer): Unit = {
       takeBIO(function, pos.get)
     }
 
-    def in(function: Functoid[F[Any, _, Assertion]])(implicit pos: SourceFilePositionMaterializer, d1: DummyImplicit): Unit = {
+    def in(function: Functoid[F[Any, ?, Assertion]])(implicit pos: SourceFilePositionMaterializer, d1: DummyImplicit): Unit = {
       takeBIO(function, pos.get)
     }
 
-    def in(value: => F[Any, _, Unit])(implicit pos: SourceFilePositionMaterializer): Unit = {
+    def in(value: => F[Any, ?, Unit])(implicit pos: SourceFilePositionMaterializer): Unit = {
       takeBIO(() => value, pos.get)
     }
 
-    def in(value: => F[Any, _, Assertion])(implicit pos: SourceFilePositionMaterializer, d1: DummyImplicit): Unit = {
+    def in(value: => F[Any, ?, Assertion])(implicit pos: SourceFilePositionMaterializer, d1: DummyImplicit): Unit = {
       takeBIO(() => value, pos.get)
     }
 
-    override protected def takeIO(fAsThrowable: Functoid[F[Any, Throwable, _]], pos: SourceFilePosition): Unit = {
+    override protected def takeIO(fAsThrowable: Functoid[F[Any, Throwable, ?]], pos: SourceFilePosition): Unit = {
       val id = TestId(
         context.fold(testname)(_.toName(testname)),
         suiteName,

--- a/distage/distage-testkit-scalatest/src/test/scala/izumi/distage/testkit/distagesuite/integration/IntegrationTest1Test.scala
+++ b/distage/distage-testkit-scalatest/src/test/scala/izumi/distage/testkit/distagesuite/integration/IntegrationTest1Test.scala
@@ -65,7 +65,7 @@ final class MyDisabledTestFMonixBIOTask extends MyDisabledTestF[monix.bio.Task, 
 final class MyDisabledTestFZioUIO extends MyDisabledTestF[zio.Task, zio.UIO]
 final class MyDisabledTestFZioTask extends MyDisabledTestF[zio.Task, zio.Task]
 
-class DisabledTestF2[F[+_, +_]: Applicative2] extends Lifecycle.Basic[F[Nothing, +?], TestEnableDisable] with IntegrationCheck[F[Nothing, ?]] {
+class DisabledTestF2[F[+_, +_]: Applicative2] extends Lifecycle.Basic[F[Nothing, +_], TestEnableDisable] with IntegrationCheck[F[Nothing, _]] {
   override def resourcesAvailable(): F[Nothing, ResourceCheck] =
     F.pure(ResourceCheck.ResourceUnavailable("This test is intentionally disabled.", None))
   override def acquire: F[Nothing, TestEnableDisable] = F.pure(TestEnableDisable())
@@ -88,4 +88,4 @@ abstract class MyDisabledTestF2[F[+_, +_]: DefaultModule2: TagKK](implicit F: Ap
 
 final class MyDisabledTestF2MonixBIO extends MyDisabledTestF2[monix.bio.IO]
 final class MyDisabledTestF2ZioIO extends MyDisabledTestF2[zio.IO]
-//final class MyDisabledTestF2ZIOZIOZEnv extends MyDisabledTestF2[zio.ZIO[zio.ZEnv, +?, +?]]
+//final class MyDisabledTestF2ZIOZIOZEnv extends MyDisabledTestF2[zio.ZIO[zio.ZEnv, +_, +_]]

--- a/doc/microsite/src/main/scala/microsite/FakePackageModifier.scala
+++ b/doc/microsite/src/main/scala/microsite/FakePackageModifier.scala
@@ -5,7 +5,7 @@ import mdoc.{PostModifier, PostModifierContext}
 class FakePackageModifier extends PostModifier {
   override val name = "fakepackage"
   override def process(ctx: PostModifierContext): String = {
-    val regex = "\"fakepackage (.+?)\": Unit"
+    val regex = "\"fakepackage (.+_)\": Unit"
 
     val silent = ctx.info.contains("silent")
 

--- a/doc/microsite/src/main/scala/microsite/FakePackageModifier.scala
+++ b/doc/microsite/src/main/scala/microsite/FakePackageModifier.scala
@@ -5,7 +5,7 @@ import mdoc.{PostModifier, PostModifierContext}
 class FakePackageModifier extends PostModifier {
   override val name = "fakepackage"
   override def process(ctx: PostModifierContext): String = {
-    val regex = "\"fakepackage (.+_)\": Unit"
+    val regex = "\"fakepackage (.+?)\": Unit"
 
     val silent = ctx.info.contains("silent")
 

--- a/doc/microsite/src/main/tut/distage/00_distage.md
+++ b/doc/microsite/src/main/tut/distage/00_distage.md
@@ -24,7 +24,7 @@ It shows how to write an idiomatic `distage` application from scratch and how to
 add to distage-example
 
 - how to setup graalvm native image with distage
-- how to debug dump graphs and render to graphviz [Actually, we have a GUI component now, can we show em there???]
+- how to debug dump graphs and render to graphviz [Actually, we have a GUI component now, can we show em there??_]
 */
 ```
 

--- a/doc/microsite/src/main/tut/distage/00_distage.md
+++ b/doc/microsite/src/main/tut/distage/00_distage.md
@@ -24,7 +24,7 @@ It shows how to write an idiomatic `distage` application from scratch and how to
 add to distage-example
 
 - how to setup graalvm native image with distage
-- how to debug dump graphs and render to graphviz [Actually, we have a GUI component now, can we show em there??_]
+- how to debug dump graphs and render to graphviz [Actually, we have a GUI component now, can we show em there???]
 */
 ```
 

--- a/doc/microsite/src/main/tut/distage/basics.md
+++ b/doc/microsite/src/main/tut/distage/basics.md
@@ -6,7 +6,7 @@
 
 ```scala mdoc:reset:invisible:to-string
 // ##### New overview
-// (sentence-two per concept + link to details [or inline expand? or these should just be chapters_])
+// (sentence-two per concept + link to details [or inline expand? or these should just be chapters?])
 //
 // ###### Concepts
 // ####### ModuleDef
@@ -230,7 +230,7 @@ It shows how to write an idiomatic `distage`-style from scratch and how to:
 add to distage-example
 
 - how to setup graalvm native image with distage
-- how to debug dump graphs and render to graphviz [Actually, we have a GUI component now, can we show em there??_]
+- how to debug dump graphs and render to graphviz [Actually, we have a GUI component now, can we show em there???]
 */
 ```
 

--- a/doc/microsite/src/main/tut/distage/basics.md
+++ b/doc/microsite/src/main/tut/distage/basics.md
@@ -126,7 +126,7 @@ actionable series of steps - an @scaladoc[OrderedPlan](izumi.distage.model.plan.
 ```scala mdoc:to-string
 import distage.{Activation, Injector, Roots}
 
-val injector = Injector[RIO[Console, *]]()
+val injector = Injector[RIO[Console, _]]()
 
 val plan = injector.plan(HelloByeModule, Activation.empty, Roots.target[HelloByeApp])
 ```

--- a/doc/microsite/src/main/tut/distage/basics.md
+++ b/doc/microsite/src/main/tut/distage/basics.md
@@ -6,7 +6,7 @@
 
 ```scala mdoc:reset:invisible:to-string
 // ##### New overview
-// (sentence-two per concept + link to details [or inline expand? or these should just be chapters?])
+// (sentence-two per concept + link to details [or inline expand? or these should just be chapters_])
 //
 // ###### Concepts
 // ####### ModuleDef
@@ -230,7 +230,7 @@ It shows how to write an idiomatic `distage`-style from scratch and how to:
 add to distage-example
 
 - how to setup graalvm native image with distage
-- how to debug dump graphs and render to graphviz [Actually, we have a GUI component now, can we show em there???]
+- how to debug dump graphs and render to graphviz [Actually, we have a GUI component now, can we show em there??_]
 */
 ```
 
@@ -612,9 +612,9 @@ val catsEffectHello = polymorphicHelloWorld[cats.effect.IO]
 
 val monixHello = polymorphicHelloWorld[monix.eval.Task]
 
-val zioHello = polymorphicHelloWorld[zio.IO[Throwable, ?]]
+val zioHello = polymorphicHelloWorld[zio.IO[Throwable, _]]
 
-val monixBioHello = polymorphicHelloWorld[monix.bio.IO[Throwable, ?]]
+val monixBioHello = polymorphicHelloWorld[monix.bio.IO[Throwable, _]]
 ```
 
 See @scaladoc[`DefaultModule`](izumi.distage.modules.DefaultModule) implicit for implementation details. For details on
@@ -1421,24 +1421,24 @@ import zio.RIO
 import zio.console.{Console, getStrLn, putStrLn}
 import distage.Activation
 
-object RealInteractionZIO extends Interaction[RIO[Console, ?]] {
+object RealInteractionZIO extends Interaction[RIO[Console, _]] {
   def tell(s: String): RIO[Console, Unit]  = putStrLn(s)
   def ask(s: String): RIO[Console, String] = putStrLn(s) *> getStrLn
 }
 
 def RealInterpretersZIO = {
-  SyncInterpreters[RIO[Console, ?]] overriddenBy new ModuleDef {
-    make[Interaction[RIO[Console, ?]]].from(RealInteractionZIO)
+  SyncInterpreters[RIO[Console, _]] overriddenBy new ModuleDef {
+    make[Interaction[RIO[Console, _]]].from(RealInteractionZIO)
   }
 }
 
 def chooseInterpreters(isDummy: Boolean) = {
-  val interpreters = if (isDummy) SyncInterpreters[RIO[Console, ?]]
+  val interpreters = if (isDummy) SyncInterpreters[RIO[Console, _]]
                      else         RealInterpretersZIO
-  def module = ProgramModule[RIO[Console, ?]] ++ interpreters
+  def module = ProgramModule[RIO[Console, _]] ++ interpreters
 
-  Injector[RIO[Console, ?]]()
-    .produceGet[TaglessProgram[RIO[Console, ?]]](module, Activation.empty)
+  Injector[RIO[Console, _]]()
+    .produceGet[TaglessProgram[RIO[Console, _]]](module, Activation.empty)
 }
 
 // execute

--- a/doc/microsite/src/main/tut/distage/distage-testkit.md
+++ b/doc/microsite/src/main/tut/distage/distage-testkit.md
@@ -934,11 +934,11 @@ object leaderboard {
     import repo.Ladder
     type LadderEnv = Has[Ladder[IO]]
     type RndEnv = Has[Rnd[IO]]
-    object ladder extends Ladder[ZIO[LadderEnv, ?, ?]] {
+    object ladder extends Ladder[ZIO[LadderEnv, ?, _]] {
       def submitScore(userId: UserId, score: Score): ZIO[LadderEnv, QueryFailure, Unit] = ZIO.accessM(_.get.submitScore(userId, score))
       def getScores: ZIO[LadderEnv, QueryFailure, List[(UserId, Score)]]                = ZIO.accessM(_.get.getScores)
     }
-    object rnd extends Rnd[ZIO[RndEnv, ?, ?]] {
+    object rnd extends Rnd[ZIO[RndEnv, ?, _]] {
       override def apply[A]: URIO[RndEnv, A] = ZIO.accessM(_.get.apply[A])
     }
   }

--- a/doc/microsite/src/main/tut/distage/distage-testkit.md
+++ b/doc/microsite/src/main/tut/distage/distage-testkit.md
@@ -934,11 +934,11 @@ object leaderboard {
     import repo.Ladder
     type LadderEnv = Has[Ladder[IO]]
     type RndEnv = Has[Rnd[IO]]
-    object ladder extends Ladder[ZIO[LadderEnv, ?, _]] {
+    object ladder extends Ladder[ZIO[LadderEnv, _, _]] {
       def submitScore(userId: UserId, score: Score): ZIO[LadderEnv, QueryFailure, Unit] = ZIO.accessM(_.get.submitScore(userId, score))
       def getScores: ZIO[LadderEnv, QueryFailure, List[(UserId, Score)]]                = ZIO.accessM(_.get.getScores)
     }
-    object rnd extends Rnd[ZIO[RndEnv, ?, _]] {
+    object rnd extends Rnd[ZIO[RndEnv, _, _]] {
       override def apply[A]: URIO[RndEnv, A] = ZIO.accessM(_.get.apply[A])
     }
   }

--- a/fundamentals/fundamentals-bio/.jvm/src/main/scala/izumi/functional/bio/BlockingIO3.scala
+++ b/fundamentals/fundamentals-bio/.jvm/src/main/scala/izumi/functional/bio/BlockingIO3.scala
@@ -62,7 +62,7 @@ object BlockingIOInstances extends LowPriorityBlockingIOInstances {
 sealed trait LowPriorityBlockingIOInstances extends LowPriorityBlockingIOInstances1 {
   type ZIOWithBlocking[-R, +E, +A] = ZIO[R with Blocking, E, A]
 
-  @inline implicit final def blockingIOZIOR[R]: BlockingIO2[ZIOWithBlocking[R, +?, +?]] = cast3To2[BlockingIO3, ZIOWithBlocking, R](blockingIOZIO3R)
+  @inline implicit final def blockingIOZIOR[R]: BlockingIO2[ZIOWithBlocking[R, +_, +_]] = cast3To2[BlockingIO3, ZIOWithBlocking, R](blockingIOZIO3R)
 
   implicit final val blockingIOZIO3R: BlockingIO3[ZIOWithBlocking] = new BlockingIO3[ZIOWithBlocking] {
     override def shiftBlocking[R, E, A](f: ZIO[R with Blocking, E, A]): ZIO[R with Blocking, E, A] = zio.blocking.blocking(f)
@@ -72,5 +72,5 @@ sealed trait LowPriorityBlockingIOInstances extends LowPriorityBlockingIOInstanc
 }
 
 sealed trait LowPriorityBlockingIOInstances1 {
-  @inline implicit final def blockingIO3To2[FR[-_, +_, +_], R](implicit BlockingIO3: BlockingIO3[FR]): BlockingIO2[FR[R, +?, +?]] = cast3To2(BlockingIO3)
+  @inline implicit final def blockingIO3To2[FR[-_, +_, +_], R](implicit BlockingIO3: BlockingIO3[FR]): BlockingIO2[FR[R, +_, +_]] = cast3To2(BlockingIO3)
 }

--- a/fundamentals/fundamentals-bio/.jvm/src/test/scala/izumi/functional/bio/laws/MiniBIOLawsTest.scala
+++ b/fundamentals/fundamentals-bio/.jvm/src/test/scala/izumi/functional/bio/laws/MiniBIOLawsTest.scala
@@ -8,9 +8,9 @@ import izumi.functional.bio.impl.MiniBIO
 import izumi.functional.bio.laws.env.MiniBIOEnv
 
 class MiniBIOLawsTest extends CatsLawsTestBase with MiniBIOEnv {
-  val syncTests: SyncTests[MiniBIO[Throwable, ?]] = new SyncTests[MiniBIO[Throwable, ?]] {
-    override val laws = new SyncLaws[MiniBIO[Throwable, ?]] {
-      override val F = Sync[MiniBIO[Throwable, ?]]
+  val syncTests: SyncTests[MiniBIO[Throwable, _]] = new SyncTests[MiniBIO[Throwable, _]] {
+    override val laws = new SyncLaws[MiniBIO[Throwable, _]] {
+      override val F = Sync[MiniBIO[Throwable, _]]
     }
   }
 

--- a/fundamentals/fundamentals-bio/.jvm/src/test/scala/izumi/functional/bio/test/BlockingIOSyntaxTest.scala
+++ b/fundamentals/fundamentals-bio/.jvm/src/test/scala/izumi/functional/bio/test/BlockingIOSyntaxTest.scala
@@ -18,7 +18,7 @@ class BlockingIOSyntaxTest extends AnyWordSpec {
       implicit val blocking: Blocking = Has(Blocking.Service.live)
       `attach BlockingIO methods to a trifunctor BIO`[ZIO]
       `attach BlockingIO methods to a bifunctor BIO`[zio.IO]
-      `attach BlockingIO methods to a bifunctor BIO`[BlockingIOInstances.ZIOWithBlocking[Any, +?, +?]]
+      `attach BlockingIO methods to a bifunctor BIO`[BlockingIOInstances.ZIOWithBlocking[Any, +_, +_]]
     }
   }
 
@@ -30,7 +30,7 @@ class BlockingIOSyntaxTest extends AnyWordSpec {
       def hello = BlockingIO3[F].syncBlocking(println("hello world!"))
     }
 
-    assert(new X[zio.ZIO[Blocking, +?, +?]].hello != null)
+    assert(new X[zio.ZIO[Blocking, +_, +_]].hello != null)
     locally {
       implicit val blocking: Blocking = Has(Blocking.Service.live)
       assert(new X[zio.IO].hello != null)

--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/CatsConversions.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/CatsConversions.scala
@@ -18,12 +18,12 @@ import izumi.fundamentals.platform.language.unused
   *   import cats.effect.Sync
   *
   *   def divideByZero[F[+_, +_]: IO2]: F[Throwable, Int] = {
-  *     Sync[F[Throwable, ?]].delay(10 / 0)
+  *     Sync[F[Throwable, _]].delay(10 / 0)
   *   }
   * }}}
   */
 trait CatsConversions extends CatsConversions1 {
-  @inline implicit final def BIOToFunctor[F[+_, +_], E](implicit F0: Functor2[F]): cats.Functor[F[E, ?]] with S1 = new BIOCatsFunctor[F, E] {
+  @inline implicit final def BIOToFunctor[F[+_, +_], E](implicit F0: Functor2[F]): cats.Functor[F[E, _]] with S1 = new BIOCatsFunctor[F, E] {
     override val F: Functor2[F] = F0
   }
 }
@@ -33,34 +33,34 @@ trait CatsConversions1 extends CatsConversions2 {
   }
 }
 trait CatsConversions2 extends CatsConversions3 {
-  @inline implicit final def BIOToApplicative[F[+_, +_], E](implicit F0: Applicative2[F]): cats.Applicative[F[E, ?]] with S3 = new BIOCatsApplicative[F, E] {
+  @inline implicit final def BIOToApplicative[F[+_, +_], E](implicit F0: Applicative2[F]): cats.Applicative[F[E, _]] with S3 = new BIOCatsApplicative[F, E] {
     override val F: Applicative2[F] = F0
   }
 }
 trait CatsConversions3 extends CatsConversions4 {
-  @inline implicit final def BIOToMonad[F[+_, +_], E](implicit F: Monad2[F]): cats.Monad[F[E, ?]] with S5 = new BIOCatsMonad[F, E](F)
+  @inline implicit final def BIOToMonad[F[+_, +_], E](implicit F: Monad2[F]): cats.Monad[F[E, _]] with S5 = new BIOCatsMonad[F, E](F)
 }
 trait CatsConversions4 extends CatsConversions5 {
-  @inline implicit final def BIOToMonadError[F[+_, +_], E](implicit F: Error2[F]): cats.MonadError[F[E, ?], E] with S6 = new BIOCatsMonadError[F, E](F)
+  @inline implicit final def BIOToMonadError[F[+_, +_], E](implicit F: Error2[F]): cats.MonadError[F[E, _], E] with S6 = new BIOCatsMonadError[F, E](F)
 }
 trait CatsConversions5 extends CatsConversions6 {
-  @inline implicit final def BIOToBracket[F[+_, +_]](implicit F: Panic2[F]): cats.effect.Bracket[F[Throwable, ?], Throwable] with S7 = new BIOCatsBracket[F](F)
+  @inline implicit final def BIOToBracket[F[+_, +_]](implicit F: Panic2[F]): cats.effect.Bracket[F[Throwable, _], Throwable] with S7 = new BIOCatsBracket[F](F)
 }
 trait CatsConversions6 extends CatsConversions7 {
-  @inline implicit final def BIOToSync[F[+_, +_]](implicit F: IO2[F]): cats.effect.Sync[F[Throwable, ?]] with S8 = new BIOCatsSync[F](F)
+  @inline implicit final def BIOToSync[F[+_, +_]](implicit F: IO2[F]): cats.effect.Sync[F[Throwable, _]] with S8 = new BIOCatsSync[F](F)
 }
 trait CatsConversions7 extends CatsConversions8 {
-  @inline implicit final def BIOAsyncToAsync[F[+_, +_]](implicit F: Async2[F]): cats.effect.Async[F[Throwable, ?]] with S9 = new BIOCatsAsync[F](F)
+  @inline implicit final def BIOAsyncToAsync[F[+_, +_]](implicit F: Async2[F]): cats.effect.Async[F[Throwable, _]] with S9 = new BIOCatsAsync[F](F)
 }
 trait CatsConversions8 extends CatsConversions9 {
-  @inline implicit final def BIOParallelToParallel[F[+_, +_]](implicit F: Parallel2[F]): cats.Parallel[F[Throwable, ?]] = new BIOCatsParallel[F](F)
+  @inline implicit final def BIOParallelToParallel[F[+_, +_]](implicit F: Parallel2[F]): cats.Parallel[F[Throwable, _]] = new BIOCatsParallel[F](F)
 }
 trait CatsConversions9 extends CatsConversions10 {
   @inline implicit final def BIOAsyncForkToConcurrent[F[+_, +_]](
     implicit @unused ev: Functor2[F],
     F: Async2[F],
     Fork: Fork2[F],
-  ): cats.effect.Concurrent[F[Throwable, ?]] with S10 = new BIOCatsConcurrent[F](F, Fork)
+  ): cats.effect.Concurrent[F[Throwable, _]] with S10 = new BIOCatsConcurrent[F](F, Fork)
 }
 trait CatsConversions10 {
   @inline implicit final def BIOAsyncForkUnsafeRunToConcurrentEffect[F[+_, +_]](
@@ -68,12 +68,12 @@ trait CatsConversions10 {
     F: Async2[F],
     Fork: Fork2[F],
     UnsafeRun: UnsafeRun2[F],
-  ): cats.effect.ConcurrentEffect[F[Throwable, ?]] with S11 = new BIOCatsConcurrentEffect[F](F, Fork, UnsafeRun)
+  ): cats.effect.ConcurrentEffect[F[Throwable, _]] with S11 = new BIOCatsConcurrentEffect[F](F, Fork, UnsafeRun)
 }
 
 object CatsConversions {
 
-  trait BIOCatsFunctor[F[+_, +_], E] extends cats.Functor[F[E, ?]] with S1 with S2 with S3 with S4 with S5 with S6 with S7 with S8 with S9 with S10 with S11 {
+  trait BIOCatsFunctor[F[+_, +_], E] extends cats.Functor[F[E, _]] with S1 with S2 with S3 with S4 with S5 with S6 with S7 with S8 with S9 with S10 with S11 {
     def F: Functor2[F]
 
     @inline override final def map[A, B](fa: F[E, A])(f: A => B): F[E, B] = F.map(fa)(f)
@@ -88,7 +88,7 @@ object CatsConversions {
     @inline override final def leftMap[A, B, C](fab: F[A, B])(f: A => C): F[C, B] = F.leftMap(fab)(f)
   }
 
-  trait BIOCatsApplicative[F[+_, +_], E] extends cats.Applicative[F[E, ?]] with BIOCatsFunctor[F, E] {
+  trait BIOCatsApplicative[F[+_, +_], E] extends cats.Applicative[F[E, _]] with BIOCatsFunctor[F, E] {
     override def F: Applicative2[F]
 
     @inline override final def ap[A, B](ff: F[E, A => B])(fa: F[E, A]): F[E, B] = F.map2(ff, fa)(_.apply(_))
@@ -102,13 +102,13 @@ object CatsConversions {
     @inline override final def productL[A, B](fa: F[E, A])(fb: F[E, B]): F[E, A] = F.<*(fa, fb)
   }
 
-  class BIOCatsMonad[F[+_, +_], E](override val F: Monad2[F]) extends cats.Monad[F[E, ?]] with BIOCatsApplicative[F, E] {
+  class BIOCatsMonad[F[+_, +_], E](override val F: Monad2[F]) extends cats.Monad[F[E, _]] with BIOCatsApplicative[F, E] {
     @inline override final def flatMap[A, B](fa: F[E, A])(f: A => F[E, B]): F[E, B] = F.flatMap(fa)(f)
     @inline override final def flatten[A](ffa: F[E, F[E, A]]): F[E, A] = F.flatten(ffa)
     @inline override final def tailRecM[A, B](a: A)(f: A => F[E, Either[A, B]]): F[E, B] = F.tailRecM(a)(f)
   }
 
-  class BIOCatsMonadError[F[+_, +_], E](override val F: Error2[F]) extends BIOCatsMonad[F, E](F) with cats.MonadError[F[E, ?], E] {
+  class BIOCatsMonadError[F[+_, +_], E](override val F: Error2[F]) extends BIOCatsMonad[F, E](F) with cats.MonadError[F[E, _], E] {
     @inline override final def raiseError[A](e: E): F[E, A] = F.fail(e)
     @inline override final def handleErrorWith[A](fa: F[E, A])(f: E => F[E, A]): F[E, A] = F.catchAll(fa)(f)
     @inline override final def recoverWith[A](fa: F[E, A])(pf: PartialFunction[E, F[E, A]]): F[E, A] = F.catchSome(fa)(pf)
@@ -117,7 +117,7 @@ object CatsConversions {
     @inline override final def fromEither[A](x: Either[E, A]): F[E, A] = F.fromEither(x)
   }
 
-  class BIOCatsBracket[F[+_, +_]](override val F: Panic2[F]) extends BIOCatsMonadError[F, Throwable](F) with cats.effect.Bracket[F[Throwable, ?], Throwable] {
+  class BIOCatsBracket[F[+_, +_]](override val F: Panic2[F]) extends BIOCatsMonadError[F, Throwable](F) with cats.effect.Bracket[F[Throwable, _], Throwable] {
     @inline override final def bracketCase[A, B](
       acquire: F[Throwable, A]
     )(use: A => F[Throwable, B]
@@ -143,12 +143,12 @@ object CatsConversions {
     }
   }
 
-  class BIOCatsSync[F[+_, +_]](override val F: IO2[F]) extends BIOCatsBracket[F](F) with cats.effect.Sync[F[Throwable, ?]] {
+  class BIOCatsSync[F[+_, +_]](override val F: IO2[F]) extends BIOCatsBracket[F](F) with cats.effect.Sync[F[Throwable, _]] {
     @inline override final def suspend[A](thunk: => F[Throwable, A]): F[Throwable, A] = F.flatten(F.syncThrowable(thunk))
     @inline override final def delay[A](thunk: => A): F[Throwable, A] = F.syncThrowable(thunk)
   }
 
-  class BIOCatsParallel[F0[+_, +_]](private val F0: Parallel2[F0]) extends cats.Parallel[F0[Throwable, ?]] {
+  class BIOCatsParallel[F0[+_, +_]](private val F0: Parallel2[F0]) extends cats.Parallel[F0[Throwable, _]] {
     type M[A] = F0[Throwable, A]
     override type F[A] = M[A]
 
@@ -167,7 +167,7 @@ object CatsConversions {
     override lazy val monad: cats.Monad[M] = new BIOCatsMonad(F0.InnerF)
   }
 
-  class BIOCatsAsync[F[+_, +_]](override val F: Async2[F]) extends BIOCatsSync[F](F) with cats.effect.Async[F[Throwable, ?]] {
+  class BIOCatsAsync[F[+_, +_]](override val F: Async2[F]) extends BIOCatsSync[F](F) with cats.effect.Async[F[Throwable, _]] {
     @inline override final def async[A](k: (Either[Throwable, A] => Unit) => Unit): F[Throwable, A] = F.async(k)
     @inline override final def asyncF[A](k: (Either[Throwable, A] => Unit) => F[Throwable, Unit]): F[Throwable, A] = F.asyncF(k)
     @inline override def liftIO[A](ioa: cats.effect.IO[A]): F[Throwable, A] =
@@ -175,7 +175,7 @@ object CatsConversions {
     @inline override final def never[A]: F[Throwable, A] = F.never
   }
 
-  class BIOCatsConcurrent[F[+_, +_]](override val F: Async2[F], val Fork: Fork2[F]) extends BIOCatsAsync[F](F) with cats.effect.Concurrent[F[Throwable, ?]] {
+  class BIOCatsConcurrent[F[+_, +_]](override val F: Async2[F], val Fork: Fork2[F]) extends BIOCatsAsync[F](F) with cats.effect.Concurrent[F[Throwable, _]] {
     @inline override final def start[A](fa: F[Throwable, A]): F[Throwable, Fiber[F[Throwable, *], A]] = {
       F.map(Fork.fork(fa))(_.toCats(F))
     }
@@ -200,7 +200,7 @@ object CatsConversions {
 
   class BIOCatsConcurrentEffect[F[+_, +_]](override val F: Async2[F], override val Fork: Fork2[F], val UnsafeRun: UnsafeRun2[F])
     extends BIOCatsConcurrent[F](F, Fork)
-    with cats.effect.ConcurrentEffect[F[Throwable, ?]] {
+    with cats.effect.ConcurrentEffect[F[Throwable, _]] {
     override final def runCancelable[A](fa: F[Throwable, A])(cb: Either[Throwable, A] => IO[Unit]): SyncIO[F[Throwable, Unit]] = {
       SyncIO[F[Throwable, Unit]] {
         UnsafeRun.unsafeRunAsyncInterruptible(fa)(exit => cb(exit.toThrowableEither).unsafeRunAsync(_ => ())).interrupt

--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/CatsConversions.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/CatsConversions.scala
@@ -176,13 +176,13 @@ object CatsConversions {
   }
 
   class BIOCatsConcurrent[F[+_, +_]](override val F: Async2[F], val Fork: Fork2[F]) extends BIOCatsAsync[F](F) with cats.effect.Concurrent[F[Throwable, _]] {
-    @inline override final def start[A](fa: F[Throwable, A]): F[Throwable, Fiber[F[Throwable, *], A]] = {
+    @inline override final def start[A](fa: F[Throwable, A]): F[Throwable, Fiber[F[Throwable, _], A]] = {
       F.map(Fork.fork(fa))(_.toCats(F))
     }
     @inline override final def racePair[A, B](
       fa: F[Throwable, A],
       fb: F[Throwable, B],
-    ): F[Throwable, Either[(A, Fiber[F[Throwable, *], B]), (Fiber[F[Throwable, *], A], B)]] = {
+    ): F[Throwable, Either[(A, Fiber[F[Throwable, _], B]), (Fiber[F[Throwable, _], A], B)]] = {
       F.map(F.racePair(fa, fb)) {
         case Left((a, f)) => Left((a, f.toCats(F)))
         case Right((f, b)) => Right((f.toCats(F), b))
@@ -191,7 +191,7 @@ object CatsConversions {
     @inline override final def race[A, B](fa: F[Throwable, A], fb: F[Throwable, B]): F[Throwable, Either[A, B]] = {
       F.race(F.map(fa)(Left(_)), F.map(fb)(Right(_)))
     }
-    @inline override final def cancelable[A](k: (Either[Throwable, A] => Unit) => CancelToken[F[Throwable, *]]): F[Throwable, A] = {
+    @inline override final def cancelable[A](k: (Either[Throwable, A] => Unit) => CancelToken[F[Throwable, _]]): F[Throwable, A] = {
       F.asyncCancelable(F orTerminate k(_))
     }
     @inline override final def liftIO[A](ioa: cats.effect.IO[A]): F[Throwable, A] = Concurrent.liftIO(ioa)(this)

--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/Fiber2.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/Fiber2.scala
@@ -26,7 +26,7 @@ object Fiber2 {
     }
 
   implicit final class ToCats[FR[+_, +_], A](private val bioFiber: Fiber2[FR, Throwable, A]) extends AnyVal {
-    def toCats(implicit F: Functor2[FR]): cats.effect.Fiber[FR[Throwable, ?], A] = new cats.effect.Fiber[FR[Throwable, ?], A] {
+    def toCats(implicit F: Functor2[FR]): cats.effect.Fiber[FR[Throwable, _], A] = new cats.effect.Fiber[FR[Throwable, _], A] {
       override def cancel: FR[Throwable, Unit] = F.void(bioFiber.interrupt)
       override def join: FR[Throwable, A] = bioFiber.join
     }

--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/Local3.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/Local3.scala
@@ -22,6 +22,6 @@ trait Local3[FR[-_, +_, +_]] extends MonadAsk3[FR] with ArrowChoice3[FR] with Lo
 private[bio] sealed trait LocalInstances
 object LocalInstances {
   implicit final class ToKleisliSyntaxLocal[FR[-_, +_, +_]](private val FR: Local3[FR]) extends AnyVal {
-    @inline final def toKleisli[R, E, A](fr: FR[R, E, A]): Kleisli[FR[Any, E, ?], R, A] = Kleisli(FR.provide(fr)(_))
+    @inline final def toKleisli[R, E, A](fr: FR[R, E, A]): Kleisli[FR[Any, E, _], R, A] = Kleisli(FR.provide(fr)(_))
   }
 }

--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/MonadAsk3.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/MonadAsk3.scala
@@ -11,6 +11,6 @@ trait MonadAsk3[FR[-_, +_, +_]] extends Ask3[FR] with MonadAskSyntax {
 private[bio] sealed trait MonadAskSyntax
 object MonadAskSyntax {
   implicit final class KleisliSyntaxMonadAsk[FR[-_, +_, +_]](private val FR: MonadAsk3[FR]) extends AnyVal {
-    @inline def fromKleisli[R, E, A](k: Kleisli[FR[Any, E, ?], R, A]): FR[R, E, A] = FR.access(k.run)
+    @inline def fromKleisli[R, E, A](k: Kleisli[FR[Any, E, _], R, A]): FR[R, E, A] = FR.access(k.run)
   }
 }

--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/Panic3.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/Panic3.scala
@@ -12,8 +12,8 @@ trait Panic3[F[-_, +_, +_]] extends Bracket3[F] with PanicSyntax {
 private[bio] sealed trait PanicSyntax
 object PanicSyntax {
   implicit final class PanicOrTerminateK[F[-_, +_, +_]](private val F: Panic3[F]) extends AnyVal {
-    def orTerminateK[R]: F[R, Throwable, ?] ~> F[R, Nothing, ?] = {
-      Lambda[F[R, Throwable, ?] ~> F[R, Nothing, ?]](f => F.orTerminate(f))
+    def orTerminateK[R]: F[R, Throwable, _] ~> F[R, Nothing, _] = {
+      Lambda[F[R, Throwable, _] ~> F[R, Nothing, _]](f => F.orTerminate(f))
     }
   }
 }

--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/Promise2.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/Promise2.scala
@@ -25,7 +25,7 @@ object Promise2 {
     }
   }
 
-  def fromCats[F[+_, +_]: Panic2, E, A](deferred: TryableDeferred[F[Throwable, ?], F[E, A]]): Promise2[F, E, A] = {
+  def fromCats[F[+_, +_]: Panic2, E, A](deferred: TryableDeferred[F[Throwable, _], F[E, A]]): Promise2[F, E, A] = {
     new Promise2[F, E, A] {
       override def await: F[E, A] = deferred.get.orTerminate.flatten
       override def poll: F[Nothing, Option[F[E, A]]] = deferred.tryGet.orTerminate

--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/Ref1.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/Ref1.scala
@@ -23,7 +23,7 @@ object Ref1 {
       override def update_(f: A => A): IO[Nothing, Unit] = ref.update(f)
     }
 
-  def fromCats[F[+_, +_]: Panic2, A](ref: cats.effect.concurrent.Ref[F[Throwable, ?], A]): Ref2[F, A] =
+  def fromCats[F[+_, +_]: Panic2, A](ref: cats.effect.concurrent.Ref[F[Throwable, _], A]): Ref2[F, A] =
     new Ref2[F, A] {
       override def get: F[Nothing, A] = ref.get.orTerminate
       override def set(a: A): F[Nothing, Unit] = ref.set(a).orTerminate

--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/Root.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/Root.scala
@@ -28,8 +28,8 @@ object Root extends RootInstancesLowPriority1 {
   @inline implicit final def AttachBlockingIO3[FR[-_, +_, +_]](@unused self: Functor3[FR])(implicit BlockingIO: BlockingIO3[FR]): BlockingIO.type = BlockingIO
 
   implicit final class KleisliSyntaxAttached[FR[-_, +_, +_]](private val FR0: Functor3[FR]) extends AnyVal {
-    @inline def fromKleisli[R, E, A](k: Kleisli[FR[Any, E, ?], R, A])(implicit FR: MonadAsk3[FR]): FR[R, E, A] = FR.fromKleisli(k)
-    @inline def toKleisli[R, E, A](fr: FR[R, E, A])(implicit FR: Local3[FR]): Kleisli[FR[Any, E, ?], R, A] = {
+    @inline def fromKleisli[R, E, A](k: Kleisli[FR[Any, E, _], R, A])(implicit FR: MonadAsk3[FR]): FR[R, E, A] = FR.fromKleisli(k)
+    @inline def toKleisli[R, E, A](fr: FR[R, E, A])(implicit FR: Local3[FR]): Kleisli[FR[Any, E, _], R, A] = {
       val _ = FR0
       FR.toKleisli(fr)
     }

--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/Semaphore1.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/Semaphore1.scala
@@ -14,7 +14,7 @@ trait Semaphore1[+F[_]] {
 }
 
 object Semaphore1 {
-  def fromCats[F[+_, +_]: Panic2](semaphore: Semaphore[F[Throwable, ?]]): Semaphore2[F] = new Semaphore2[F] {
+  def fromCats[F[+_, +_]: Panic2](semaphore: Semaphore[F[Throwable, _]]): Semaphore2[F] = new Semaphore2[F] {
     override def acquire: F[Nothing, Unit] = semaphore.acquire.orTerminate
     override def release: F[Nothing, Unit] = semaphore.release.orTerminate
 

--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/Temporal3.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/Temporal3.scala
@@ -44,6 +44,6 @@ object TemporalInstances extends TemporalInstancesLowPriority1 {
 sealed trait TemporalInstancesLowPriority1 {
   @inline implicit final def TemporalMonix[MonixBIO[+_, +_]: `monix.bio.IO`, Timer[_[_]]: `cats.effect.Timer`](
     implicit
-    timer: Timer[MonixBIO[Nothing, ?]]
+    timer: Timer[MonixBIO[Nothing, _]]
   ): Predefined.Of[Temporal2[MonixBIO]] = new TemporalMonix(timer.asInstanceOf[cats.effect.Timer[monix.bio.UIO]]).asInstanceOf[Predefined.Of[Temporal2[MonixBIO]]]
 }

--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/catz.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/catz.scala
@@ -9,7 +9,7 @@ package izumi.functional.bio
   *   import cats.effect.Sync
   *
   *   def divideByZero[F[+_, +_]: IO2]: F[Throwable, Int] = {
-  *     Sync[F[Throwable, ?]].delay(10 / 0)
+  *     Sync[F[Throwable, _]].delay(10 / 0)
   *   }
   * }}}
   */

--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/data/Free.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/data/Free.scala
@@ -12,7 +12,7 @@ sealed abstract class Free[+S[_, _], +E, +A] {
   @inline final def void: Free[S, E, Unit] = map(_ => ())
 
   @inline final def mapK[S1[e, a] >: S[e, a], T[_, _]](f: S1 ~>> T): Free[T, E, A] = {
-    foldMap[S1, Free[T, +?, +?]](Morphism2(Free Suspend f(_)))
+    foldMap[S1, Free[T, +_, +_]](Morphism2(Free Suspend f(_)))
   }
 
   @inline def foldMap[S1[e, a] >: S[e, a], G[+_, +_]](transform: S1 ~>> G)(implicit G: Monad2[G]): G[E, A] = {
@@ -42,10 +42,10 @@ object Free {
     override def toString: String = s"FlatMapped:[sub=$sub]"
   }
 
-  @inline implicit def FreeMonadInstances[S[_, _]]: Monad2[Free[S, +?, +?]] = new Monad2Instance[S]
+  @inline implicit def FreeMonadInstances[S[_, _]]: Monad2[Free[S, +_, +_]] = new Monad2Instance[S]
 
   object Monad2Instance extends Monad2Instance[Any]
-  class Monad2Instance[S[_, _]] extends Monad2[Free[S, +?, +?]] {
+  class Monad2Instance[S[_, _]] extends Monad2[Free[S, +_, +_]] {
     @inline override def flatMap[R, E, A, B](r: Free[S, E, A])(f: A => Free[S, E, B]): Free[S, E, B] = r.flatMap(f)
     @inline override def pure[A](a: A): Free[S, Nothing, A] = Free.pure(a)
     @inline override def *>[R, E, A, B](f: Free[S, E, A], next: => Free[S, E, B]): Free[S, E, B] = f *> next

--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/data/FreeError.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/data/FreeError.scala
@@ -29,7 +29,7 @@ sealed abstract class FreeError[+S[_, _], +E, +A] {
   @inline final def void: FreeError[S, E, Unit] = map(_ => ())
 
   @inline final def mapK[S1[e, a] >: S[e, a], T[_, _]](f: S1 ~>> T): FreeError[T, E, A] = {
-    foldMap[S1, FreeError[T, +?, +?]](Morphism2(FreeError lift f(_)))
+    foldMap[S1, FreeError[T, +_, +_]](Morphism2(FreeError lift f(_)))
   }
 
   @inline final def foldMap[S1[e, a] >: S[e, a], G[+_, +_]](transform: S1 ~>> G)(implicit G: Error2[G]): G[E, A] = {
@@ -74,10 +74,10 @@ object FreeError {
     override def toString: String = s"Redeem:[sub=$sub]"
   }
 
-  @inline implicit def FreeErrorInstances[S[_, _]]: Error2[FreeError[S, +?, +?]] = Error2Instance.asInstanceOf[Error2Instance[S]]
+  @inline implicit def FreeErrorInstances[S[_, _]]: Error2[FreeError[S, +_, +_]] = Error2Instance.asInstanceOf[Error2Instance[S]]
 
   object Error2Instance extends Error2Instance[Any]
-  class Error2Instance[S[_, _]] extends Error2[FreeError[S, +?, +?]] {
+  class Error2Instance[S[_, _]] extends Error2[FreeError[S, +_, +_]] {
     @inline override def flatMap[R, E, A, B](r: FreeError[S, E, A])(f: A => FreeError[S, E, B]): FreeError[S, E, B] = r.flatMap(f)
     @inline override def *>[R, E, A, B](f: FreeError[S, E, A], next: => FreeError[S, E, B]): FreeError[S, E, B] = f *> next
     @inline override def <*[R, E, A, B](f: FreeError[S, E, A], next: => FreeError[S, E, B]): FreeError[S, E, A] = f <* next

--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/data/FreePanic.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/data/FreePanic.scala
@@ -38,7 +38,7 @@ sealed abstract class FreePanic[+S[_, _], +E, +A] {
   @inline final def void: FreePanic[S, E, Unit] = map(_ => ())
 
   @inline final def mapK[S1[e, a] >: S[e, a], T[_, _]](f: S1 ~>> T): FreePanic[T, E, A] = {
-    foldMap[S1, FreePanic[T, +?, +?]](Morphism2(FreePanic lift f(_)))
+    foldMap[S1, FreePanic[T, +_, +_]](Morphism2(FreePanic lift f(_)))
   }
 
   @inline final def foldMap[S1[e, a] >: S[e, a], G[+_, +_]](transform: S1 ~>> G)(implicit G: Panic2[G]): G[E, A] = {
@@ -54,7 +54,7 @@ sealed abstract class FreePanic[+S[_, _], +E, +A] {
             suc(_).foldMap(transform),
           )
       case s: FreePanic.Sandbox[S, E, A] =>
-        @inline def foldMapSandbox[e, a](s: FreePanic[S, e, a] with FreePanic.Sandbox[S, _, _]): G[e, a] = {
+        @inline def foldMapSandbox[e, a](s: FreePanic[S, e, a] with FreePanic.Sandbox[S, e, a]): G[e, a] = {
           s match {
             case FreePanic.Sandbox(sub) => sub.foldMap(transform).sandbox
           }
@@ -115,10 +115,10 @@ object FreePanic {
     override def toString: String = s"BracketCase:[acquire=$acquire;use=${use.getClass.getSimpleName}]"
   }
 
-  @inline implicit def FreePanicInstances[S[_, _]]: Panic2[FreePanic[S, +?, +?]] = Panic2Instance.asInstanceOf[Panic2Instance[S]]
+  @inline implicit def FreePanicInstances[S[_, _]]: Panic2[FreePanic[S, +_, +_]] = Panic2Instance.asInstanceOf[Panic2Instance[S]]
 
   object Panic2Instance extends Panic2Instance[Any]
-  class Panic2Instance[S[_, _]] extends Panic2[FreePanic[S, +?, +?]] {
+  class Panic2Instance[S[_, _]] extends Panic2[FreePanic[S, +_, +_]] {
     @inline override def flatMap[R, E, A, B](r: FreePanic[S, E, A])(f: A => FreePanic[S, E, B]): FreePanic[S, E, B] = r.flatMap(f)
     @inline override def *>[R, E, A, B](f: FreePanic[S, E, A], next: => FreePanic[S, E, B]): FreePanic[S, E, B] = f *> next
     @inline override def <*[R, E, A, B](f: FreePanic[S, E, A], next: => FreePanic[S, E, B]): FreePanic[S, E, A] = f <* next

--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/data/Morphism1.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/data/Morphism1.scala
@@ -46,14 +46,14 @@ object Morphism1 {
       Morphism1(functionKKInstance.apply)
   }
 
-  implicit def conversion2To1[F[_, _], G[_, _], E](f: Morphism2[F, G]): Morphism1[F[E, ?], G[E, ?]] = f.asInstanceOf[Morphism1[F[E, ?], G[E, ?]]]
-  implicit def Convert2To1[F[_, _], G[_, _], E](implicit f: Morphism2[F, G]): Morphism1[F[E, ?], G[E, ?]] = f.asInstanceOf[Morphism1[F[E, ?], G[E, ?]]]
+  implicit def conversion2To1[F[_, _], G[_, _], E](f: Morphism2[F, G]): Morphism1[F[E, _], G[E, _]] = f.asInstanceOf[Morphism1[F[E, _], G[E, _]]]
+  implicit def Convert2To1[F[_, _], G[_, _], E](implicit f: Morphism2[F, G]): Morphism1[F[E, _], G[E, _]] = f.asInstanceOf[Morphism1[F[E, _], G[E, _]]]
 
   // workaround for inference issues with `E=Nothing`
-  implicit def conversion2To1Nothing[F[_, _], G[_, _]](f: Morphism2[F, G]): Morphism1[F[Nothing, ?], G[Nothing, ?]] =
-    f.asInstanceOf[Morphism1[F[Nothing, ?], G[Nothing, ?]]]
-  implicit def Convert2To1Nothing[F[_, _], G[_, _]](implicit f: Morphism2[F, G]): Morphism1[F[Nothing, ?], G[Nothing, ?]] =
-    f.asInstanceOf[Morphism1[F[Nothing, ?], G[Nothing, ?]]]
+  implicit def conversion2To1Nothing[F[_, _], G[_, _]](f: Morphism2[F, G]): Morphism1[F[Nothing, _], G[Nothing, _]] =
+    f.asInstanceOf[Morphism1[F[Nothing, _], G[Nothing, _]]]
+  implicit def Convert2To1Nothing[F[_, _], G[_, _]](implicit f: Morphism2[F, G]): Morphism1[F[Nothing, _], G[Nothing, _]] =
+    f.asInstanceOf[Morphism1[F[Nothing, _], G[Nothing, _]]]
 
   private[Morphism1] type UnknownA
 

--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/data/Morphism2.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/data/Morphism2.scala
@@ -40,8 +40,8 @@ object Morphism2 {
       Morphism2(functionKKInstance.apply)
   }
 
-  implicit def conversion3To2[F[_, _, _], G[_, _, _], R](f: Morphism3[F, G]): Morphism2[F[R, ?, ?], G[R, ?, ?]] = f.asInstanceOf[Morphism2[F[R, ?, ?], G[R, ?, ?]]]
-  implicit def Convert3To2[F[_, _, _], G[_, _, _], R](implicit f: Morphism3[F, G]): Morphism2[F[R, ?, ?], G[R, ?, ?]] = f.asInstanceOf[Morphism2[F[R, ?, ?], G[R, ?, ?]]]
+  implicit def conversion3To2[F[_, _, _], G[_, _, _], R](f: Morphism3[F, G]): Morphism2[F[R, _, _], G[R, _, _]] = f.asInstanceOf[Morphism2[F[R, _, _], G[R, _, _]]]
+  implicit def Convert3To2[F[_, _, _], G[_, _, _], R](implicit f: Morphism3[F, G]): Morphism2[F[R, _, _], G[R, _, _]] = f.asInstanceOf[Morphism2[F[R, _, _], G[R, _, _]]]
 
   private[Morphism2] type UnknownE
   private[Morphism2] type UnknownA

--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/impl/MiniBIO.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/impl/MiniBIO.scala
@@ -80,7 +80,7 @@ sealed trait MiniBIO[+E, +A] {
             case t: Throwable =>
               Exit.Termination(t, Trace.empty)
           }
-        val catcher = stack.dropWhile(!_.isInstanceOf[Catcher[_, _, _, _]])
+        val catcher = stack.dropWhile(!_.isInstanceOf[Catcher[?, ?, ?, ?]])
         catcher match {
           case value :: stackRest =>
             runner(value.asInstanceOf[Catcher[Any, Any, Any, Any]].recover(err), stackRest)

--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/impl/PrimitivesFromBIOAndCats.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/impl/PrimitivesFromBIOAndCats.scala
@@ -5,13 +5,13 @@ import cats.effect.concurrent.{Deferred, Ref, Semaphore}
 import izumi.functional.bio.{Async2, Fork2, Primitives2, Promise2, Ref2, Semaphore2, catz}
 
 class PrimitivesFromBIOAndCats[F[+_, +_]: Async2: Fork2] extends Primitives2[F] {
-  private val Concurrent: Concurrent[F[Throwable, ?]] = catz.BIOAsyncForkToConcurrent
+  private val Concurrent: Concurrent[F[Throwable, _]] = catz.BIOAsyncForkToConcurrent
 
   override def mkRef[A](a: A): F[Nothing, Ref2[F, A]] = {
     Ref.of(a)(Concurrent).map(Ref2.fromCats[F, A]).orTerminate
   }
   override def mkPromise[E, A]: F[Nothing, Promise2[F, E, A]] = {
-    Deferred.tryable[F[Throwable, ?], F[E, A]](Concurrent).map(Promise2.fromCats[F, E, A]).orTerminate
+    Deferred.tryable[F[Throwable, _], F[E, A]](Concurrent).map(Promise2.fromCats[F, E, A]).orTerminate
   }
   override def mkSemaphore(permits: Long): F[Nothing, Semaphore2[F]] = {
     Semaphore(permits)(Concurrent).map(Semaphore2.fromCats[F]).orTerminate

--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/package.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/package.scala
@@ -144,7 +144,7 @@ package object bio extends Syntax3 with Syntax2 {
 
   type Fork2[F[+_, +_]] = Fork3[Lambda[(`-R`, `+E`, `+A`) => F[E, A]]]
 
-  type Primitives3[F[-_, +_, +_]] = Primitives2[F[Any, +?, +?]]
+  type Primitives3[F[-_, +_, +_]] = Primitives2[F[Any, +_, +_]]
   object Primitives3 {
     @inline def apply[F[-_, +_, +_]: Primitives3]: Primitives3[F] = implicitly
   }
@@ -162,12 +162,12 @@ package object bio extends Syntax3 with Syntax2 {
   type Fiber3[+F[-_, +_, +_], +E, +A] = Fiber2[F[Any, +?, +?], E, A]
   lazy val Fiber3: Fiber2.type = Fiber2
 
-  type Ref2[+F[_, _], A] = Ref1[F[Nothing, ?], A]
+  type Ref2[+F[_, _], A] = Ref1[F[Nothing, _], A]
   lazy val Ref2: Ref1.type = Ref1
-  type Ref3[+F[_, _, _], A] = Ref1[F[Any, Nothing, ?], A]
+  type Ref3[+F[_, _, _], A] = Ref1[F[Any, Nothing, _], A]
   lazy val Ref3: Ref1.type = Ref1
 
-  type Promise3[+F[-_, +_, +_], E, A] = Promise2[F[Any, +?, +?], E, A]
+  type Promise3[+F[-_, +_, +_], E, A] = Promise2[F[Any, +_, +_], E, A]
   lazy val Promise3: Promise2.type = Promise2
 
   type Latch2[+F[+_, +_]] = Promise2[F, Nothing, Unit]
@@ -175,39 +175,39 @@ package object bio extends Syntax3 with Syntax2 {
   type Latch3[+F[-_, +_, +_]] = Promise3[F, Nothing, Unit]
   lazy val Latch3: Promise2.type = Promise2
 
-  type Semaphore2[+F[_, _]] = Semaphore1[F[Nothing, ?]]
+  type Semaphore2[+F[_, _]] = Semaphore1[F[Nothing, _]]
   lazy val Semaphore2: Semaphore1.type = Semaphore1
-  type Semaphore3[+F[_, _, _]] = Semaphore1[F[Any, Nothing, ?]]
+  type Semaphore3[+F[_, _, _]] = Semaphore1[F[Any, Nothing, _]]
   lazy val Semaphore3: Semaphore1.type = Semaphore1
 
-  type UnsafeRun3[F[_, _, _]] = UnsafeRun2[F[Any, ?, ?]]
+  type UnsafeRun3[F[_, _, _]] = UnsafeRun2[F[Any, _, _]]
   object UnsafeRun3 {
     @inline def apply[F[_, _, _]: UnsafeRun3]: UnsafeRun3[F] = implicitly
   }
 
-  type SyncSafe2[F[_, _]] = SyncSafe[F[Nothing, ?]]
+  type SyncSafe2[F[_, _]] = SyncSafe[F[Nothing, _]]
   object SyncSafe2 {
     @inline def apply[F[_, _]: SyncSafe2]: SyncSafe2[F] = implicitly
   }
-  type SyncSafe3[F[_, _, _]] = SyncSafe[F[Any, Nothing, ?]]
+  type SyncSafe3[F[_, _, _]] = SyncSafe[F[Any, Nothing, _]]
   object SyncSafe3 {
     @inline def apply[F[_, _, _]: SyncSafe3]: SyncSafe3[F] = implicitly
   }
 
-  type Clock2[F[_, _]] = Clock[F[Nothing, ?]]
+  type Clock2[F[_, _]] = Clock[F[Nothing, _]]
   object Clock2 {
     @inline def apply[F[_, _]: Clock2]: Clock2[F] = implicitly
   }
-  type Clock3[F[_, _, _]] = Clock[F[Any, Nothing, ?]]
+  type Clock3[F[_, _, _]] = Clock[F[Any, Nothing, _]]
   object Clock3 {
     @inline def apply[F[_, _, _]: Clock3]: Clock3[F] = implicitly
   }
 
-  type Entropy2[F[_, _]] = Entropy[F[Nothing, ?]]
+  type Entropy2[F[_, _]] = Entropy[F[Nothing, _]]
   object Entropy2 {
     @inline def apply[F[_, _]: Entropy2]: Entropy2[F] = implicitly
   }
-  type Entropy3[F[_, _, _]] = Entropy[F[Any, Nothing, ?]]
+  type Entropy3[F[_, _, _]] = Entropy[F[Any, Nothing, _]]
   object Entropy3 {
     @inline def apply[F[_, _, _]: Entropy3]: Entropy3[F] = implicitly
   }
@@ -339,7 +339,7 @@ package object bio extends Syntax3 with Syntax2 {
   @deprecated("renamed to Primitives2", "1.0")
   lazy val BIOPrimitives: Primitives2.type = Primitives2
   @deprecated("renamed to Primitives3", "1.0")
-  type BIOPrimitives3[F[-_, +_, +_]] = Primitives2[F[Any, +?, +?]]
+  type BIOPrimitives3[F[-_, +_, +_]] = Primitives2[F[Any, +_, +_]]
   @deprecated("renamed to Primitives3", "1.0")
   lazy val BIOPrimitives3: Primitives3.type = Primitives3
 

--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/package.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/package.scala
@@ -159,7 +159,7 @@ package object bio extends Syntax3 with Syntax2 {
     @inline def apply[F[_, _]: TransZio]: TransZio[F] = implicitly
   }
 
-  type Fiber3[+F[-_, +_, +_], +E, +A] = Fiber2[F[Any, +?, +?], E, A]
+  type Fiber3[+F[-_, +_, +_], +E, +A] = Fiber2[F[Any, +_, +_], E, A]
   lazy val Fiber3: Fiber2.type = Fiber2
 
   type Ref2[+F[_, _], A] = Ref1[F[Nothing, _], A]

--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/syntax/BIO3Syntax.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/syntax/BIO3Syntax.scala
@@ -220,7 +220,7 @@ object BIO3Syntax {
   }
 
   final class BIOLocalOpsKleisliSyntax[FR[-_, +_, +_], R, E, A](private val r: FR[R, E, A])(implicit private val F: Local3[FR]) {
-    @inline final def toKleisli: Kleisli[FR[Any, E, ?], R, A] = F.toKleisli(r)
+    @inline final def toKleisli: Kleisli[FR[Any, E, _], R, A] = F.toKleisli(r)
   }
 
   trait BIO3ImplicitPuns extends BIO3ImplicitPuns1 {

--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/syntax/Syntax3.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/syntax/Syntax3.scala
@@ -292,7 +292,7 @@ object Syntax3 {
   }
 
   final class LocalOpsKleisliSyntax[FR[-_, +_, +_], R, E, A](private val r: FR[R, E, A])(implicit private val F: Local3[FR]) {
-    @inline final def toKleisli: Kleisli[FR[Any, E, ?], R, A] = F.toKleisli(r)
+    @inline final def toKleisli: Kleisli[FR[Any, E, _], R, A] = F.toKleisli(r)
   }
 
   trait ImplicitPuns extends ImplicitPuns1 {

--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/mono/SyncSafe.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/mono/SyncSafe.scala
@@ -31,15 +31,15 @@ object SyncSafe extends LowPrioritySyncSafeInstances0 {
 }
 
 trait LowPrioritySyncSafeInstances0 extends LowPrioritySyncSafeInstances1 {
-  implicit final def fromBIO3[F[-_, +_, +_]: IO3]: SyncSafe[F[Any, Nothing, ?]] =
-    new SyncSafe[F[Any, Nothing, ?]] {
+  implicit final def fromBIO3[F[-_, +_, +_]: IO3]: SyncSafe[F[Any, Nothing, _]] =
+    new SyncSafe[F[Any, Nothing, _]] {
       override def syncSafe[A](f: => A): F[Any, Nothing, A] = F.sync(f)
     }
 }
 
 trait LowPrioritySyncSafeInstances1 extends LowPrioritySyncSafeInstances2 {
-  implicit final def fromBIO[F[+_, +_]: IO2]: SyncSafe[F[Nothing, ?]] =
-    new SyncSafe[F[Nothing, ?]] {
+  implicit final def fromBIO[F[+_, +_]: IO2]: SyncSafe[F[Nothing, _]] =
+    new SyncSafe[F[Nothing, _]] {
       override def syncSafe[A](f: => A): F[Nothing, A] = F.sync(f)
     }
 }
@@ -54,6 +54,6 @@ trait LowPrioritySyncSafeInstances2 {
     *
     * @see https://github.com/scala/bug/issues/11427
     */
-  @inline implicit final def limitedCovariance[F[+_, _], E](implicit F: SyncSafe2[F]): SyncSafe[F[E, ?]] = F.asInstanceOf[SyncSafe[F[E, ?]]]
-  @inline implicit final def covarianceConversion[G[_], F[_]](log: SyncSafe[F])(implicit ev: F[_] <:< G[_]): SyncSafe[G] = { val _ = ev; log.asInstanceOf[SyncSafe[G]] }
+  @inline implicit final def limitedCovariance[F[+_, _], E](implicit F: SyncSafe2[F]): SyncSafe[F[E, _]] = F.asInstanceOf[SyncSafe[F[E, _]]]
+  @inline implicit final def covarianceConversion[G[_], F[_]](log: SyncSafe[F])(implicit ev: F[?] <:< G[?]): SyncSafe[G] = { val _ = ev; log.asInstanceOf[SyncSafe[G]] }
 }

--- a/fundamentals/fundamentals-bio/src/test/scala/izumi/functional/CovariantHKTImplicitsBugTest.scala
+++ b/fundamentals/fundamentals-bio/src/test/scala/izumi/functional/CovariantHKTImplicitsBugTest.scala
@@ -30,11 +30,11 @@ class CovariantHKTImplicitsBugTest extends AnyWordSpec with GivenWhenThen {
   trait AnyIO[+F[_]]
   object AnyIO {
     implicit def fromMono[F[_]: MonoIO]: AnyIO[F] = new AnyIO[F] {}
-    implicit def fromBIO[F[+_, _]: BifunctorIO]: AnyIO[F[Nothing, ?]] = new AnyIO[F[Nothing, ?]] {}
+    implicit def fromBIO[F[+_, _]: BifunctorIO]: AnyIO[F[Nothing, _]] = new AnyIO[F[Nothing, _]] {}
   }
 
   class SomeAlg[+F[_]]
-  type SomeAlg2[F[_, _]] = SomeAlg[F[Nothing, ?]]
+  type SomeAlg2[F[_, _]] = SomeAlg[F[Nothing, _]]
   object SomeAlg {
     def mk[F[_]: AnyIO](): SomeAlg[F] = new SomeAlg[F]
   }

--- a/fundamentals/fundamentals-bio/src/test/scala/izumi/fundamentals/bio/test/CatsConversionTest.scala
+++ b/fundamentals/fundamentals-bio/src/test/scala/izumi/fundamentals/bio/test/CatsConversionTest.scala
@@ -9,7 +9,7 @@ import cats.Parallel
 
 class CatsConversionTest extends AnyWordSpec {
 
-  class X[F[+_, +_]: IO2](val ref: Ref[F[Throwable, ?], Int])
+  class X[F[+_, +_]: IO2](val ref: Ref[F[Throwable, _], Int])
 
   "pickup conversion to Sync" in {
     def conv[F[+_, +_]: IO2]: F[Throwable, Int] = {

--- a/fundamentals/fundamentals-bio/src/test/scala/izumi/fundamentals/bio/test/SyntaxTest.scala
+++ b/fundamentals/fundamentals-bio/src/test/scala/izumi/fundamentals/bio/test/SyntaxTest.scala
@@ -615,7 +615,7 @@ class SyntaxTest extends AnyWordSpec {
   "Fiber3 and Fiber2 types are wholly compatible" in {
     import izumi.functional.bio.{Applicative2, Applicative3, F, Fiber2, Fiber3, Fork2, Fork3}
 
-    def x2[FR[-_, +_, +_]](implicit applicative: Applicative2[FR[Any, +?, +?]], fork: Fork2[FR[Any, +?, +?]]) = {
+    def x2[FR[-_, +_, +_]](implicit applicative: Applicative2[FR[Any, +_, +_]], fork: Fork2[FR[Any, +_, +_]]) = {
       type F[+E, +A] = FR[Any, E, A]
       for {
         fiber <- F.unit.fork

--- a/fundamentals/fundamentals-collections/src/main/scala/izumi/fundamentals/collections/IzCollections.scala
+++ b/fundamentals/fundamentals-collections/src/main/scala/izumi/fundamentals/collections/IzCollections.scala
@@ -7,5 +7,5 @@ import scala.collection.compat._
 object IzCollections {
   implicit def toRichTraversables[A](xs: IterableOnce[A]): IzTraversables[A] = new IzTraversables(xs)
   implicit def toRichMappings[A, B](xs: IterableOnce[(A, B)]): IzMappings[A, B] = new IzMappings(xs)
-  implicit def toRichIterables[A, Repr[_] <: Iterable[_]](xs: Repr[A]): IzIterable[A, Repr] = new IzIterable(xs)
+  implicit def toRichIterables[A, Repr[X] <: Iterable[X]](xs: Repr[A]): IzIterable[A, Repr] = new IzIterable(xs)
 }

--- a/fundamentals/fundamentals-collections/src/main/scala/izumi/fundamentals/collections/IzIterable.scala
+++ b/fundamentals/fundamentals-collections/src/main/scala/izumi/fundamentals/collections/IzIterable.scala
@@ -3,11 +3,11 @@ package izumi.fundamentals.collections
 import scala.collection.compat._
 import scala.collection.mutable
 
-final class IzIterable[A, Repr[_] <: Iterable[_]](private val xs: Repr[A]) extends AnyVal {
+final class IzIterable[A, Repr[X] <: Iterable[X]](private val xs: Repr[A]) extends AnyVal {
 
   def distinctBy[B, That](f: A => B)(implicit cbf: BuildFrom[Repr[A], A, That]): That = {
     val builder = cbf.newBuilder(xs)
-    val i = xs.iterator.asInstanceOf[Iterator[A]] // 2.13 compat, dirty
+    val i = xs.iterator
     val set = mutable.Set[B]()
     while (i.hasNext) {
       val o = i.next()

--- a/fundamentals/fundamentals-collections/src/main/scala/izumi/fundamentals/graphs/DG.scala
+++ b/fundamentals/fundamentals-collections/src/main/scala/izumi/fundamentals/graphs/DG.scala
@@ -4,7 +4,7 @@ import GraphProperty._
 import GraphImpl._
 import izumi.fundamentals.graphs.struct.IncidenceMatrix
 
-final case class DG[N, M] private (
+final case class DG[N, M] private[izumi] (
   successors: IncidenceMatrix[N],
   predecessors: IncidenceMatrix[N],
   meta: GraphMeta[N, M],

--- a/fundamentals/fundamentals-language/src/main/scala/izumi/fundamentals/platform/language/IzScala.scala
+++ b/fundamentals/fundamentals-language/src/main/scala/izumi/fundamentals/platform/language/IzScala.scala
@@ -14,14 +14,20 @@ object IzScala {
     def parse(versionString: String): ScalaRelease = {
       val parts = versionString.split('.').toList
       parts match {
-        case "2" :: "12" :: bugfix :: Nil =>
-          ScalaRelease.`2_12`(Integer.parseInt(bugfix))
-        case "2" :: "13" :: bugfix :: Nil =>
-          ScalaRelease.`2_13`(Integer.parseInt(bugfix))
-        case major :: minor :: bugfix :: Nil =>
-          ScalaRelease.Unsupported(Seq(Integer.parseInt(major), Integer.parseInt(minor), Integer.parseInt(bugfix)))
+        case "2" :: "12" :: ParseInt(bugfix) :: Nil =>
+          ScalaRelease.`2_12`(bugfix)
+        case "2" :: "13" :: ParseInt(bugfix) :: Nil =>
+          ScalaRelease.`2_13`(bugfix)
+        case ParseInt(major) :: ParseInt(minor) :: ParseInt(bugfix) :: Nil =>
+          ScalaRelease.Unsupported(Seq(major, minor, bugfix))
         case _ =>
           ScalaRelease.Unknown(versionString)
+      }
+    }
+    private[this] object ParseInt {
+      def unapply(str: String): Option[Int] = {
+        try { Some(Integer.parseInt(str)) }
+        catch { case _: NumberFormatException => None }
       }
     }
 

--- a/fundamentals/fundamentals-language/src/main/scala/izumi/fundamentals/platform/language/Quirks.scala
+++ b/fundamentals/fundamentals-language/src/main/scala/izumi/fundamentals/platform/language/Quirks.scala
@@ -24,6 +24,6 @@ object Quirks {
   }
   @inline implicit final def LazyDiscarder[T](@unused t: => T): LazyDiscarder[Unit] = new LazyDiscarder[Unit]()
 
-  @inline final def forget(@unused trash: LazyDiscarder[_]*): Unit = ()
+  @inline final def forget(@unused trash: LazyDiscarder[?]*): Unit = ()
 
 }

--- a/fundamentals/fundamentals-platform/.jvm/src/main/scala/izumi/fundamentals/platform/resources/IzResources.scala
+++ b/fundamentals/fundamentals-platform/.jvm/src/main/scala/izumi/fundamentals/platform/resources/IzResources.scala
@@ -136,7 +136,7 @@ final class IzResourcesDirty(private val classLoader: ClassLoader) extends AnyVa
 }
 
 object IzResourcesDirty {
-  @inline def apply(clazz: Class[_]): IzResourcesDirty = new IzResourcesDirty(clazz.getClassLoader)
+  @inline def apply(clazz: Class[?]): IzResourcesDirty = new IzResourcesDirty(clazz.getClassLoader)
   @inline def apply(classLoader: ClassLoader): IzResourcesDirty = new IzResourcesDirty(classLoader)
 
   def copyFromClasspath(sourcePath: String, targetDir: Path): RecursiveCopyOutput = {
@@ -153,10 +153,10 @@ object IzResourcesDirty {
 }
 
 object IzResources {
-  @inline def apply(clazz: Class[_]): IzResources = new IzResources(clazz.getClassLoader)
+  @inline def apply(clazz: Class[?]): IzResources = new IzResources(clazz.getClassLoader)
   @inline def apply(classLoader: ClassLoader): IzResources = new IzResources(classLoader)
 
-  @inline implicit def toResources(clazz: Class[_]): IzResources = new IzResources(clazz.getClassLoader)
+  @inline implicit def toResources(clazz: Class[?]): IzResources = new IzResources(clazz.getClassLoader)
   @inline implicit def toResources(classLoader: ClassLoader): IzResources = new IzResources(classLoader)
 
   private def classLocationUrl[C: ClassTag](): Option[URL] = {

--- a/fundamentals/fundamentals-reflection/src/main/scala/izumi/fundamentals/reflection/AnnotationTools.scala
+++ b/fundamentals/fundamentals-reflection/src/main/scala/izumi/fundamentals/reflection/AnnotationTools.scala
@@ -1,24 +1,20 @@
 package izumi.fundamentals.reflection
 
-import izumi.fundamentals.reflection.ReflectionUtil.stripByName
-
 import scala.reflect.api.Universe
 
 object AnnotationTools {
 
   def getAllAnnotations(u: Universe)(symb: u.Symbol): List[u.Annotation] = {
-    val out = symb.annotations ++ getAllTypeAnnotations(u)(symb.typeSignature)
-    out
+    symb.annotations ++ getAllTypeAnnotations[u.type](symb.typeSignature)
   }
 
-  def getAllTypeAnnotations(u: Universe)(typ: u.Type): List[u.Annotation] = {
-    val out = stripByName(u)(typ.finalResultType.dealias) match {
-      case t: u.AnnotatedTypeApi =>
+  def getAllTypeAnnotations[U <: Universe with Singleton](typ: U#Type): List[U#Annotation] = {
+    typ.finalResultType.dealias match {
+      case t: U#AnnotatedTypeApi =>
         t.annotations
       case _ =>
         Nil
     }
-    out
   }
 
   def annotationTypeEq(u: Universe)(tpe: u.Type, ann: u.Annotation): Boolean = {

--- a/fundamentals/fundamentals-reflection/src/main/scala/izumi/fundamentals/reflection/AnnotationTools.scala
+++ b/fundamentals/fundamentals-reflection/src/main/scala/izumi/fundamentals/reflection/AnnotationTools.scala
@@ -1,20 +1,25 @@
 package izumi.fundamentals.reflection
 
+import izumi.fundamentals.reflection.ReflectionUtil.stripByName
+
+import scala.annotation.nowarn
 import scala.reflect.api.Universe
 
 object AnnotationTools {
 
   def getAllAnnotations(u: Universe)(symb: u.Symbol): List[u.Annotation] = {
-    symb.annotations ++ getAllTypeAnnotations[u.type](symb.typeSignature)
+    symb.annotations ++ getAllTypeAnnotations(u)(symb.typeSignature)
   }
 
-  def getAllTypeAnnotations[U <: Universe with Singleton](typ: U#Type): List[U#Annotation] = {
-    typ.finalResultType.dealias match {
-      case t: U#AnnotatedTypeApi =>
+  def getAllTypeAnnotations(u: Universe)(typ: u.Type): List[u.Annotation] = {
+    @nowarn("msg=outer reference")
+    val out = stripByName(u)(typ.finalResultType.dealias) match {
+      case t: u.AnnotatedTypeApi =>
         t.annotations
       case _ =>
         Nil
     }
+    out
   }
 
   def annotationTypeEq(u: Universe)(tpe: u.Type, ann: u.Annotation): Boolean = {

--- a/fundamentals/fundamentals-reflection/src/main/scala/izumi/fundamentals/reflection/ReflectionUtil.scala
+++ b/fundamentals/fundamentals-reflection/src/main/scala/izumi/fundamentals/reflection/ReflectionUtil.scala
@@ -25,17 +25,17 @@ object ReflectionUtil {
     * So we just strip it when we get it.
     */
   @tailrec
-  final def norm0(u: Universe)(x: u.Type): u.Type = {
+  final def norm0[U <: SingletonUniverse](x: U#Type): U#Type = {
     x match {
-      case r: u.RefinedTypeApi if (r.parents.drop(1) eq Nil) && r.decls.isEmpty => norm0(u)(r.asInstanceOf[u.Type])
-      case a: u.AnnotatedTypeApi => norm0(u)(a.underlying)
+      case r: U#RefinedTypeApi if (r.parents.drop(1) eq Nil) && r.decls.isEmpty => norm0[U](r.asInstanceOf[U#Type])
+      case a: U#AnnotatedTypeApi => norm0[U](a.underlying)
       case _ => x
     }
   }
 
-  def toTypeRef(u: Universe)(tpe: u.TypeApi): Option[u.TypeRefApi] = {
+  def toTypeRef[U <: SingletonUniverse](tpe: U#TypeApi): Option[U#TypeRefApi] = {
     tpe match {
-      case typeRef: u.TypeRefApi =>
+      case typeRef: U#TypeRefApi =>
         Some(typeRef)
       case _ =>
         None
@@ -100,10 +100,10 @@ object ReflectionUtil {
     tpe1.dealias =:= tpe1
   }
 
-  def deepIntersectionTypeMembers(u: Universe)(targetType: u.Type): List[u.Type] = {
-    def go(tpe: u.Type): List[u.Type] = {
+  def deepIntersectionTypeMembers[U <: SingletonUniverse](targetType: U#Type): List[U#Type] = {
+    def go(tpe: U#Type): List[U#Type] = {
       tpe match {
-        case r: u.RefinedTypeApi => r.parents.flatMap(t => deepIntersectionTypeMembers(u)(norm0(u)(t.dealias)))
+        case r: U#RefinedTypeApi => r.parents.flatMap(t => deepIntersectionTypeMembers[U](norm0[U](t.dealias): U#Type))
         case _ => List(tpe)
       }
     }

--- a/fundamentals/fundamentals-reflection/src/main/scala/izumi/fundamentals/reflection/ReflectionUtil.scala
+++ b/fundamentals/fundamentals-reflection/src/main/scala/izumi/fundamentals/reflection/ReflectionUtil.scala
@@ -25,17 +25,17 @@ object ReflectionUtil {
     * So we just strip it when we get it.
     */
   @tailrec
-  final def norm0[U <: SingletonUniverse](x: U#Type): U#Type = {
+  final def norm0(u: Universe)(x: u.Type): u.Type = {
     x match {
-      case r: U#RefinedTypeApi if (r.parents.drop(1) eq Nil) && r.decls.isEmpty => norm0[U](r.asInstanceOf[U#Type])
-      case a: U#AnnotatedTypeApi => norm0[U](a.underlying)
+      case r: u.RefinedTypeApi if (r.parents.drop(1) eq Nil) && r.decls.isEmpty => norm0(u)(r.asInstanceOf[u.Type])
+      case a: u.AnnotatedTypeApi => norm0(u)(a.underlying)
       case _ => x
     }
   }
 
-  def toTypeRef[U <: SingletonUniverse](tpe: U#TypeApi): Option[U#TypeRefApi] = {
+  def toTypeRef(u: Universe)(tpe: u.TypeApi): Option[u.TypeRefApi] = {
     tpe match {
-      case typeRef: U#TypeRefApi =>
+      case typeRef: u.TypeRefApi =>
         Some(typeRef)
       case _ =>
         None
@@ -100,10 +100,10 @@ object ReflectionUtil {
     tpe1.dealias =:= tpe1
   }
 
-  def deepIntersectionTypeMembers[U <: SingletonUniverse](targetType: U#Type): List[U#Type] = {
-    def go(tpe: U#Type): List[U#Type] = {
+  def deepIntersectionTypeMembers(u: Universe)(targetType: u.Type): List[u.Type] = {
+    def go(tpe: u.Type): List[u.Type] = {
       tpe match {
-        case r: U#RefinedTypeApi => r.parents.flatMap(t => deepIntersectionTypeMembers[U](norm0[U](t.dealias): U#Type))
+        case r: u.RefinedTypeApi => r.parents.flatMap(t => deepIntersectionTypeMembers(u)(norm0(u)(t.dealias)))
         case _ => List(tpe)
       }
     }

--- a/fundamentals/fundamentals-reflection/src/main/scala/izumi/fundamentals/reflection/TypeUtil.scala
+++ b/fundamentals/fundamentals-reflection/src/main/scala/izumi/fundamentals/reflection/TypeUtil.scala
@@ -4,7 +4,7 @@ import java.lang.reflect.{Constructor, Field}
 
 object TypeUtil {
 
-  def isAssignableFrom(superClass: Class[_], obj: Any): Boolean = {
+  def isAssignableFrom(superClass: Class[?], obj: Any): Boolean = {
     def instanceClass = obj.getClass
 
     if (obj == null) {
@@ -30,7 +30,7 @@ object TypeUtil {
     }
   }
 
-  final def defaultValue(clazz: Class[_]): Any = {
+  final def defaultValue(clazz: Class[?]): Any = {
     if (clazz == classOf[java.lang.Integer] || clazz == classOf[Int]) {
       0: Int
     } else if (clazz == classOf[java.lang.Float] || clazz == classOf[Float]) {
@@ -52,7 +52,7 @@ object TypeUtil {
     }
   }
 
-  final def isObject(clazz: Class[_]): Option[Field] = {
+  final def isObject(clazz: Class[?]): Option[Field] = {
     val name = clazz.getName
     if ((name ne null) && name.endsWith("$")) {
       try {
@@ -66,11 +66,11 @@ object TypeUtil {
     }
   }
 
-  final def isZeroArgClass(clazz: Class[_]): Option[Constructor[_]] = {
+  final def isZeroArgClass(clazz: Class[?]): Option[Constructor[?]] = {
     clazz.getDeclaredConstructors.find(_.getParameterCount == 0)
   }
 
-  @inline final def instantiateObject[T](clazz: Class[_]): T = {
+  @inline final def instantiateObject[T](clazz: Class[?]): T = {
     clazz.getField("MODULE$").get(null).asInstanceOf[T]
   }
 
@@ -78,15 +78,15 @@ object TypeUtil {
     field.get(null).asInstanceOf[T]
   }
 
-  @inline final def instantiateZeroArgClass[T](clazz: Class[_]): Option[T] = {
+  @inline final def instantiateZeroArgClass[T](clazz: Class[?]): Option[T] = {
     isZeroArgClass(clazz).map(instantiateZeroArgClass[T])
   }
 
-  @inline final def instantiateZeroArgClass[T](ctor: Constructor[_]): T = {
+  @inline final def instantiateZeroArgClass[T](ctor: Constructor[?]): T = {
     ctor.newInstance().asInstanceOf[T]
   }
 
-  final def isAnonymous(clazz: Class[_]): Boolean = {
+  final def isAnonymous(clazz: Class[?]): Boolean = {
     clazz.isAnonymousClass ||
     clazz.getName.contains("$anon$") // On Java 8 `.isAnonymousClass` returns false for Scala's anonymous classes, work around it with name matching
   }

--- a/logstage/logstage-core/.jvm/src/main/scala/izumi/logstage/sink/file/models/FileSinkConfig.scala
+++ b/logstage/logstage-core/.jvm/src/main/scala/izumi/logstage/sink/file/models/FileSinkConfig.scala
@@ -2,7 +2,7 @@ package izumi.logstage.sink.file.models
 
 import LogPayloadSize._
 
-final case class FileSinkConfig private (fileSizeInBytes: Option[Int] = None, fileSizeSoft: Option[Int] = None) {
+final case class FileSinkConfig private (fileSizeInBytes: Option[Int], fileSizeSoft: Option[Int]) {
 
   val (maxAllowedSize, calculateMessageSize) = {
     (fileSizeSoft, fileSizeInBytes) match {
@@ -15,6 +15,6 @@ final case class FileSinkConfig private (fileSizeInBytes: Option[Int] = None, fi
 }
 
 object FileSinkConfig {
-  def inBytes(limit: Int): FileSinkConfig = new FileSinkConfig(fileSizeInBytes = Some(limit))
-  def soft(limit: Int): FileSinkConfig = new FileSinkConfig(fileSizeSoft = Some(limit))
+  def inBytes(limit: Int): FileSinkConfig = new FileSinkConfig(fileSizeInBytes = Some(limit), fileSizeSoft = None)
+  def soft(limit: Int): FileSinkConfig = new FileSinkConfig(fileSizeSoft = Some(limit), fileSizeInBytes = None)
 }

--- a/logstage/logstage-core/.jvm/src/test/scala/izumi/logstage/ImplicitsTest.scala
+++ b/logstage/logstage-core/.jvm/src/test/scala/izumi/logstage/ImplicitsTest.scala
@@ -79,7 +79,7 @@ class ImplicitsTest extends AnyWordSpec {
 
   def logIO[F[_]: LogIO](): F[Unit] = LogIO[F].info("abc")
 
-  def logThrowable[F[+_, _]]()(implicit f: LogIO[F[Throwable, ?]]): F[Throwable, Unit] = f.info("cba")
+  def logThrowable[F[+_, _]]()(implicit f: LogIO[F[Throwable, _]]): F[Throwable, Unit] = f.info("cba")
 
   def expectThrowable[F[+_, _]](f: F[Throwable, Unit]): F[Throwable, Unit] = f
 

--- a/logstage/logstage-core/src/main/scala/izumi/logstage/api/logger/AbstractLogIO.scala
+++ b/logstage/logstage-core/src/main/scala/izumi/logstage/api/logger/AbstractLogIO.scala
@@ -13,5 +13,5 @@ trait AbstractLogIO[F[_]] extends UnsafeLogIO[F] {
   def withCustomContext(context: CustomContext): Self[F]
   final def apply(context: CustomContext): Self[F] = withCustomContext(context)
 
-  override def widen[G[_]](implicit @unused ev: F[_] <:< G[_]): AbstractLogIO[G] = this.asInstanceOf[AbstractLogIO[G]]
+  override def widen[G[_]](implicit @unused ev: F[?] <:< G[?]): AbstractLogIO[G] = this.asInstanceOf[AbstractLogIO[G]]
 }

--- a/logstage/logstage-core/src/main/scala/izumi/logstage/api/logger/LogIORaw.scala
+++ b/logstage/logstage-core/src/main/scala/izumi/logstage/api/logger/LogIORaw.scala
@@ -21,5 +21,5 @@ final class LogIORaw[F[_], E <: AnyEncoded](
   override def createContext(logLevel: Level, customContext: Log.CustomContext)(implicit pos: CodePositionMaterializer): F[Log.Context] =
     delegate.createContext(logLevel, customContext)
 
-  override def widen[G[_]](implicit ev: F[_] <:< G[_]): LogIORaw[G, E] = this.asInstanceOf[LogIORaw[G, E]]
+  override def widen[G[_]](implicit ev: F[?] <:< G[?]): LogIORaw[G, E] = this.asInstanceOf[LogIORaw[G, E]]
 }

--- a/logstage/logstage-core/src/main/scala/logstage/LogCreateIO.scala
+++ b/logstage/logstage-core/src/main/scala/logstage/LogCreateIO.scala
@@ -10,7 +10,7 @@ trait LogCreateIO[F[_]] {
   def createEntry(logLevel: Level, message: Message)(implicit pos: CodePositionMaterializer): F[Entry]
   def createContext(logLevel: Level, customContext: CustomContext)(implicit pos: CodePositionMaterializer): F[Context]
 
-  def widen[G[_]](implicit @unused ev: F[_] <:< G[_]): LogCreateIO[G] = this.asInstanceOf[LogCreateIO[G]]
+  def widen[G[_]](implicit @unused ev: F[?] <:< G[?]): LogCreateIO[G] = this.asInstanceOf[LogCreateIO[G]]
 }
 
 object LogCreateIO {
@@ -37,8 +37,8 @@ object LogCreateIO {
     *
     * @see https://github.com/scala/bug/issues/11427
     */
-  implicit def limitedCovariance[F[+_, _], E](implicit log: LogCreateIO2[F]): LogCreateIO[F[E, ?]] = log.widen
-  implicit def covarianceConversion[G[_], F[_]](log: LogCreateIO[F])(implicit ev: F[_] <:< G[_]): LogCreateIO[G] = log.widen
+  implicit def limitedCovariance[F[+_, _], E](implicit log: LogCreateIO2[F]): LogCreateIO[F[E, _]] = log.widen
+  implicit def covarianceConversion[G[_], F[_]](log: LogCreateIO[F])(implicit ev: F[?] <:< G[?]): LogCreateIO[G] = log.widen
 }
 
 object LogCreateIO2 {

--- a/logstage/logstage-core/src/main/scala/logstage/LogIO.scala
+++ b/logstage/logstage-core/src/main/scala/logstage/LogIO.scala
@@ -18,7 +18,7 @@ trait LogIO[F[_]] extends logger.EncodingAwareAbstractLogIO[F, AnyEncoded] with 
 
   final def raw: LogIORaw[F, AnyEncoded] = new logger.LogIORaw(this)
 
-  override def widen[G[_]](implicit @unused ev: F[_] <:< G[_]): LogIO[G] = this.asInstanceOf[LogIO[G]]
+  override def widen[G[_]](implicit @unused ev: F[?] <:< G[?]): LogIO[G] = this.asInstanceOf[LogIO[G]]
 }
 
 object LogIO {
@@ -64,8 +64,8 @@ object LogIO {
     *
     * @see https://github.com/scala/bug/issues/11427
     */
-  implicit def limitedCovariance[F[+_, _], E](implicit log: LogIO2[F]): LogIO[F[E, ?]] = log.widen
-  implicit def covarianceConversion[G[_], F[_]](log: LogIO[F])(implicit ev: F[_] <:< G[_]): LogIO[G] = log.widen
+  implicit def limitedCovariance[F[+_, _], E](implicit log: LogIO2[F]): LogIO[F[E, _]] = log.widen
+  implicit def covarianceConversion[G[_], F[_]](log: LogIO[F])(implicit ev: F[?] <:< G[?]): LogIO[G] = log.widen
 
   implicit final class LogIO2Syntax[F[+_, +_]](private val log: LogIO2[F]) extends AnyVal {
     def fail(msg: Message)(implicit F: Error2[F], pos: CodePositionMaterializer): F[RuntimeException, Nothing] = {

--- a/logstage/logstage-core/src/main/scala/logstage/LogIO3Ask.scala
+++ b/logstage/logstage-core/src/main/scala/logstage/LogIO3Ask.scala
@@ -49,7 +49,7 @@ object LogIO3Ask {
       F.access(get(_).createEntry(logLevel, message))
     override final def createContext(logLevel: Level, customContext: CustomContext)(implicit pos: CodePositionMaterializer): F[Has[LogIO3[F]], Nothing, Log.Context] =
       F.access(get(_).createContext(logLevel, customContext))
-    override final def withCustomContext(context: CustomContext): LogIO2[F[Has[LogIO3[F]], ?, ?]] = {
+    override final def withCustomContext(context: CustomContext): LogIO2[F[Has[LogIO3[F]], _, _]] = {
       new LogIO3AskImpl[F](get(_).withCustomContext(context))
     }
   }

--- a/logstage/logstage-core/src/main/scala/logstage/LogZIO.scala
+++ b/logstage/logstage-core/src/main/scala/logstage/LogZIO.scala
@@ -26,7 +26,7 @@ object LogZIO {
   object log extends LogIO3Ask.LogIO3AskImpl[ZIO](_.get)
 
   def withFiberId(logger: AbstractLogger): LogIO2[IO] = {
-    new WrappedLogIO[IO[Nothing, ?]](logger)(SyncSafe2[IO]) {
+    new WrappedLogIO[IO[Nothing, _]](logger)(SyncSafe2[IO]) {
       override def withCustomContext(context: CustomContext): LogIO2[IO] = {
         withFiberId(logger.withCustomContext(context))
       }
@@ -40,9 +40,9 @@ object LogZIO {
     }
   }
 
-  def withDynamicContext[R](logger: AbstractLogger)(dynamic: ZIO[R, Nothing, CustomContext]): LogIO2[ZIO[R, ?, ?]] = {
-    new WrappedLogIO[ZIO[R, Nothing, ?]](logger)(SyncSafe[ZIO[R, Nothing, ?]]) {
-      override def withCustomContext(context: CustomContext): LogIO[ZIO[R, Nothing, ?]] = {
+  def withDynamicContext[R](logger: AbstractLogger)(dynamic: ZIO[R, Nothing, CustomContext]): LogIO2[ZIO[R, _, _]] = {
+    new WrappedLogIO[ZIO[R, Nothing, _]](logger)(SyncSafe[ZIO[R, Nothing, _]]) {
+      override def withCustomContext(context: CustomContext): LogIO[ZIO[R, Nothing, _]] = {
         withDynamicContext(logger.withCustomContext(context))(dynamic)
       }
 

--- a/logstage/logstage-core/src/main/scala/logstage/UnsafeLogIO.scala
+++ b/logstage/logstage-core/src/main/scala/logstage/UnsafeLogIO.scala
@@ -19,7 +19,7 @@ trait UnsafeLogIO[F[_]] extends LogCreateIO[F] {
   /** Check if this class/package is allowed to log messages at or above `logLevel` */
   def acceptable(logLevel: Level)(implicit pos: CodePositionMaterializer): F[Boolean]
 
-  override def widen[G[_]](implicit @unused ev: F[_] <:< G[_]): UnsafeLogIO[G] = this.asInstanceOf[UnsafeLogIO[G]]
+  override def widen[G[_]](implicit @unused ev: F[?] <:< G[?]): UnsafeLogIO[G] = this.asInstanceOf[UnsafeLogIO[G]]
 }
 
 object UnsafeLogIO {
@@ -50,8 +50,8 @@ object UnsafeLogIO {
     *
     * @see https://github.com/scala/bug/issues/11427
     */
-  implicit def limitedCovariance[F[+_, _], E](implicit log: UnsafeLogIO2[F]): UnsafeLogIO[F[E, ?]] = log.widen
-  implicit def covarianceConversion[G[_], F[_]](log: UnsafeLogIO[F])(implicit ev: F[_] <:< G[_]): UnsafeLogIO[G] = log.widen
+  implicit def limitedCovariance[F[+_, _], E](implicit log: UnsafeLogIO2[F]): UnsafeLogIO[F[E, _]] = log.widen
+  implicit def covarianceConversion[G[_], F[_]](log: UnsafeLogIO[F])(implicit ev: F[?] <:< G[?]): UnsafeLogIO[G] = log.widen
 }
 
 object UnsafeLogIO2 {

--- a/logstage/logstage-core/src/main/scala/logstage/package.scala
+++ b/logstage/logstage-core/src/main/scala/logstage/package.scala
@@ -4,16 +4,16 @@ import zio.Has
 
 package object logstage extends LogStage {
 
-  type LogIO2[F[_, _]] = LogIO[F[Nothing, ?]]
-  type LogIO3[F[_, _, _]] = LogIO[F[Any, Nothing, ?]]
-  type LogIO3Ask[F[_, _, _]] = LogIO2[F[Has[LogIO3[F]], ?, ?]]
+  type LogIO2[F[_, _]] = LogIO[F[Nothing, _]]
+  type LogIO3[F[_, _, _]] = LogIO[F[Any, Nothing, _]]
+  type LogIO3Ask[F[_, _, _]] = LogIO2[F[Has[LogIO3[F]], _, _]]
   type LogZIO = Has[LogZIO.Service]
 
-  type LogCreateIO2[F[_, _]] = LogCreateIO[F[Nothing, ?]]
-  type LogCreateIO3[F[_, _, _]] = LogCreateIO[F[Any, Nothing, ?]]
+  type LogCreateIO2[F[_, _]] = LogCreateIO[F[Nothing, _]]
+  type LogCreateIO3[F[_, _, _]] = LogCreateIO[F[Any, Nothing, _]]
 
-  type UnsafeLogIO2[F[_, _]] = UnsafeLogIO[F[Nothing, ?]]
-  type UnsafeLogIO3[F[_, _, _]] = UnsafeLogIO[F[Any, Nothing, ?]]
+  type UnsafeLogIO2[F[_, _]] = UnsafeLogIO[F[Nothing, _]]
+  type UnsafeLogIO3[F[_, _, _]] = UnsafeLogIO[F[Any, Nothing, _]]
 
   override type IzLogger = api.IzLogger
   override final val IzLogger: api.IzLogger.type = api.IzLogger

--- a/logstage/logstage-core/src/main/scala/logstage/strict/LogIO3AskStrict.scala
+++ b/logstage/logstage-core/src/main/scala/logstage/strict/LogIO3AskStrict.scala
@@ -71,7 +71,7 @@ object LogIO3AskStrict {
     )(implicit pos: CodePositionMaterializer
     ): F[Has[LogIO3Strict[F]], Nothing, Log.Context] =
       F.access(get(_).createContext(logLevel, customContext))
-    override final def withCustomContext(context: CustomContext): LogIO2Strict[F[Has[LogIO3Strict[F]], ?, ?]] = {
+    override final def withCustomContext(context: CustomContext): LogIO2Strict[F[Has[LogIO3Strict[F]], _, _]] = {
       new LogIO3AskStrictImpl[F](get(_).withCustomContext(context))
     }
   }

--- a/logstage/logstage-core/src/main/scala/logstage/strict/LogIOStrict.scala
+++ b/logstage/logstage-core/src/main/scala/logstage/strict/LogIOStrict.scala
@@ -16,7 +16,7 @@ trait LogIOStrict[F[_]] extends EncodingAwareAbstractLogIO[F, StrictEncoded] wit
 
   final def raw: LogIORaw[F, StrictEncoded] = new LogIORaw(this)
 
-  override def widen[G[_]](implicit ev: F[_] <:< G[_]): LogIOStrict[G] = this.asInstanceOf[LogIOStrict[G]]
+  override def widen[G[_]](implicit ev: F[?] <:< G[?]): LogIOStrict[G] = this.asInstanceOf[LogIOStrict[G]]
 }
 
 object LogIOStrict {
@@ -60,8 +60,8 @@ object LogIOStrict {
     *
     * @see https://github.com/scala/bug/issues/11427
     */
-  implicit def limitedCovariance[F[+_, _], E](implicit log: LogIO2Strict[F]): LogIOStrict[F[E, ?]] = log.asInstanceOf[LogIOStrict[F[E, ?]]]
-  implicit def covarianceConversion[G[_], F[_]](log: LogIOStrict[F])(implicit ev: F[_] <:< G[_]): LogIOStrict[G] = log.widen
+  implicit def limitedCovariance[F[+_, _], E](implicit log: LogIO2Strict[F]): LogIOStrict[F[E, _]] = log.asInstanceOf[LogIOStrict[F[E, _]]]
+  implicit def covarianceConversion[G[_], F[_]](log: LogIOStrict[F])(implicit ev: F[?] <:< G[?]): LogIOStrict[G] = log.widen
 }
 
 object LogIO2Strict {

--- a/logstage/logstage-core/src/main/scala/logstage/strict/LogZIOStrict.scala
+++ b/logstage/logstage-core/src/main/scala/logstage/strict/LogZIOStrict.scala
@@ -27,8 +27,8 @@ object LogZIOStrict {
   object log extends LogIO3AskStrictImpl[ZIO](_.get)
 
   def withFiberIdStrict(logger: AbstractLogger): LogIO2Strict[IO] = {
-    new WrappedLogIOStrict[IO[Nothing, ?]](logger)(SyncSafe2[IO]) {
-      override def withCustomContext(context: CustomContext): LogIOStrict[IO[Nothing, ?]] = {
+    new WrappedLogIOStrict[IO[Nothing, _]](logger)(SyncSafe2[IO]) {
+      override def withCustomContext(context: CustomContext): LogIOStrict[IO[Nothing, _]] = {
         withFiberIdStrict(logger.withCustomContext(context))
       }
 
@@ -41,9 +41,9 @@ object LogZIOStrict {
     }
   }
 
-  def withDynamicContextStrict[R](logger: AbstractLogger)(dynamic: ZIO[R, Nothing, CustomContext]): LogIOStrict[ZIO[R, Nothing, ?]] = {
-    new WrappedLogIOStrict[ZIO[R, Nothing, ?]](logger)(SyncSafe[ZIO[R, Nothing, ?]]) {
-      override def withCustomContext(context: CustomContext): LogIOStrict[ZIO[R, Nothing, ?]] = {
+  def withDynamicContextStrict[R](logger: AbstractLogger)(dynamic: ZIO[R, Nothing, CustomContext]): LogIOStrict[ZIO[R, Nothing, _]] = {
+    new WrappedLogIOStrict[ZIO[R, Nothing, _]](logger)(SyncSafe[ZIO[R, Nothing, _]]) {
+      override def withCustomContext(context: CustomContext): LogIOStrict[ZIO[R, Nothing, _]] = {
         withDynamicContextStrict(logger.withCustomContext(context))(dynamic)
       }
 

--- a/logstage/logstage-core/src/main/scala/logstage/strict/LogstageStrict.scala
+++ b/logstage/logstage-core/src/main/scala/logstage/strict/LogstageStrict.scala
@@ -11,17 +11,17 @@ trait LogstageStrict {
   type LogBIOEnvStrictInstance[F[-_, +_, +_]] = LogIO3AskStrict.LogIO3AskStrictImpl[F]
 
   @deprecated("renamed to LogIO2Strict", "1.0")
-  type LogBIOStrict[F[_, _]] = LogIOStrict[F[Nothing, ?]]
+  type LogBIOStrict[F[_, _]] = LogIOStrict[F[Nothing, _]]
   @deprecated("renamed to LogIO2Strict", "1.0")
   lazy val LogBIOStrict: LogIO2Strict.type = LogIO2Strict
 
   @deprecated("renamed to LogIO3Strict", "1.0")
-  type LogBIO3Strict[F[_, _, _]] = LogIOStrict[F[Any, Nothing, ?]]
+  type LogBIO3Strict[F[_, _, _]] = LogIOStrict[F[Any, Nothing, _]]
   @deprecated("renamed to LogIO3Strict", "1.0")
   lazy val LogBIO3Strict: LogIO3Strict.type = LogIO3Strict
 
   @deprecated("renamed to LogIO3AskStrict", "1.0")
-  type LogBIOEnvStrict[F[_, _, _]] = LogIOStrict[F[Has[LogIO3Strict[F]], Nothing, ?]]
+  type LogBIOEnvStrict[F[_, _, _]] = LogIOStrict[F[Has[LogIO3Strict[F]], Nothing, _]]
   @deprecated("renamed to LogIO3AskStrict", "1.0")
   lazy val LogBIOEnvStrict: LogIO3AskStrict.type = LogIO3AskStrict
 }

--- a/logstage/logstage-core/src/main/scala/logstage/strict/package.scala
+++ b/logstage/logstage-core/src/main/scala/logstage/strict/package.scala
@@ -4,9 +4,9 @@ import izumi.logstage.api
 import zio.{Has, ZIO}
 
 package object strict extends LogstageStrict {
-  type LogIO2Strict[F[_, _]] = LogIOStrict[F[Nothing, ?]]
-  type LogIO3Strict[F[_, _, _]] = LogIOStrict[F[Any, Nothing, ?]]
-  type LogIO3AskStrict[F[_, _, _]] = LogIOStrict[F[Has[LogIO3Strict[F]], Nothing, ?]]
+  type LogIO2Strict[F[_, _]] = LogIOStrict[F[Nothing, _]]
+  type LogIO3Strict[F[_, _, _]] = LogIOStrict[F[Any, Nothing, _]]
+  type LogIO3AskStrict[F[_, _, _]] = LogIOStrict[F[Has[LogIO3Strict[F]], Nothing, _]]
 
   type LogZIOStrict = Has[LogIO3Strict[ZIO]]
 

--- a/project/Deps.sc
+++ b/project/Deps.sc
@@ -102,7 +102,7 @@ object Izumi {
     final val scala_library = Library("org.scala-lang", "scala-library", Version.VExpr("scalaVersion.value"), LibraryType.Invariant)
     final val scala_reflect = Library("org.scala-lang", "scala-reflect", Version.VExpr("scalaVersion.value"), LibraryType.Invariant)
 
-    final val cglib_nodep = Library("cglib", "cglib-nodep", V.cglib_nodep, LibraryType.Invariant) in Scope.Compile.jvm()
+    final val cglib_nodep = Library("cglib", "cglib-nodep", V.cglib_nodep, LibraryType.Invariant) in Scope.Compile.jvm
 
     final val projector = Library("org.typelevel", "kind-projector", V.kind_projector, LibraryType.Invariant)
       .more(LibSetting.Raw("cross CrossVersion.full"))

--- a/project/Deps.sc
+++ b/project/Deps.sc
@@ -102,7 +102,7 @@ object Izumi {
     final val scala_library = Library("org.scala-lang", "scala-library", Version.VExpr("scalaVersion.value"), LibraryType.Invariant)
     final val scala_reflect = Library("org.scala-lang", "scala-reflect", Version.VExpr("scalaVersion.value"), LibraryType.Invariant)
 
-    final val cglib_nodep = Library("cglib", "cglib-nodep", V.cglib_nodep, LibraryType.Invariant) in Scope.Compile.jvm
+    final val cglib_nodep = Library("cglib", "cglib-nodep", V.cglib_nodep, LibraryType.Invariant) in Scope.Compile.jvm()
 
     final val projector = Library("org.typelevel", "kind-projector", V.kind_projector, LibraryType.Invariant)
       .more(LibSetting.Raw("cross CrossVersion.full"))
@@ -128,7 +128,7 @@ object Izumi {
   import Deps._
 
   // DON'T REMOVE, these variables are read from CI build (build.sh)
-  final val scala212 = ScalaVersion("2.12.13")
+  final val scala212 = ScalaVersion("2.12.14-bin-SNAPSHOT")
   final val scala213 = ScalaVersion("2.13.6-bin-SNAPSHOT")
 
   object Groups {
@@ -227,7 +227,10 @@ object Izumi {
       final val sharedSettings = Defaults.SbtMetaOptions ++ outOfSource ++ Seq(
         "testOptions" in SettingScope.Test += """Tests.Argument("-oDF")""".raw,
         "scalacOptions" ++= Seq(
-          SettingKey(Some(scala212), None) := Defaults.Scala212Options,
+          SettingKey(Some(scala212), None) := Defaults.Scala212Options ++ Seq[Const](
+            "-Xsource:3",
+            "-P:kind-projector:underscore-placeholders",
+          ),
           SettingKey(Some(scala213), None) := (Defaults.Scala213Options ++ Seq[Const](
             "-Wunused:-synthetics",
             "-Xsource:3",

--- a/project/Deps.sc
+++ b/project/Deps.sc
@@ -104,8 +104,7 @@ object Izumi {
 
     final val cglib_nodep = Library("cglib", "cglib-nodep", V.cglib_nodep, LibraryType.Invariant) in Scope.Compile.jvm()
 
-    final val projector = Library("org.typelevel", "kind-projector", V.kind_projector, LibraryType.Invariant)
-      .more(LibSetting.Raw("cross CrossVersion.full"))
+    final val projector = Library("org.typelevel", "kind-projector_2.13.5", V.kind_projector, LibraryType.Invariant)
 
     final val fast_classpath_scanner = Library("io.github.classgraph", "classgraph", V.classgraph, LibraryType.Invariant) in Scope.Compile.jvm
     final val scala_java_time = Library("io.github.cquiroz", "scala-java-time", V.scala_java_time, LibraryType.Auto)
@@ -129,7 +128,7 @@ object Izumi {
 
   // DON'T REMOVE, these variables are read from CI build (build.sh)
   final val scala212 = ScalaVersion("2.12.14-bin-SNAPSHOT")
-  final val scala213 = ScalaVersion("2.13.6-bin-SNAPSHOT")
+  final val scala213 = ScalaVersion("2.13.6")
 
   object Groups {
     final val fundamentals = Set(Group("fundamentals"))

--- a/project/Deps.sc
+++ b/project/Deps.sc
@@ -582,6 +582,7 @@ object Izumi {
         depends = all.flatMap(_.artifacts).map(_.name in Scope.Compile.all).distinct,
         settings = Seq(
           "scalacOptions" -= "-Wconf:any:error",
+          "scalacOptions" -= "-Xsource:3",
           "coverageEnabled" := false,
           "skip" in SettingScope.Raw("publish") := true,
           "DocKeys.prefix" :=

--- a/project/Deps.sc
+++ b/project/Deps.sc
@@ -129,7 +129,7 @@ object Izumi {
 
   // DON'T REMOVE, these variables are read from CI build (build.sh)
   final val scala212 = ScalaVersion("2.12.13")
-  final val scala213 = ScalaVersion("2.13.5")
+  final val scala213 = ScalaVersion("2.13.6-bin-SNAPSHOT")
 
   object Groups {
     final val fundamentals = Set(Group("fundamentals"))

--- a/project/Deps.sc
+++ b/project/Deps.sc
@@ -231,6 +231,7 @@ object Izumi {
           SettingKey(Some(scala213), None) := (Defaults.Scala213Options ++ Seq[Const](
             "-Wunused:-synthetics",
             "-Xsource:3",
+            "-P:kind-projector:underscore-placeholders",
           )),
           SettingKey.Default := Const.EmptySeq,
         ),

--- a/project/Deps.sc
+++ b/project/Deps.sc
@@ -229,12 +229,14 @@ object Izumi {
         "scalacOptions" ++= Seq(
           SettingKey(Some(scala212), None) := Defaults.Scala212Options,
           SettingKey(Some(scala213), None) := (Defaults.Scala213Options ++ Seq[Const](
-            "-Wunused:-synthetics"
+            "-Wunused:-synthetics",
+            "-Xsource:3",
           )),
           SettingKey.Default := Const.EmptySeq,
         ),
         "scalacOptions" += "-Wconf:msg=nowarn:silent",
         "scalacOptions" += "-Wconf:msg=parameter.value.x\\\\$4.in.anonymous.function.is.never.used:silent",
+        "scalacOptions" += "-Wconf:msg=package.object.inheritance:silent",
         "scalacOptions" in SettingScope.Raw("Compile / sbt.Keys.doc") -= "-Wconf:any:error",
         "scalacOptions" ++= Seq(
           """s"-Xmacro-settings:scalatest-version=${V.scalatest}"""".raw,

--- a/project/Deps.sc
+++ b/project/Deps.sc
@@ -582,7 +582,24 @@ object Izumi {
         depends = all.flatMap(_.artifacts).map(_.name in Scope.Compile.all).distinct,
         settings = Seq(
           "scalacOptions" -= "-Wconf:any:error",
+          //  Disable `-Xsource:3` in docs due to mdoc failures:
+          //
+          //  ```
+          //  error: basics.md:97 (mdoc generated code) could not find implicit value for parameter t: pprint.TPrint[zio.ZIO[zio.Has[zio.console.Console.Service],Throwable,β$0$]]
+          //  val injector: Injector[RIO[Console, _]] = Injector[RIO[Console, _]](); $doc.binder(injector, 2, 4, 2, 12)
+          //                                                                                    ^
+          //
+          //  error: basics.md:109 (mdoc generated code) could not find implicit value for parameter t: pprint.TPrint[zio.ZIO[zio.Has[zio.console.Console.Service],Throwable,β$0$]]
+          //  val resource = injector.produce(plan); $doc.binder(resource, 4, 4, 4, 12)
+          //                                                    ^
+          //
+          //  error: basics.md:1359 (mdoc generated code) could not find implicit value for parameter t: pprint.TPrint[zio.ZIO[zio.Has[zio.console.Console.Service],Throwable,β$9$]]
+          //  val res51 = chooseInterpreters(true); $doc.binder(res51, 26, 0, 26, 24)
+          //  ```
           "scalacOptions" -= "-Xsource:3",
+          // enable for unidoc
+          "scalacOptions" in SettingScope.Raw("Compile / sbt.Keys.doc") += "-Xsource:3",
+          //
           "coverageEnabled" := false,
           "skip" in SettingScope.Raw("publish") := true,
           "DocKeys.prefix" :=

--- a/project/Deps.sc
+++ b/project/Deps.sc
@@ -104,7 +104,8 @@ object Izumi {
 
     final val cglib_nodep = Library("cglib", "cglib-nodep", V.cglib_nodep, LibraryType.Invariant) in Scope.Compile.jvm()
 
-    final val projector = Library("org.typelevel", "kind-projector_2.13.5", V.kind_projector, LibraryType.Invariant)
+    final val projector = Library("org.typelevel", "kind-projector", V.kind_projector, LibraryType.Invariant)
+      .more(LibSetting.Raw("cross CrossVersion.full"))
 
     final val fast_classpath_scanner = Library("io.github.classgraph", "classgraph", V.classgraph, LibraryType.Invariant) in Scope.Compile.jvm
     final val scala_java_time = Library("io.github.cquiroz", "scala-java-time", V.scala_java_time, LibraryType.Auto)
@@ -127,7 +128,7 @@ object Izumi {
   import Deps._
 
   // DON'T REMOVE, these variables are read from CI build (build.sh)
-  final val scala212 = ScalaVersion("2.12.14-bin-SNAPSHOT")
+  final val scala212 = ScalaVersion("2.12.14")
   final val scala213 = ScalaVersion("2.13.6")
 
   object Groups {

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -5,7 +5,7 @@ object V {
   // foundation
   val collection_compat = "2.4.4"
 
-  val kind_projector = "0.12.1-SNAPSHOT"
+  val kind_projector = "0.13.0"
 
   val scalatest = "3.2.9"
 

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -5,7 +5,7 @@ object V {
   // foundation
   val collection_compat = "2.4.4"
 
-  val kind_projector = "0.11.3"
+  val kind_projector = "0.12.1-SNAPSHOT"
 
   val scalatest = "3.2.9"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,14 @@
+// https://www.scala-js.org/
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % PV.scala_js_version)
+
+// https://github.com/portable-scala/sbt-crossproject
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % PV.crossproject_version)
+
+// https://scalacenter.github.io/scalajs-bundler/
+addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % PV.scalajs_bundler_version)
+
+// https://github.com/scala-js/jsdependencies
+addSbtPlugin("org.scala-js" % "sbt-jsdependencies" % "1.0.2")
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,14 +1,3 @@
-// https://www.scala-js.org/
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % PV.scala_js_version)
-
-// https://github.com/portable-scala/sbt-crossproject
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % PV.crossproject_version)
-
-// https://scalacenter.github.io/scalajs-bundler/
-addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % PV.scalajs_bundler_version)
-
-// https://github.com/scala-js/jsdependencies
-addSbtPlugin("org.scala-js" % "sbt-jsdependencies" % "1.0.2")
 
 ////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
To build you would need to `publishLocal` the following:

- Scala 2.13.6 <strike>[scalac from branch "7mind"](https://github.com/7mind/scala/tree/7mind) for 2.13</strike>
- Scala 2.12.14 <strike>[scalac from branch "backport/underscore-changes"](https://github.com/7mind/scala/tree/backport/underscore-changes) for 2.12</strike>
- kind-projector 0.13.0 <strike>[kind-projector from branch "feature/Yunderscore-placeholders-wip"](https://github.com/7mind/kind-projector/tree/feature/Yunderscore-placeholders-wip)</strike>

Related PRs: 

- Scala 2.13: https://github.com/scala/scala/pull/9605 https://github.com/scala/scala/pull/9614
- Scala 2.12: https://github.com/scala/scala/pull/9620
- kind-projector: https://github.com/typelevel/kind-projector/pull/188  