### PR TITLE
BIO: add workaround for ZIO for https://github.com/zio/zio/issues/6911 - do not interpret child fiber interruptions as `Exit.Interrupted` in `parTraverse`/`zipPar`

### DIFF
--- a/distage/distage-framework/src/main/scala/izumi/distage/framework/services/ModuleProvider.scala
+++ b/distage/distage-framework/src/main/scala/izumi/distage/framework/services/ModuleProvider.scala
@@ -114,7 +114,7 @@ object ModuleProvider {
         FailureHandler.Custom {
           case Exit.Error(error, trace) =>
             logger.warn(s"Fiber errored out due to unhandled $error $trace")
-          case Exit.Interruption(interrupt, trace) =>
+          case Exit.Interruption(interrupt, _, trace) =>
             logger.trace(s"Fiber interrupted with $interrupt $trace")
           case Exit.Termination(defect, _, trace) =>
             logger.warn(s"Fiber terminated erroneously with unhandled $defect $trace")

--- a/fundamentals/fundamentals-bio/.jvm/src/test/scala/izumi/functional/bio/test/ZIOWorkaroundsTest.scala
+++ b/fundamentals/fundamentals-bio/.jvm/src/test/scala/izumi/functional/bio/test/ZIOWorkaroundsTest.scala
@@ -1,0 +1,152 @@
+package izumi.functional.bio.test
+
+import izumi.functional.bio.{Async2, Exit, F}
+import org.scalatest.wordspec.AnyWordSpec
+
+class ZIOWorkaroundsTest extends AnyWordSpec {
+
+  "Issue https://github.com/zio/zio/issues/6911" should {
+
+    val silentRuntime = zio.Runtime.default.withReportFailure(_ => ())
+
+    "not reproduce with F.parTraverse" in silentRuntime.unsafeRun {
+      F.parTraverse(
+        List(
+          F.unit.forever,
+          F.terminate(new RuntimeException("testexception")),
+        )
+      )(identity).sandboxExit.map {
+          case Exit.Termination(exc, _, _) =>
+            assert(exc.getMessage.contains("testexception"))
+            assert(exc.getMessage.contains("during a `parTraverse` or `zipWithPar` operation"))
+          case other =>
+            fail(s"Unexpected status: $other")
+        }
+    }
+
+    "not reproduce with F.parTraverse_" in silentRuntime.unsafeRun {
+      F.parTraverse_(
+        List(
+          F.unit.forever,
+          F.terminate(new RuntimeException("testexception")),
+        )
+      )(identity).sandboxExit.map {
+          case Exit.Termination(exc, _, _) =>
+            assert(exc.getMessage.contains("testexception"))
+            assert(exc.getMessage.contains("during a `parTraverse` or `zipWithPar` operation"))
+          case other =>
+            fail(s"Unexpected status: $other")
+        }
+    }
+
+    "not reproduce with F.parTraverseN" in silentRuntime.unsafeRun {
+      F.parTraverseN(2)(
+        List(
+          F.unit.forever,
+          F.terminate(new RuntimeException("testexception")),
+        )
+      )(identity).sandboxExit.map {
+          case Exit.Termination(exc, _, _) =>
+            assert(exc.getMessage.contains("testexception"))
+            assert(exc.getMessage.contains("during a `parTraverse` or `zipWithPar` operation"))
+          case other =>
+            fail(s"Unexpected status: $other")
+        }
+    }
+
+    "not reproduce with F.parTraverseN_" in silentRuntime.unsafeRun {
+      F.parTraverseN_(2)(
+        List(
+          F.unit.forever,
+          F.terminate(new RuntimeException("testexception")),
+        )
+      )(identity).sandboxExit.map {
+          case Exit.Termination(exc, _, _) =>
+            assert(exc.getMessage.contains("testexception"))
+            assert(exc.getMessage.contains("during a `parTraverse` or `zipWithPar` operation"))
+          case other =>
+            fail(s"Unexpected status: $other")
+        }
+    }
+
+    "not reproduce with F.race" in silentRuntime.unsafeRun {
+      F.race(
+        F.unit.forever,
+        F.terminate(new RuntimeException("testexception")),
+      ).sandboxExit.map {
+          case Exit.Termination(exc, _, _) =>
+            assert(exc.getMessage.contains("testexception"))
+            assert(!exc.getMessage.contains("during a `parTraverse` or `zipWithPar` operation"))
+          case other =>
+            fail(s"Unexpected status: $other")
+        }
+    }
+
+    "not reproduce with F.racePairUnsafe" in silentRuntime.unsafeRun {
+      F.racePairUnsafe(
+        F.unit.forever,
+        F.terminate(new RuntimeException("testexception")),
+      ).map {
+          case Right((_, Exit.Termination(exc, _, _))) =>
+            assert(exc.getMessage.contains("testexception"))
+            assert(!exc.getMessage.contains("during a `parTraverse` or `zipWithPar` operation"))
+          case other =>
+            fail(s"Unexpected status: $other")
+        }
+    }
+
+    "not reproduce with F.zipWithPar" in silentRuntime.unsafeRun {
+      F.zipWithPar(
+        F.unit.forever.widen[Unit],
+        F.terminate(new RuntimeException("testexception")).widen[Unit],
+      )((_, _) => ()).sandboxExit.map {
+          case Exit.Termination(exc, _, _) =>
+            assert(exc.getMessage.contains("testexception"))
+            assert(exc.getMessage.contains("during a `parTraverse` or `zipWithPar` operation"))
+          case other =>
+            fail(s"Unexpected status: $other")
+        }
+    }
+
+    "not reproduce with F.zipPar" in silentRuntime.unsafeRun {
+      F.zipPar(
+        F.unit.forever,
+        F.terminate(new RuntimeException("testexception")),
+      ).sandboxExit.map {
+          case Exit.Termination(exc, _, _) =>
+            assert(exc.getMessage.contains("testexception"))
+            assert(exc.getMessage.contains("during a `parTraverse` or `zipWithPar` operation"))
+          case other =>
+            fail(s"Unexpected status: $other")
+        }
+    }
+
+    "not reproduce with F.zipParLeft" in silentRuntime.unsafeRun {
+      F.zipParLeft(
+        F.unit.forever,
+        F.terminate(new RuntimeException("testexception")),
+      ).sandboxExit.map {
+          case Exit.Termination(exc, _, _) =>
+            assert(exc.getMessage.contains("testexception"))
+            assert(exc.getMessage.contains("during a `parTraverse` or `zipWithPar` operation"))
+          case other =>
+            fail(s"Unexpected status: $other")
+        }
+    }
+
+    "not reproduce with F.zipParRight" in silentRuntime.unsafeRun {
+      F.zipParRight(
+        F.unit.forever,
+        F.terminate(new RuntimeException("testexception")),
+      ).sandboxExit.map {
+          case Exit.Termination(exc, _, _) =>
+            assert(exc.getMessage.contains("testexception"))
+            assert(exc.getMessage.contains("during a `parTraverse` or `zipWithPar` operation"))
+          case other =>
+            fail(s"Unexpected status: $other")
+        }
+    }
+
+  }
+
+}

--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/CatsConversions.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/CatsConversions.scala
@@ -202,7 +202,7 @@ object CatsConversions {
     @inline override final def forceR[A, B](fa: F[Throwable, A])(fb: F[Throwable, B]): F[Throwable, B] = {
       F.redeem(F.sandbox(fa))(
         {
-          case exit @ Exit.Interruption(_, _) => F.halt(exit)
+          case exit: Exit.Interruption => F.halt(exit)
           case _ => fb
         },
         _ => fb,

--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/impl/MiniBIO.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/impl/MiniBIO.scala
@@ -136,8 +136,8 @@ object MiniBIO {
       Redeem[E, A, E2, B](
         r,
         {
-          case e @ Exit.Interruption(_, _) => Fail.halt(e)
-          case e @ Exit.Termination(_, _, _) => Fail.halt(e)
+          case e: Exit.Interruption => Fail.halt(e)
+          case e: Exit.Termination => Fail.halt(e)
           case Exit.Error(e, _) => err(e)
         },
         succ,
@@ -147,7 +147,7 @@ object MiniBIO {
     override def catchAll[R, E, A, E2](r: MiniBIO[E, A])(f: E => MiniBIO[E2, A]): MiniBIO[E2, A] = redeem(r)(f, pure)
 
     override def bracketCase[R, E, A, B](acquire: MiniBIO[E, A])(release: (A, Exit[E, B]) => MiniBIO[Nothing, Unit])(use: A => MiniBIO[E, B]): MiniBIO[E, B] = {
-      // does not propagate error in release in case `use` fails, propagates only error from `use`
+      // does not propagate error raised in release if `use` failed, in that case only error from `use` is preserved
       flatMap(acquire)(
         a =>
           Redeem[E, B, E, B](


### PR DESCRIPTION
BIO: add workaround for ZIO for https://github.com/zio/zio/issues/6911 - do not interpret child fiber interruptions as `Exit.Interrupted` in `parTraverse`/`zipPar`