### PR TITLE
Fix unrunnable DefaultModule being created for ZIO when `R` != `Any`

### DIFF
--- a/distage/distage-core/.jvm/src/main/scala/izumi/distage/modules/platform/ZIOPlatformDependentSupportModule.scala
+++ b/distage/distage-core/.jvm/src/main/scala/izumi/distage/modules/platform/ZIOPlatformDependentSupportModule.scala
@@ -20,7 +20,7 @@ import scala.concurrent.ExecutionContext
 private[modules] trait ZIOPlatformDependentSupportModule extends ModuleDef {
   make[ZEnv].from(Has.allOf(_: Clock.Service, _: Console.Service, _: System.Service, _: Random.Service, _: Blocking.Service))
 
-  make[UnsafeRun3[ZIO]].using[ZIORunner]
+  make[UnsafeRun3[ZIO]].using[ZIORunner[Any]]
 
   make[BlockingIO3[ZIO]].from(BlockingIOInstances.BlockingZIO3FromBlocking(_: zio.blocking.Blocking.Service))
   make[BlockingIO2[IO]].from {
@@ -35,7 +35,7 @@ private[modules] trait ZIOPlatformDependentSupportModule extends ModuleDef {
       }
   }
 
-  make[ZIORunner].from {
+  make[ZIORunner[Any]].from {
     (cpuPool: ThreadPoolExecutor @Id("zio.cpu"), handler: FailureHandler, tracingConfig: TracingConfig) =>
       UnsafeRun2.createZIO(
         cpuPool = cpuPool,
@@ -45,7 +45,7 @@ private[modules] trait ZIOPlatformDependentSupportModule extends ModuleDef {
   }
   make[TracingConfig].fromValue(TracingConfig.enabled)
   make[FailureHandler].fromValue(FailureHandler.Default)
-  make[Runtime[Any]].from((_: ZIORunner).runtime)
+  make[Runtime[Any]].from((_: ZIORunner[Any]).runtime)
   make[Platform].from((_: Runtime[Any]).platform)
 
   make[ThreadPoolExecutor].named("zio.cpu").fromResource {

--- a/distage/distage-core/src/main/scala/izumi/distage/modules/DefaultModule.scala
+++ b/distage/distage-core/src/main/scala/izumi/distage/modules/DefaultModule.scala
@@ -161,11 +161,6 @@ sealed trait LowPriorityDefaultModulesInstances5 extends LowPriorityDefaultModul
 
 sealed trait LowPriorityDefaultModulesInstances6 {
   implicit final def fromQuasiIO[F[_]: TagK: QuasiIO: QuasiAsync: QuasiIORunner]: DefaultModule[F] = {
-    DefaultModule(new ModuleDef {
-      addImplicit[QuasiIO[F]]
-      addImplicit[QuasiAsync[F]]
-      addImplicit[QuasiApplicative[F]]
-      addImplicit[QuasiIORunner[F]]
-    })
+    DefaultModule(AnyQuasiIOSupportModule.withImplicits[F])
   }
 }

--- a/distage/distage-core/src/main/scala/izumi/distage/modules/package.scala
+++ b/distage/distage-core/src/main/scala/izumi/distage/modules/package.scala
@@ -7,13 +7,15 @@ package object modules {
   object DefaultModule2 {
     @inline def apply[F[_, _]](module: Module): DefaultModule2[F] = DefaultModule(module)
 
-    @inline def apply[F[_, _]](implicit modules: DefaultModule2[F], d: DummyImplicit): Module = modules.module
+    // summoner
+    @inline def apply[F[_, _]](implicit defaultModule: DefaultModule2[F], d: DummyImplicit): Module = defaultModule.module
   }
 
   type DefaultModule3[F[_, _, _]] = DefaultModule[F[Any, Throwable, _]]
   object DefaultModule3 {
     @inline def apply[F[_, _, _]](module: Module): DefaultModule3[F] = DefaultModule(module)
 
-    @inline def apply[F[_, _, _]](implicit modules: DefaultModule3[F], d: DummyImplicit): Module = modules.module
+    // summoner
+    @inline def apply[F[_, _, _]](implicit defaultModule: DefaultModule3[F], d: DummyImplicit): Module = defaultModule.module
   }
 }

--- a/distage/distage-core/src/main/scala/izumi/distage/modules/support/AnyBIO2SupportModule.scala
+++ b/distage/distage-core/src/main/scala/izumi/distage/modules/support/AnyBIO2SupportModule.scala
@@ -19,7 +19,7 @@ import izumi.reflect.TagKK
   *
   * Depends on `make[Async2[F]]`, `make[Temporal2[F]]`, `make[UnsafeRun2[F]]`
   */
-class AnyBIO2SupportModule[F[+_, +_]: TagKK] extends ModuleDef {
+abstract class AnyBIO2SupportModule[F[+_, +_]: TagKK] extends ModuleDef {
   include(BIO2InstancesModule[F])
 
   make[QuasiIORunner2[F]]
@@ -46,8 +46,9 @@ class AnyBIO2SupportModule[F[+_, +_]: TagKK] extends ModuleDef {
   }
 }
 
-object AnyBIO2SupportModule extends ModuleDef {
-  @inline def apply[F[+_, +_]: TagKK]: AnyBIO2SupportModule[F] = new AnyBIO2SupportModule
+object AnyBIO2SupportModule {
+  // FIXME remove apply()
+  @inline def asIs[F[+_, +_]: TagKK]: AnyBIO2SupportModule[F] = new AnyBIO2SupportModule {}
 
   /**
     * Make [[AnyBIO2SupportModule]], binding the required dependencies in place to values from implicit scope
@@ -55,9 +56,7 @@ object AnyBIO2SupportModule extends ModuleDef {
     * `make[Fork2[F]]` and `make[Primitives2[F]]` are not required by [[AnyBIO2SupportModule]]
     * but are added for completeness
     */
-  def withImplicits[F[+_, +_]: TagKK: Async2: Temporal2: UnsafeRun2: Fork2: Primitives2: PrimitivesM2: Scheduler2]: ModuleDef = new ModuleDef {
-    include(AnyBIO2SupportModule[F])
-
+  def withImplicits[F[+_, +_]: TagKK: Async2: Temporal2: UnsafeRun2: Fork2: Primitives2: PrimitivesM2: Scheduler2]: ModuleDef = new AnyBIO2SupportModule[F] {
     addImplicit[Async2[F]]
     addImplicit[Fork2[F]]
     addImplicit[Temporal2[F]]

--- a/distage/distage-core/src/main/scala/izumi/distage/modules/support/AnyBIO3SupportModule.scala
+++ b/distage/distage-core/src/main/scala/izumi/distage/modules/support/AnyBIO3SupportModule.scala
@@ -19,9 +19,9 @@ import scala.annotation.unchecked.{uncheckedVariance => v}
   *
   * Depends on `make[Async3[F]]`, `make[Temporal3[F]]`, `make[Local3[F]]`, `make[Fork3[F]]` & `make[UnsafeRun3[F]]`
   */
-class AnyBIO3SupportModule[F[-_, +_, +_]: TagK3](implicit tagBIO: TagKK[F[Any, +_, +_]]) extends ModuleDef {
+abstract class AnyBIO3SupportModule[F[-_, +_, +_]: TagK3](implicit tagBIO: TagKK[F[Any, +_, +_]]) extends ModuleDef {
   // QuasiIO & bifunctor bio instances
-  include(AnyBIO2SupportModule[F[Any, +_, +_]])
+  include(AnyBIO2SupportModule.asIs[F[Any, +_, +_]])
   // trifunctor bio instances
   include(BIO3InstancesModule[F])
   addConverted3To2[F[Any, +_, +_]]
@@ -43,8 +43,8 @@ class AnyBIO3SupportModule[F[-_, +_, +_]: TagK3](implicit tagBIO: TagKK[F[Any, +
   }
 }
 
-object AnyBIO3SupportModule extends App with ModuleDef {
-  @inline def apply[F[-_, +_, +_]: TagK3](implicit tagBIO: TagKK[F[Any, +_, +_]]): AnyBIO3SupportModule[F] = new AnyBIO3SupportModule
+object AnyBIO3SupportModule {
+  @inline def apply[F[-_, +_, +_]: TagK3](implicit tagBIO: TagKK[F[Any, +_, +_]]): AnyBIO3SupportModule[F] = new AnyBIO3SupportModule {}
 
   /**
     * Make [[AnyBIO3SupportModule]], binding the required dependencies in place to values from implicit scope
@@ -54,32 +54,29 @@ object AnyBIO3SupportModule extends App with ModuleDef {
     */
   def withImplicits[F[-_, +_, +_]: TagK3: Async3: Temporal3: Local3: UnsafeRun3: Fork3: Primitives3: PrimitivesM3: Scheduler3](
     implicit tagBIO: TagKK[F[Any, +_, +_]]
-  ): ModuleDef =
-    new ModuleDef {
-      include(AnyBIO3SupportModule[F])
+  ): ModuleDef = new AnyBIO3SupportModule[F] {
+    addImplicit[Async3[F]]
+    addImplicit[Temporal3[F]]
+    addImplicit[Local3[F]]
+    addImplicit[Fork3[F]]
+    addImplicit[Primitives3[F]]
+    addImplicit[PrimitivesM3[F]]
+    addImplicit[UnsafeRun3[F]]
+    addImplicit[Scheduler3[F]]
 
-      addImplicit[Async3[F]]
-      addImplicit[Temporal3[F]]
-      addImplicit[Local3[F]]
-      addImplicit[Fork3[F]]
-      addImplicit[Primitives3[F]]
-      addImplicit[PrimitivesM3[F]]
-      addImplicit[UnsafeRun3[F]]
-      addImplicit[Scheduler3[F]]
-
-      // no corresponding bifunctor (`F[Any, +_, +_]`) instances need to be added for these types because they already match
-      private[this] def aliasingCheck(): Unit = {
-        lazy val _ = aliasingCheck()
-        implicitly[Scheduler3[F] =:= Scheduler2[F[Any, +_, +_]]]
-        implicitly[UnsafeRun3[F] =:= UnsafeRun2[F[Any, +_, +_]]]
-        implicitly[Primitives3[F] =:= Primitives2[F[Any, +_, +_]]]
-        implicitly[PrimitivesM3[F] =:= PrimitivesM2[F[Any, +_, +_]]]
-        implicitly[SyncSafe3[F] =:= SyncSafe2[F[Any, +_, +_]]]
-        implicitly[QuasiIORunner3[F] =:= QuasiIORunner2[F[Any, +_, +_]]]
-        implicitly[QuasiIO3[F] =:= QuasiIO2[F[Any, +_, +_]]]
-        implicitly[QuasiApplicative3[F] =:= QuasiApplicative2[F[Any, +_, +_]]]
-        implicitly[QuasiAsync3[F] =:= QuasiAsync2[F[Any, +_, +_]]]
-        ()
-      }
+    // no corresponding bifunctor (`F[Any, +_, +_]`) instances need to be added for these types because they already match
+    private[this] def aliasingCheck(): Unit = {
+      lazy val _ = aliasingCheck()
+      implicitly[Scheduler3[F] =:= Scheduler2[F[Any, +_, +_]]]
+      implicitly[UnsafeRun3[F] =:= UnsafeRun2[F[Any, +_, +_]]]
+      implicitly[Primitives3[F] =:= Primitives2[F[Any, +_, +_]]]
+      implicitly[PrimitivesM3[F] =:= PrimitivesM2[F[Any, +_, +_]]]
+      implicitly[SyncSafe3[F] =:= SyncSafe2[F[Any, +_, +_]]]
+      implicitly[QuasiIORunner3[F] =:= QuasiIORunner2[F[Any, +_, +_]]]
+      implicitly[QuasiIO3[F] =:= QuasiIO2[F[Any, +_, +_]]]
+      implicitly[QuasiApplicative3[F] =:= QuasiApplicative2[F[Any, +_, +_]]]
+      implicitly[QuasiAsync3[F] =:= QuasiAsync2[F[Any, +_, +_]]]
+      ()
     }
+  }
 }

--- a/distage/distage-core/src/main/scala/izumi/distage/modules/support/AnyQuasiIOSupportModule.scala
+++ b/distage/distage-core/src/main/scala/izumi/distage/modules/support/AnyQuasiIOSupportModule.scala
@@ -1,0 +1,14 @@
+package izumi.distage.modules.support
+
+import izumi.reflect.TagK
+import izumi.distage.model.definition.{Module, ModuleDef}
+import izumi.distage.model.effect.{QuasiApplicative, QuasiAsync, QuasiIO, QuasiIORunner}
+
+object AnyQuasiIOSupportModule {
+  def withImplicits[F[_]: TagK: QuasiIO: QuasiAsync: QuasiIORunner]: Module = new ModuleDef {
+    addImplicit[QuasiIO[F]]
+    addImplicit[QuasiAsync[F]]
+    addImplicit[QuasiApplicative[F]]
+    addImplicit[QuasiIORunner[F]]
+  }
+}

--- a/distage/distage-core/src/main/scala/izumi/distage/modules/support/CatsIOSupportModule.scala
+++ b/distage/distage-core/src/main/scala/izumi/distage/modules/support/CatsIOSupportModule.scala
@@ -7,8 +7,6 @@ import izumi.distage.modules.platform.CatsIOPlatformDependentSupportModule
 
 import scala.concurrent.ExecutionContext
 
-object CatsIOSupportModule extends CatsIOSupportModule
-
 /**
   * `cats.effect.IO` effect type support for `distage` resources, effects, roles & tests
   *
@@ -34,6 +32,8 @@ trait CatsIOSupportModule extends ModuleDef with CatsIOPlatformDependentSupportM
   make[ExecutionContext].named("cpu").from((_: PublicIOApp).executionContext)
   make[PublicIOApp]
 }
+
+object CatsIOSupportModule extends CatsIOSupportModule
 
 private[support] trait PublicIOApp extends IOApp {
   override def contextShift: ContextShift[IO] = super.contextShift

--- a/distage/distage-core/src/main/scala/izumi/distage/modules/support/MonixBIOSupportModule.scala
+++ b/distage/distage-core/src/main/scala/izumi/distage/modules/support/MonixBIOSupportModule.scala
@@ -12,8 +12,6 @@ import monix.execution.Scheduler
 
 import scala.concurrent.ExecutionContext
 
-object MonixBIOSupportModule extends MonixBIOSupportModule
-
 /**
   * `monix.bio.IO` effect type support for `distage` resources, effects, roles & tests
   *
@@ -33,7 +31,7 @@ object MonixBIOSupportModule extends MonixBIOSupportModule
   */
 trait MonixBIOSupportModule extends ModuleDef with MonixBIOPlatformDependentSupportModule {
   // QuasiIO & BIO instances
-  include(AnyBIO2SupportModule[IO])
+  include(AnyBIO2SupportModule.asIs[IO])
   // cats-effect instances
   include(CatsEffectInstancesModule[Task])
 
@@ -61,3 +59,5 @@ trait MonixBIOSupportModule extends ModuleDef with MonixBIOPlatformDependentSupp
   addImplicit[Timer[Task]]
   addImplicit[Timer[UIO]]
 }
+
+object MonixBIOSupportModule extends MonixBIOSupportModule

--- a/distage/distage-core/src/main/scala/izumi/distage/modules/support/MonixSupportModule.scala
+++ b/distage/distage-core/src/main/scala/izumi/distage/modules/support/MonixSupportModule.scala
@@ -9,8 +9,6 @@ import monix.execution.Scheduler
 
 import scala.concurrent.ExecutionContext
 
-object MonixSupportModule extends MonixSupportModule
-
 /**
   * `monix.eval.Task` effect type support for `distage` resources, effects, roles & tests
   *
@@ -42,3 +40,5 @@ trait MonixSupportModule extends ModuleDef with MonixPlatformDependentSupportMod
   addImplicit[ContextShift[Task]]
   addImplicit[Timer[Task]]
 }
+
+object MonixSupportModule extends MonixSupportModule

--- a/distage/distage-core/src/main/scala/izumi/distage/modules/support/ZIOSupportModule.scala
+++ b/distage/distage-core/src/main/scala/izumi/distage/modules/support/ZIOSupportModule.scala
@@ -6,8 +6,6 @@ import izumi.functional.bio._
 import izumi.functional.bio.retry.Scheduler3
 import zio.{Has, IO, ZEnv, ZIO}
 
-object ZIOSupportModule extends ZIOSupportModule
-
 /**
   * `zio.ZIO` effect type support for `distage` resources, effects, roles & tests
   *
@@ -62,3 +60,5 @@ trait ZIOSupportModule extends ModuleDef with ZIOPlatformDependentSupportModule 
   make[zio.random.Random].from(Has(_: zio.random.Random.Service))
   make[zio.random.Random.Service].from(zio.random.Random.Service.live)
 }
+
+object ZIOSupportModule extends ZIOSupportModule

--- a/distage/distage-framework/src/main/scala/izumi/distage/roles/RoleAppMain.scala
+++ b/distage/distage-framework/src/main/scala/izumi/distage/roles/RoleAppMain.scala
@@ -75,6 +75,8 @@ abstract class RoleAppMain[F[_]](
   /** Roles always enabled in this [[RoleAppMain]] */
   protected def requiredRoles(@unused argv: ArgV): Vector[RawRoleParams] = Vector.empty
 
+  protected def earlyFailureHandler(@unused args: ArgV): AppFailureHandler = AppFailureHandler.TerminatingHandler
+
   def main(args: Array[String]): Unit = {
     val argv = ArgV(args)
     try {
@@ -112,10 +114,6 @@ abstract class RoleAppMain[F[_]](
     izumi.distage.framework.PlanCheck.assertAppCompileTime[this.type, Cfg](this, cfg)
   }
 
-  override final def roleAppBootModule: Module = {
-    roleAppBootModule(ArgV.empty)
-  }
-
   def roleAppBootModule(argv: ArgV): Module = {
     val mainModule = roleAppBootModule(argv, RequiredRoles(requiredRoles(argv)))
     val overrideModule = roleAppBootOverrides(argv)
@@ -134,9 +132,10 @@ abstract class RoleAppMain[F[_]](
     )
   }
 
-  protected def earlyFailureHandler(@unused args: ArgV): AppFailureHandler = {
-    AppFailureHandler.TerminatingHandler
+  override final def roleAppBootModule: Module = {
+    roleAppBootModule(ArgV.empty)
   }
+
 }
 
 object RoleAppMain {

--- a/distage/distage-framework/src/main/scala/izumi/distage/roles/launcher/ActivationParser.scala
+++ b/distage/distage-framework/src/main/scala/izumi/distage/roles/launcher/ActivationParser.scala
@@ -10,7 +10,13 @@ import izumi.logstage.api.IzLogger
 
 /**
   * Note, besides replacing this class, activation parsing strategy can also be changed by using bootstrap modules or plugins
-  * and adding an override for `make[Activation].named("roleapp")` to [[izumi.distage.roles.RoleAppMain#appModuleOverrides]]
+  * or by adding an override for `make[Activation].named("roleapp")` to [[izumi.distage.roles.RoleAppMain#roleAppBootOverrides]]:
+  *
+  * {{{
+  * override def roleAppBootOverrides(argv: ArgV): Module = new ModuleDef {
+  *   modify[Activation].named("roleapp")(_ ++ Activation(Repo -> Repo.Dummy, ...))
+  * }
+  * }}}
   */
 trait ActivationParser {
   def parseActivation(): Activation
@@ -25,7 +31,7 @@ object ActivationParser {
     config: AppConfig,
     activationInfo: ActivationInfo,
     defaultActivations: Activation @Id("default"),
-    requiredActivations: Activation @Id("additional"),
+    overridingActivations: Activation @Id("additional"), // obsolete after mutators were added
     logger: IzLogger,
     warnUnsetActivations: Boolean @Id("distage.roles.activation.warn-unset"),
   ) extends ActivationParser {
@@ -39,7 +45,7 @@ object ActivationParser {
       } else Iterable.empty
       val configActivations = parser.parseActivation(configChoices, activationInfo)
 
-      val resultActivation = defaultActivations ++ requiredActivations ++ configActivations ++ cmdActivations // commandline choices override values in config
+      val resultActivation = defaultActivations ++ overridingActivations ++ configActivations ++ cmdActivations // commandline choices override values in config
       val unsetActivations = activationInfo.availableChoices.keySet diff resultActivation.activeChoices.keySet
       if (unsetActivations.nonEmpty && warnUnsetActivations && syspropWarnUnsetActivations) {
         logger.raw.warn {
@@ -47,21 +53,18 @@ object ActivationParser {
              |
              |  - ${activationInfo.narrow(unsetActivations).formattedChoices}
              |
-             |Consider adding default choices for these to your `Activation @Id("additional")` component.
+             |Consider adding default choices for these to your `Activation @Id("default")` component.
              |
-             |You may do this by adding a binding for it in your`RoleAppMain#appModuleOverrides`, as in:
-             |  ```scala
-             |  override def appModuleOverrides(argv: ArgV): Module = new ModuleDef {
-             |    make[Activation].named("additional").from {
-             |      Activation(
-             |        Repo -> Repo.Dummy,
-             |        ...
-             |      )
-             |    }
-             |  }
-             |  ```
+             |You may do this by adding a modifier for it in your`RoleAppMain#roleAppBootOverrides`, as in:
+             |
+             |```scala
+             |override def roleAppBootOverrides(argv: ArgV): Module = new ModuleDef {
+             |  modify[Activation].named("default")(_ ++ Activation(Repo -> Repo.Dummy, ...))
+             |}
+             |```
              |
              |You may disable this warning by setting system property `-D${DebugProperties.`izumi.distage.roles.activation.warn-unset`.name}=false`
+             |Or setting component `make[Boolean].named("distage.roles.activation.warn-unset").from(false)` in `RoleAppMain#roleAppBootOverrides`
              |""".stripMargin
         }
       }

--- a/distage/distage-framework/src/test/scala/izumi/distage/roles/test/RoleAppTest.scala
+++ b/distage/distage-framework/src/test/scala/izumi/distage/roles/test/RoleAppTest.scala
@@ -4,30 +4,37 @@ import java.io.File
 import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.{Files, Paths}
 import java.util.UUID
-
 import cats.effect.IO
 import com.github.pshirshov.test.plugins.{StaticTestMainLogIO2, StaticTestRole}
 import com.github.pshirshov.test3.plugins.Fixture3
 import com.typesafe.config.ConfigFactory
 import distage.plugins.{PluginBase, PluginDef}
-import distage.{DIKey, Injector, Locator, LocatorRef}
+import distage.{DIKey, Injector, Locator, LocatorRef, ModuleDef}
 import izumi.distage.framework.config.PlanningOptions
 import izumi.distage.framework.model.IntegrationCheck
 import izumi.distage.framework.services.{IntegrationChecker, RoleAppPlanner}
-import izumi.distage.model.PlannerInput
+import izumi.distage.model.{PlannerInput, definition}
 import izumi.distage.model.definition.{Activation, BootstrapModule, Lifecycle}
 import izumi.distage.modules.DefaultModule
+import izumi.distage.modules.support.AnyCatsEffectSupportModule
 import izumi.distage.plugins.PluginConfig
-import izumi.distage.roles.DebugProperties
-import izumi.distage.roles.test.fixtures.Fixture._
-import izumi.distage.roles.test.fixtures._
+import izumi.distage.roles.{DebugProperties, RoleAppMain}
+import izumi.distage.roles.test.fixtures.Fixture.*
+import izumi.distage.roles.test.fixtures.*
 import izumi.distage.roles.test.fixtures.roles.TestRole00
+import izumi.functional.bio.Exit.ZIOExit
+import izumi.functional.bio.{Exit, TypedError, UnsafeRun2}
+import izumi.functional.bio.UnsafeRun2.InterruptAction
 import izumi.fundamentals.platform.functional.Identity
 import izumi.fundamentals.platform.resources.ArtifactVersion
 import izumi.logstage.api.IzLogger
 import org.scalatest.wordspec.AnyWordSpec
+import zio.{RIO, Runtime, ZEnv, ZIO}
+import zio.clock.Clock
+import zio.internal.Platform
 
-import scala.jdk.CollectionConverters._
+import scala.concurrent.Future
+import scala.jdk.CollectionConverters.*
 
 class RoleAppTest extends AnyWordSpec with WithProperties {
   private final val targetPath = "target/configwriter"
@@ -392,6 +399,7 @@ class RoleAppTest extends AnyWordSpec with WithProperties {
         val checkTestGoodResouce = getClass.getResource("/check-test-good.conf").getPath
         new StaticTestMainLogIO2[zio.IO].main(Array("-ll", logLevel, "-c", checkTestGoodResouce, ":" + StaticTestRole.id))
         new StaticTestMainLogIO2[monix.bio.IO].main(Array("-ll", logLevel, "-c", checkTestGoodResouce, ":" + StaticTestRole.id))
+        new StaticTestMainLogIO2[zio.ZIO[zio.ZEnv, +_, +_]].main(Array("-ll", logLevel, "-c", checkTestGoodResouce, ":" + StaticTestRole.id))
       }
     }
   }

--- a/distage/distage-testkit-scalatest/src/test/scala/izumi/distage/testkit/distagesuite/fixtures/Fixtures.scala
+++ b/distage/distage-testkit-scalatest/src/test/scala/izumi/distage/testkit/distagesuite/fixtures/Fixtures.scala
@@ -18,6 +18,7 @@ import scala.collection.mutable
 object MockAppCatsIOPlugin extends MockAppPlugin[CIO]
 object MockAppZioPlugin extends MockAppPlugin[Task]
 object MockAppIdPlugin extends MockAppPlugin[Identity]
+object MockAppZioRPlugin extends MockAppPlugin[zio.ZIO[zio.ZEnv, Throwable, +_]]
 
 abstract class MockAppPlugin[F[_]: TagK] extends PluginDef {
   make[MockPostgresDriver[F]]

--- a/fundamentals/fundamentals-collections/src/main/scala/izumi/fundamentals/collections/nonempty/NonEmptyMap.scala
+++ b/fundamentals/fundamentals-collections/src/main/scala/izumi/fundamentals/collections/nonempty/NonEmptyMap.scala
@@ -760,7 +760,7 @@ final class NonEmptyMap[K, +V] private (val toMap: Map[K, V]) extends AnyVal {
     *
     * @return an <code>Iterable</code> containing all entries of this <code>NonEmptyMap</code>.
     */
-  def toIterable: Iterable[(K, V)] = toMap.toIterable
+  def toIterable: Iterable[(K, V)] = toMap
 
   /**
     * Returns an <code>Iterator</code> over the entries in this <code>NonEmptyMap</code>.

--- a/fundamentals/fundamentals-collections/src/main/scala/izumi/fundamentals/collections/nonempty/NonEmptyString.scala
+++ b/fundamentals/fundamentals-collections/src/main/scala/izumi/fundamentals/collections/nonempty/NonEmptyString.scala
@@ -1323,7 +1323,7 @@ final class NonEmptyString private (val theString: String) extends AnyVal {
     *
     * @return an <code>Iterable</code> containing all characters of this <code>NonEmptyString</code>.
     */
-  def toIterable: Iterable[Char] = theString.toIterable
+  def toIterable: Iterable[Char] = theString
 
   /**
     * Returns an <code>Iterator</code> over the elements in this <code>NonEmptyString</code>.


### PR DESCRIPTION
If you try to make a Launcher with non-Any ZIO effect type currently, e.g. 

```scala
object Launcher extends RoleAppMain.LauncherBIO2[ZIO[zio.ZEnv, +_, +_]]
```

Your app will fail to start with errors such as:

```
  [!] Instance is not available in the object graph: {type.izumi.distage.model.effect.QuasiIO[=λ %1 → ZIO[-{Has[=package::System::Service] & Has[=package::Clock::Service] & Has[=package::Random::Service] & Has[=package::Blocking::Service] & Has[=package::Console::Service]},+Throwable,+1]]}.
      Required by refs: ø
  [!] Instance is not available in the object graph: {type.izumi.distage.model.effect.QuasiAsync[=λ %1 → ZIO[-{Has[=package::System::Service] & Has[=package::Clock::Service] & Has[=package::Random::Service] & Has[=package::Blocking::Service] & Has[=package::Console::Service]},+Throwable,+1]]}.
      Required by refs: ø
  [!] Instance is not available in the object graph: {type.izumi.distage.model.effect.QuasiIORunner[=λ %1 → ZIO[-{Has[=package::System::Service] & Has[=package::Clock::Service] & Has[=package::Random::Service] & Has[=package::Blocking::Service] & Has[=package::Console::Service]},+Throwable,+1]]}.
      Required by refs: ø
```