### PR TITLE
Add `QuasiIO#tailRecM`, fix stackoverflow with Identity in a pathological nested case

### DIFF
--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/Binding.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/Binding.scala
@@ -4,7 +4,7 @@ import izumi.distage.constructors.AnyConstructor
 import izumi.distage.model.definition.Binding.GroupingKey
 import izumi.distage.model.plan.repr.{BindingFormatter, KeyFormatter}
 import izumi.distage.model.providers.Functoid
-import izumi.distage.model.reflection._
+import izumi.distage.model.reflection.*
 import izumi.fundamentals.platform.language.SourceFilePosition
 import izumi.reflect.Tag
 
@@ -33,8 +33,8 @@ sealed trait Binding {
 
 object Binding {
 
-  sealed trait GroupingKey {
-    override final lazy val hashCode: Int = scala.util.hashing.MurmurHash3.productHash(this.asInstanceOf[Product])
+  sealed abstract class GroupingKey extends Product {
+    override final lazy val hashCode: Int = scala.util.hashing.MurmurHash3.productHash(this)
   }
   object GroupingKey {
     final case class KeyImpl(key: DIKey, impl: ImplDef) extends GroupingKey

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/ImplDef.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/ImplDef.scala
@@ -3,11 +3,11 @@ package izumi.distage.model.definition
 import izumi.distage.model.plan.repr.{BindingFormatter, KeyFormatter}
 import izumi.distage.model.reflection.{DIKey, Provider, SafeType}
 
-sealed trait ImplDef {
+sealed abstract class ImplDef extends Product {
   def implType: SafeType
 
   override final def toString: String = BindingFormatter(KeyFormatter.Full).formatImplDef(this)
-  override final lazy val hashCode: Int = scala.util.hashing.MurmurHash3.productHash(this.asInstanceOf[Product])
+  override final lazy val hashCode: Int = scala.util.hashing.MurmurHash3.productHash(this)
 }
 
 object ImplDef {

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/ModuleBase.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/ModuleBase.scala
@@ -14,7 +14,7 @@ trait ModuleBase {
   final def keys: Set[DIKey] = keysIterator.toSet
   def keysIterator: Iterator[DIKey] = iterator.map(_.key)
 
-  override final def hashCode(): Int = bindings.hashCode()
+  override final lazy val hashCode: Int = bindings.hashCode()
   override final def equals(obj: Any): Boolean = obj match {
     case m: ModuleBase =>
       m.bindings == this.bindings
@@ -163,7 +163,7 @@ object ModuleBase extends ModuleBaseLowPriorityInstances {
     import cats.instances.set.*
     new PartialOrder[T] with Hash[T] {
       override def partialCompare(x: T, y: T): Double = PartialOrder[Set[Binding]].partialCompare(x.bindings, y.bindings)
-      override def hash(x: T): Int = x.hashCode()
+      override def hash(x: T): Int = x.hashCode
       override def eqv(x: T, y: T): Boolean = x == y
     }.asInstanceOf[K[T]]
   }

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/conflicts/semigraph.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/conflicts/semigraph.scala
@@ -2,14 +2,22 @@ package izumi.distage.model.definition.conflicts
 
 import izumi.distage.model.planning.AxisPoint
 
-final case class Node[N, V](deps: Set[N], meta: V)
+import scala.util.hashing.MurmurHash3
+
+final case class Node[N, V](deps: Set[N], meta: V) {
+  override lazy val hashCode: Int = MurmurHash3.productHash(this)
+}
 
 final case class Annotated[N](key: N, mut: Option[Int], axis: Set[AxisPoint]) {
   def withoutAxis: MutSel[N] = MutSel(key, mut)
   def isMutator: Boolean = mut.isDefined
+
+  override lazy val hashCode: Int = MurmurHash3.productHash(this)
 }
 
 final case class MutSel[N](key: N, mut: Option[Int]) {
   def isMutator: Boolean = mut.isDefined
   def asString: String = s"$key${mut.fold("")(i => s":$i")}"
+
+  override lazy val hashCode: Int = MurmurHash3.productHash(this)
 }

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/plan/ExecutableOp.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/plan/ExecutableOp.scala
@@ -10,13 +10,15 @@ import izumi.distage.model.reflection.{DIKey, SafeType}
 import izumi.reflect.TagK
 
 import scala.annotation.tailrec
+import scala.util.hashing.MurmurHash3
 
-sealed trait ExecutableOp {
+sealed abstract class ExecutableOp extends Product {
   def target: DIKey
   def origin: EqualizedOperationOrigin
   override final def toString: String = {
     OpFormatter(KeyFormatter.Full, TypeFormatter.Full, DIRendering.colorsEnabled).format(this)
   }
+  override final lazy val hashCode: Int = MurmurHash3.productHash(this)
 }
 
 object ExecutableOp {

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/reflection/DIKey.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/reflection/DIKey.scala
@@ -3,9 +3,9 @@ package izumi.distage.model.reflection
 import izumi.distage.model.definition.{Identifier, ImplDef}
 import izumi.reflect.Tag
 
-sealed trait DIKey {
+sealed abstract class DIKey extends Product {
   def tpe: SafeType
-  override final lazy val hashCode: Int = scala.util.hashing.MurmurHash3.productHash(this.asInstanceOf[Product])
+  override final lazy val hashCode: Int = scala.util.hashing.MurmurHash3.productHash(this)
   protected def formatWithIndex(base: String, index: Option[Int]): String = {
     index match {
       case Some(value) =>

--- a/distage/distage-core/src/main/scala/izumi/distage/provisioning/TraversalState.scala
+++ b/distage/distage-core/src/main/scala/izumi/distage/provisioning/TraversalState.scala
@@ -77,7 +77,7 @@ final class TraversalState(
         CannotProgress(nextPreds)
       }
     } else {
-      Step(current.keys)
+      Step(current.map(_._1))
     }
 
     new TraversalState(

--- a/distage/distage-core/src/test/scala/izumi/distage/dsl/DSLTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/dsl/DSLTest.scala
@@ -95,7 +95,7 @@ class DSLTest extends AnyWordSpec with MkInjector {
         make[TestClass].annotateParameter[TestDependency0]("test_param")
         make[TestDependency1].from[TestImpl1]
         make[TestDependency0].from[TestImpl0]
-        make[TestDependency0].named("test_param").from[TestImpl0]
+        make[TestDependency0].named("test_param").from[TestImpl00]
       }
 
       val injector = mkInjector()
@@ -107,10 +107,11 @@ class DSLTest extends AnyWordSpec with MkInjector {
       injector.produce(planAnnotated).use {
         locator =>
           val tc = locator.get[TestClass]
-          val ta0 = locator.get[TestDependency0]("test_param")
           val t0 = locator.get[TestDependency0]
-          assert(tc.fieldArgDependency == ta0)
+          val ta0 = locator.get[TestDependency0]("test_param")
           assert(tc.fieldArgDependency != t0)
+          assert(tc.fieldArgDependency == ta0)
+          assert(tc.fieldArgDependency.getClass == classOf[TestImpl00])
       }
     }
 

--- a/distage/distage-core/src/test/scala/izumi/distage/fixtures/BasicCases.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/fixtures/BasicCases.scala
@@ -15,6 +15,7 @@ object BasicCases {
     }
 
     class TestImpl0 extends TestDependency0
+    class TestImpl00 extends TestDependency0
 
     trait NotInContext
 

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/BasicTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/BasicTest.scala
@@ -507,4 +507,17 @@ class BasicTest extends AnyWordSpec with MkInjector {
     assert(error.getMessage.contains("String"))
   }
 
+  "stack does not overflow when producing very large dependency chains" in {
+    val max = 4000
+    val definition = new ModuleDef {
+      make[Int].named("0").fromValue(0)
+      for (i <- 1 to max) {
+        make[Int].named(s"$i").from((_: Int) + 1).annotateParameter[Int](s"${i - 1}")
+      }
+    }
+
+    val instance = mkInjector().produceGet[Int](s"$max")(definition).unsafeGet()
+    assert(instance == max)
+  }
+
 }


### PR DESCRIPTION
* memoize hash codes computed repeatedly during planning