### PR TITLE
Finalize CE3 support in BIO. Consider only external interruption to be `Exit.Interrupted` in ZIO. implement `sendInterruptToSelf` properly.

### DIFF
--- a/distage/distage-extension-config/src/test/scala/izumi/distage/impl/OptionalDependencyTest.scala
+++ b/distage/distage-extension-config/src/test/scala/izumi/distage/impl/OptionalDependencyTest.scala
@@ -58,7 +58,7 @@ class OptionalDependencyTest extends AnyWordSpec with GivenWhenThen {
     When("There's no cats/zio/monix on classpath")
     assertCompiles("import scala._")
     assertDoesNotCompile("import cats._")
-    assertDoesNotCompile("import zio._")
+    assertDoesNotCompile("import zio.ZIO")
     assertDoesNotCompile("import monix._")
 
     Then("QuasiIO methods can be called")

--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/Bracket3.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/Bracket3.scala
@@ -11,6 +11,10 @@ trait Bracket3[F[-_, +_, +_]] extends Error3[F] {
     bracketCase(unit: F[R, E, Unit])((_, e: Exit[E, A]) => cleanup(e))(_ => f)
   }
 
+  /**
+    * Run release action only on a failure – _any failure_, INCLUDING interruption.
+    * Do not run release action if `use` finished successfully.
+    */
   final def bracketOnFailure[R, E, A, B](acquire: F[R, E, A])(cleanupOnFailure: (A, Exit.Failure[E]) => F[R, Nothing, Unit])(use: A => F[R, E, B]): F[R, E, B] = {
     bracketCase[R, E, A, B](acquire) {
       case (a, e: Exit.Failure[E]) => cleanupOnFailure(a, e)
@@ -18,12 +22,36 @@ trait Bracket3[F[-_, +_, +_]] extends Error3[F] {
     }(use)
   }
 
+  /**
+    * Run cleanup only on a failure – _any failure_, INCLUDING interruption.
+    * Do not run cleanup if `use` finished successfully.
+    */
   final def guaranteeOnFailure[R, E, A](f: F[R, E, A], cleanupOnFailure: Exit.Failure[E] => F[R, Nothing, Unit]): F[R, E, A] = {
     guaranteeCase[R, E, A](f, { case e: Exit.Failure[E] => cleanupOnFailure(e); case _ => unit })
   }
 
+  /**
+    * Run cleanup only on interruption.
+    * Do not run cleanup if `use` finished successfully.
+    */
   final def guaranteeOnInterrupt[R, E, A](f: F[R, E, A], cleanupOnInterruption: Exit.Interruption => F[R, Nothing, Unit]): F[R, E, A] = {
     guaranteeCase[R, E, A](f, { case e: Exit.Interruption => cleanupOnInterruption(e); case _ => unit })
+  }
+
+  /** Run cleanup on both _success_ and _failure_, if the failure IS NOT an interruption. */
+  final def guaranteeExceptOnInterrupt[R, E, A](
+    f: F[R, E, A],
+    cleanupOnNonInterruption: Either[Exit.Termination, Either[Exit.Error[E], Exit.Success[A]]] => F[R, Nothing, Unit],
+  ): F[R, E, A] = {
+    guaranteeCase[R, E, A](
+      f,
+      {
+        case e: Exit.Termination => cleanupOnNonInterruption(Left(e))
+        case e: Exit.Error[E] => cleanupOnNonInterruption(Right(Left(e)))
+        case e: Exit.Success[A] => cleanupOnNonInterruption(Right(Right(e)))
+        case _: Exit.Interruption => unit
+      },
+    )
   }
 
   // defaults

--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/Exit.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/Exit.scala
@@ -165,7 +165,7 @@ object Exit {
     }
 
     def withIsInterrupted[R, E, A](f: Boolean => A): ZIO[R, E, A] = {
-      withIsInterruptedF(b => ZIOSucceedNow(f(b)))
+      withIsInterruptedF[R, E, A](b => ZIOSucceedNow(f(b)))
     }
 
     def withIsInterruptedF[R, E, A](f: Boolean => ZIO[R, E, A]): ZIO[R, E, A] = {

--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/Panic3.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/Panic3.scala
@@ -5,7 +5,6 @@ import izumi.functional.bio.data.RestoreInterruption3
 
 trait Panic3[F[-_, +_, +_]] extends Bracket3[F] with PanicSyntax {
   def terminate(v: => Throwable): F[Any, Nothing, Nothing]
-  def halt[E](exit: Exit.Failure[E]): F[Any, E, Nothing]
 
   def sandbox[R, E, A](r: F[R, E, A]): F[R, Exit.Failure[E], A]
 
@@ -38,19 +37,10 @@ trait Panic3[F[-_, +_, +_]] extends Bracket3[F] with PanicSyntax {
     *   } *> F.sync(println("Impossible")) // interrupted immediately after `uninterruptible` block ends. Impossible _not_ printed
     * }}}
     *
-    * @note
-    *   The above semantic doesn't work right now under ZIO. This method, and ZIO's compatibility with cats-effect 3,
-    *   are both broken in at least ZIO 1.0 and until further notice. This method is tagged deprecated to avoid its use
-    *   until the problem is resolved.
-    *
     * @see
-    *   - [[https://github.com/zio/interop-cats/issues/503]] - Implementing this method requires new APIs in ZIO itself, until
-    *     the linked issue is resolved, this method is broken.
+    *   - [[https://github.com/zio/interop-cats/issues/503]] - History of supporting this method in ZIO
+    *   - [[https://github.com/zio/zio/issues/6911]] - related issue
     */
-  @deprecated(
-    "This method behaves incorrectly until https://github.com/zio/interop-cats/issues/503 is resolved. Use `F.halt(Exit.Interrupted(Trace.empty))` in case you only need to exit with interrupted status",
-    "24.05.2022",
-  )
   def sendInterruptToSelf: F[Any, Nothing, Unit]
 
   def uninterruptible[R, E, A](r: F[R, E, A]): F[R, E, A] = {

--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/impl/MiniBIO.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/impl/MiniBIO.scala
@@ -121,7 +121,6 @@ object MiniBIO {
     override def flatMap[R, E, A, B](r: MiniBIO[E, A])(f: A => MiniBIO[E, B]): MiniBIO[E, B] = FlatMap(r, f)
     override def fail[E](v: => E): MiniBIO[E, Nothing] = Fail(() => Exit.Error(v, Trace.empty))
     override def terminate(v: => Throwable): MiniBIO[Nothing, Nothing] = Fail.terminate(v)
-    override def halt[E](exit: Exit.Failure[E]): MiniBIO[E, Nothing] = Fail(() => exit)
     override def sendInterruptToSelf: MiniBIO[Nothing, Unit] = unit
 
     override def syncThrowable[A](effect: => A): MiniBIO[Throwable, A] = Sync {

--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/syntax/Syntax2.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/syntax/Syntax2.scala
@@ -143,6 +143,10 @@ object Syntax2 {
       F.bracketOnFailure(r: F[E1, A])(cleanupOnFailure)(use)
     @inline final def guaranteeOnFailure(cleanupOnFailure: Exit.Failure[E] => F[Nothing, Unit]): F[E, A] = F.guaranteeOnFailure(r, cleanupOnFailure)
     @inline final def guaranteeOnInterrupt(cleanupOnInterruption: Exit.Interruption => F[Nothing, Unit]): F[E, A] = F.guaranteeOnInterrupt(r, cleanupOnInterruption)
+    @inline final def guaranteeExceptOnInterrupt(
+      cleanupOnNonInterruption: Either[Exit.Termination, Either[Exit.Error[E], Exit.Success[A]]] => F[Nothing, Unit]
+    ): F[E, A] =
+      F.guaranteeExceptOnInterrupt(r, cleanupOnNonInterruption)
   }
 
   class PanicOps[F[+_, +_], +E, +A](override protected[this] val r: F[E, A])(implicit override protected[this] val F: Panic2[F]) extends BracketOps(r) {

--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/syntax/Syntax3.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/syntax/Syntax3.scala
@@ -200,6 +200,10 @@ object Syntax3 {
     @inline final def guaranteeOnFailure[R1 <: R](cleanupOnFailure: Exit.Failure[E] => FR[R1, Nothing, Unit]): FR[R1, E, A] = F.guaranteeOnFailure(r, cleanupOnFailure)
     @inline final def guaranteeOnInterrupt[R1 <: R](cleanupOnInterruption: Exit.Interruption => FR[R1, Nothing, Unit]): FR[R1, E, A] =
       F.guaranteeOnInterrupt(r, cleanupOnInterruption)
+    @inline final def guaranteeExceptOnInterrupt[R1 <: R](
+      cleanupOnNonInterruption: Either[Exit.Termination, Either[Exit.Error[E], Exit.Success[A]]] => FR[R1, Nothing, Unit]
+    ): FR[R1, E, A] =
+      F.guaranteeExceptOnInterrupt(r, cleanupOnNonInterruption)
   }
 
   class PanicOps[FR[-_, +_, +_], -R, +E, +A](override protected[this] val r: FR[R, E, A])(implicit override protected[this] val F: Panic3[FR]) extends BracketOps(r) {
@@ -354,23 +358,6 @@ object Syntax3 {
     @inline final def Guarantee3[FR[-_, +_, +_]: Guarantee3]: Guarantee3[FR] = implicitly
   }
   trait ImplicitPuns10 extends ImplicitPuns11 {
-    @inline implicit final def Monad3[FR[-_, +_, +_]: Monad3, R, E, A](self: FR[R, E, A]): MonadOps[FR, R, E, A] = new MonadOps[FR, R, E, A](self)
-    @inline final def Monad3[FR[-_, +_, +_]: Monad3]: Monad3[FR] = implicitly
-  }
-  trait ImplicitPuns11 extends ImplicitPuns12 {
-    @inline implicit final def Applicative3[FR[-_, +_, +_]: Applicative3, R, E, A](self: FR[R, E, A]): ApplicativeOps[FR, R, E, A] = new ApplicativeOps[FR, R, E, A](self)
-    @inline final def Applicative3[FR[-_, +_, +_]: Applicative3]: Applicative3[FR] = implicitly
-  }
-  trait ImplicitPuns12 extends ImplicitPuns13 {
-    @inline implicit final def Bifunctor3[FR[-_, +_, +_]: Bifunctor3, R, E, A](self: FR[R, E, A]): BifunctorOps[FR, R, E, A] = new BifunctorOps[FR, R, E, A](self)
-    @inline implicit final def Bifunctor3[FR[-_, +_, +_]: Functor3, R, E, A](self: FR[R, E, A]): FunctorOps[FR, R, E, A] = new FunctorOps[FR, R, E, A](self)
-    @inline final def Bifunctor3[FR[-_, +_, +_]: Bifunctor3]: Bifunctor3[FR] = implicitly
-  }
-  trait ImplicitPuns13 extends ImplicitPuns14 {
-    @inline implicit final def Functor3[FR[-_, +_, +_]: Functor3, R, E, A](self: FR[R, E, A]): FunctorOps[FR, R, E, A] = new FunctorOps[FR, R, E, A](self)
-    @inline final def Functor3[FR[-_, +_, +_]: Functor3]: Functor3[FR] = implicitly
-  }
-  trait ImplicitPuns14 extends ImplicitPuns15 {
     // Note, as long as these auxilary conversions to Monad/Applicative/Functor syntaxes etc.
     // have the same output type as Monad3/etc conversions above, they will avoid the specificity rule
     // and _will not_ clash (because the outputs are equal, not <:<).
@@ -382,28 +369,45 @@ object Syntax3 {
       new LocalOpsKleisliSyntax[FR, R, E, A](self)
     @inline final def Local3[FR[-_, +_, +_]: Local3]: Local3[FR] = implicitly
   }
-  trait ImplicitPuns15 extends ImplicitPuns16 {
+  trait ImplicitPuns11 extends ImplicitPuns12 {
     @inline implicit final def MonadAsk3[FR[-_, +_, +_]: Monad3, R, E, A](self: FR[R, E, A]): MonadOps[FR, R, E, A] = new MonadOps[FR, R, E, A](self)
     @inline final def MonadAsk3[FR[-_, +_, +_]: MonadAsk3]: MonadAsk3[FR] = implicitly
   }
-  trait ImplicitPuns16 extends ImplicitPuns17 {
+  trait ImplicitPuns12 extends ImplicitPuns13 {
     @inline implicit final def Ask3[FR[-_, +_, +_]: Applicative3, R, E, A](self: FR[R, E, A]): ApplicativeOps[FR, R, E, A] = new ApplicativeOps[FR, R, E, A](self)
     @inline final def Ask3[FR[-_, +_, +_]: Ask3]: Ask3[FR] = implicitly
   }
-  trait ImplicitPuns17 extends ImplicitPuns18 {
+  trait ImplicitPuns13 extends ImplicitPuns14 {
     @inline implicit final def ArrowChoice3[FR[-_, +_, +_]: ArrowChoice3, R, E, A](self: FR[R, E, A]): ArrowChoiceOps[FR, R, E, A] = new ArrowChoiceOps[FR, R, E, A](self)
     @inline implicit final def ArrowChoice3[FR[-_, +_, +_]: Functor3, R, E, A](self: FR[R, E, A]): FunctorOps[FR, R, E, A] = new FunctorOps[FR, R, E, A](self)
     @inline final def ArrowChoice3[FR[-_, +_, +_]: ArrowChoice3]: ArrowChoice3[FR] = implicitly
   }
-  trait ImplicitPuns18 extends ImplicitPuns19 {
+  trait ImplicitPuns14 extends ImplicitPuns15 {
     @inline implicit final def Arrow3[FR[-_, +_, +_]: Arrow3, R, E, A](self: FR[R, E, A]): ArrowOps[FR, R, E, A] = new ArrowOps[FR, R, E, A](self)
     @inline implicit final def Arrow3[FR[-_, +_, +_]: Functor3, R, E, A](self: FR[R, E, A]): FunctorOps[FR, R, E, A] = new FunctorOps[FR, R, E, A](self)
     @inline final def Arrow3[FR[-_, +_, +_]: Arrow3]: Arrow3[FR] = implicitly
   }
-  trait ImplicitPuns19 {
+  trait ImplicitPuns15 extends ImplicitPuns16 {
     @inline implicit final def Profunctor3[FR[-_, +_, +_]: Profunctor3, R, E, A](self: FR[R, E, A]): ProfunctorOps[FR, R, E, A] = new ProfunctorOps[FR, R, E, A](self)
     @inline implicit final def Profunctor3[FR[-_, +_, +_]: Functor3, R, E, A](self: FR[R, E, A]): FunctorOps[FR, R, E, A] = new FunctorOps[FR, R, E, A](self)
     @inline final def Profunctor3[FR[-_, +_, +_]: Profunctor3]: Profunctor3[FR] = implicitly
+  }
+  trait ImplicitPuns16 extends ImplicitPuns17 {
+    @inline implicit final def Monad3[FR[-_, +_, +_]: Monad3, R, E, A](self: FR[R, E, A]): MonadOps[FR, R, E, A] = new MonadOps[FR, R, E, A](self)
+    @inline final def Monad3[FR[-_, +_, +_]: Monad3]: Monad3[FR] = implicitly
+  }
+  trait ImplicitPuns17 extends ImplicitPuns18 {
+    @inline implicit final def Applicative3[FR[-_, +_, +_]: Applicative3, R, E, A](self: FR[R, E, A]): ApplicativeOps[FR, R, E, A] = new ApplicativeOps[FR, R, E, A](self)
+    @inline final def Applicative3[FR[-_, +_, +_]: Applicative3]: Applicative3[FR] = implicitly
+  }
+  trait ImplicitPuns18 extends ImplicitPuns19 {
+    @inline implicit final def Bifunctor3[FR[-_, +_, +_]: Bifunctor3, R, E, A](self: FR[R, E, A]): BifunctorOps[FR, R, E, A] = new BifunctorOps[FR, R, E, A](self)
+    @inline implicit final def Bifunctor3[FR[-_, +_, +_]: Functor3, R, E, A](self: FR[R, E, A]): FunctorOps[FR, R, E, A] = new FunctorOps[FR, R, E, A](self)
+    @inline final def Bifunctor3[FR[-_, +_, +_]: Bifunctor3]: Bifunctor3[FR] = implicitly
+  }
+  trait ImplicitPuns19 {
+    @inline implicit final def Functor3[FR[-_, +_, +_]: Functor3, R, E, A](self: FR[R, E, A]): FunctorOps[FR, R, E, A] = new FunctorOps[FR, R, E, A](self)
+    @inline final def Functor3[FR[-_, +_, +_]: Functor3]: Functor3[FR] = implicitly
   }
 
 }

--- a/fundamentals/fundamentals-bio/src/main/scala/zio/_izumicompat_/__ZIOFiberContext.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/zio/_izumicompat_/__ZIOFiberContext.scala
@@ -1,0 +1,5 @@
+package zio._izumicompat_
+
+object __ZIOFiberContext {
+  type FiberContext[E, A] = zio.internal.FiberContext[E, A]
+}


### PR DESCRIPTION
* Port https://github.com/zio/interop-cats/pull/543 & https://github.com/zio/interop-cats/pull/544
* Do not ignore error/success value in laws tests
* Convert from random cats generator in Laws tests
* remove `.resetForkScope` from `raceFirst` (interruption guaranteed by raceFirst method, not supervisor)
* Remove `Panic3#halt` method.
* Add `Bracket3#guaranteeExceptOnInterrupt` method.
* fix implicit priorities in Syntax3 to avoid specificity clashes