### PR TITLE
Allow using `Lifecycle#flatMap` and related methods with a non-Throwable error

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,5 @@
-version = "3.5.9"
-runner.dialect = scala3
+version = "3.6.0"
+runner.dialect = scala3Future
 project.git = true
 project.excludePaths = ["glob:**.sbt", "glob:**sbtgen.sc"]
 

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/Lifecycle.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/Lifecycle.scala
@@ -995,11 +995,11 @@ object Lifecycle extends LifecycleInstances {
 }
 
 private[definition] sealed trait LifecycleInstances extends LifecycleCatsInstances {
-  implicit final def functor2ForLifecycle[F[+_, +_]: Functor2]: Functor2[Lifecycle2[F, + _, + _]] = new Functor2[Lifecycle2[F, + _, + _]] {
+  implicit final def functor2ForLifecycle[F[+_, +_]: Functor2]: Functor2[Lifecycle2[F, +_, +_]] = new Functor2[Lifecycle2[F, +_, +_]] {
     override def map[R, E, A, B](r: Lifecycle[F[E, _], A])(f: A => B): Lifecycle[F[E, _], B] = r.map(f)
   }
 
-  implicit final def functor3ForLifecycle[F[-_, +_, +_]: Functor3]: Functor3[Lifecycle3[F, - _, + _, + _]] = new Functor3[Lifecycle3[F, - _, + _, + _]] {
+  implicit final def functor3ForLifecycle[F[-_, +_, +_]: Functor3]: Functor3[Lifecycle3[F, -_, +_, +_]] = new Functor3[Lifecycle3[F, -_, +_, +_]] {
     override def map[R, E, A, B](r: Lifecycle[F[R, E, _], A])(f: A => B): Lifecycle[F[R, E, _], B] = r.map(f)
   }
 }

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/effect/package.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/effect/package.scala
@@ -1,11 +1,17 @@
 package izumi.distage.model
 
 package object effect {
-  type QuasiIO2[F[_, _]] = QuasiIO[F[Throwable, _]]
-  type QuasiIO3[F[_, _, _]] = QuasiIO[F[Any, Throwable, _]]
+  type QuasiFunctor2[F[_, _]] = QuasiFunctor[F[Throwable, _]]
+  type QuasiFunctor3[F[_, _, _]] = QuasiFunctor[F[Any, Throwable, _]]
 
   type QuasiApplicative2[F[_, _]] = QuasiApplicative[F[Throwable, _]]
   type QuasiApplicative3[F[_, _, _]] = QuasiApplicative[F[Any, Throwable, _]]
+
+  type QuasiPrimitives2[F[_, _]] = QuasiPrimitives[F[Throwable, _]]
+  type QuasiPrimitives3[F[_, _, _]] = QuasiPrimitives[F[Any, Throwable, _]]
+
+  type QuasiIO2[F[_, _]] = QuasiIO[F[Throwable, _]]
+  type QuasiIO3[F[_, _, _]] = QuasiIO[F[Any, Throwable, _]]
 
   type QuasiAsync2[F[_, _]] = QuasiAsync[F[Throwable, _]]
   type QuasiAsync3[F[_, _, _]] = QuasiAsync[F[Any, Throwable, _]]

--- a/distage/distage-core/.js/src/main/scala/izumi/distage/modules/support/IdentitySupportModule.scala
+++ b/distage/distage-core/.js/src/main/scala/izumi/distage/modules/support/IdentitySupportModule.scala
@@ -1,7 +1,7 @@
 package izumi.distage.modules.support
 
 import izumi.distage.model.definition.ModuleDef
-import izumi.distage.model.effect.{QuasiApplicative, QuasiIO, QuasiIORunner}
+import izumi.distage.model.effect.*
 import izumi.functional.mono.{Clock, Entropy}
 import izumi.fundamentals.platform.functional.Identity
 
@@ -12,7 +12,9 @@ object IdentitySupportModule extends IdentitySupportModule
   * Adds [[izumi.distage.model.effect.QuasiIO]] instances to support running without an effect type in `Injector`, `distage-framework` & `distage-testkit-scalatest`
   */
 trait IdentitySupportModule extends ModuleDef {
+  addImplicit[QuasiFunctor[Identity]]
   addImplicit[QuasiApplicative[Identity]]
+  addImplicit[QuasiPrimitives[Identity]]
   addImplicit[QuasiIO[Identity]]
   addImplicit[QuasiIORunner[Identity]]
 //  addImplicit[QuasiAsync[Identity]] // No QuasiAsync for Identity on JS

--- a/distage/distage-core/.jvm/src/main/scala/izumi/distage/modules/support/IdentitySupportModule.scala
+++ b/distage/distage-core/.jvm/src/main/scala/izumi/distage/modules/support/IdentitySupportModule.scala
@@ -1,7 +1,7 @@
 package izumi.distage.modules.support
 
 import izumi.distage.model.definition.ModuleDef
-import izumi.distage.model.effect.{QuasiApplicative, QuasiAsync, QuasiIO, QuasiIORunner}
+import izumi.distage.model.effect.*
 import izumi.functional.bio.{Clock1, Entropy1}
 import izumi.fundamentals.platform.functional.Identity
 
@@ -13,7 +13,9 @@ object IdentitySupportModule extends IdentitySupportModule
   * Adds [[izumi.distage.model.effect.QuasiIO]] instances to support running without an effect type in `Injector`, `distage-framework` & `distage-testkit-scalatest`
   */
 trait IdentitySupportModule extends ModuleDef {
+  addImplicit[QuasiFunctor[Identity]]
   addImplicit[QuasiApplicative[Identity]]
+  addImplicit[QuasiPrimitives[Identity]]
   addImplicit[QuasiIO[Identity]]
   addImplicit[QuasiIORunner[Identity]]
   addImplicit[QuasiAsync[Identity]]

--- a/distage/distage-core/src/main/scala/izumi/distage/modules/DefaultModule.scala
+++ b/distage/distage-core/src/main/scala/izumi/distage/modules/DefaultModule.scala
@@ -1,13 +1,14 @@
 package izumi.distage.modules
 
 import izumi.distage.model.definition.{Module, ModuleDef}
-import izumi.distage.model.effect.{QuasiApplicative, QuasiAsync, QuasiIO, QuasiIORunner}
-import izumi.distage.modules.support._
+import izumi.distage.model.effect.{QuasiApplicative, QuasiAsync, QuasiFunctor, QuasiIO, QuasiIORunner, QuasiPrimitives}
+import izumi.distage.modules.support.*
 import izumi.distage.modules.typeclass.ZIOCatsEffectInstancesModule
 import izumi.functional.bio.retry.{Scheduler2, Scheduler3}
 import izumi.functional.bio.{Async2, Async3, Fork2, Fork3, Local3, Primitives2, Primitives3, Temporal2, Temporal3, UnsafeRun2, UnsafeRun3}
-import izumi.fundamentals.orphans._
+import izumi.fundamentals.orphans.*
 import izumi.fundamentals.platform.functional.Identity
+
 import scala.annotation.unused
 import izumi.reflect.{TagK, TagK3, TagKK}
 
@@ -156,9 +157,11 @@ sealed trait LowPriorityDefaultModulesInstances5 extends LowPriorityDefaultModul
 sealed trait LowPriorityDefaultModulesInstances6 {
   implicit final def fromQuasiIO[F[_]: TagK: QuasiIO: QuasiAsync: QuasiIORunner]: DefaultModule[F] = {
     DefaultModule(new ModuleDef {
+      addImplicit[QuasiFunctor[F]]
+      addImplicit[QuasiApplicative[F]]
+      addImplicit[QuasiPrimitives[F]]
       addImplicit[QuasiIO[F]]
       addImplicit[QuasiAsync[F]]
-      addImplicit[QuasiApplicative[F]]
       addImplicit[QuasiIORunner[F]]
     })
   }

--- a/distage/distage-core/src/main/scala/izumi/distage/modules/support/AnyBIO2SupportModule.scala
+++ b/distage/distage-core/src/main/scala/izumi/distage/modules/support/AnyBIO2SupportModule.scala
@@ -4,7 +4,7 @@ import izumi.distage.model.definition.ModuleDef
 import izumi.distage.model.effect.*
 import izumi.distage.modules.typeclass.BIO2InstancesModule
 import izumi.functional.bio.retry.Scheduler2
-import izumi.functional.bio.{Applicative2, Async2, Clock1, Clock2, Entropy1, Entropy2, Fork2, IO2, Primitives2, PrimitivesM2, SyncSafe1, SyncSafe2, Temporal2, UnsafeRun2}
+import izumi.functional.bio.{Async2, Clock1, Clock2, Entropy1, Entropy2, Fork2, IO2, Primitives2, PrimitivesM2, SyncSafe1, SyncSafe2, Temporal2, UnsafeRun2}
 import izumi.fundamentals.platform.functional.Identity
 import izumi.reflect.TagKK
 
@@ -24,12 +24,13 @@ class AnyBIO2SupportModule[F[+_, +_]: TagKK] extends ModuleDef {
   make[QuasiIORunner2[F]]
     .from[QuasiIORunner.BIOImpl[F]]
 
-  make[QuasiIO2[F]].from {
-    QuasiIO.fromBIO(_: IO2[F])
-  }
-  make[QuasiApplicative2[F]].from {
-    QuasiApplicative.fromBIO[F, Throwable](_: Applicative2[F])
-  }
+  make[QuasiIO2[F]]
+    .aliased[QuasiPrimitives2[F]]
+    .aliased[QuasiApplicative2[F]]
+    .aliased[QuasiFunctor2[F]]
+    .from {
+      QuasiIO.fromBIO(_: IO2[F])
+    }
   make[QuasiAsync2[F]].from {
     QuasiAsync.fromBIO(_: Async2[F], _: Temporal2[F])
   }

--- a/distage/distage-core/src/main/scala/izumi/distage/modules/support/AnyBIO3SupportModule.scala
+++ b/distage/distage-core/src/main/scala/izumi/distage/modules/support/AnyBIO3SupportModule.scala
@@ -76,8 +76,10 @@ object AnyBIO3SupportModule extends App with ModuleDef {
         implicitly[PrimitivesM3[F] =:= PrimitivesM2[F[Any, +_, +_]]]
         implicitly[SyncSafe3[F] =:= SyncSafe2[F[Any, +_, +_]]]
         implicitly[QuasiIORunner3[F] =:= QuasiIORunner2[F[Any, +_, +_]]]
-        implicitly[QuasiIO3[F] =:= QuasiIO2[F[Any, +_, +_]]]
+        implicitly[QuasiFunctor3[F] =:= QuasiFunctor2[F[Any, +_, +_]]]
         implicitly[QuasiApplicative3[F] =:= QuasiApplicative2[F[Any, +_, +_]]]
+        implicitly[QuasiPrimitives3[F] =:= QuasiPrimitives2[F[Any, +_, +_]]]
+        implicitly[QuasiIO3[F] =:= QuasiIO2[F[Any, +_, +_]]]
         implicitly[QuasiAsync3[F] =:= QuasiAsync2[F[Any, +_, +_]]]
         ()
       }

--- a/distage/distage-core/src/main/scala/izumi/distage/modules/support/AnyCatsEffectSupportModule.scala
+++ b/distage/distage-core/src/main/scala/izumi/distage/modules/support/AnyCatsEffectSupportModule.scala
@@ -2,9 +2,9 @@ package izumi.distage.modules.support
 
 import cats.effect.kernel.{Async, Sync}
 import cats.effect.std.Dispatcher
-import cats.{Applicative, Parallel}
+import cats.Parallel
 import distage.{ModuleDef, TagK}
-import izumi.distage.model.effect.{QuasiApplicative, QuasiAsync, QuasiIO, QuasiIORunner}
+import izumi.distage.model.effect.{QuasiApplicative, QuasiAsync, QuasiFunctor, QuasiIO, QuasiIORunner, QuasiPrimitives}
 import izumi.distage.modules.typeclass.CatsEffectInstancesModule
 import izumi.functional.bio.{Clock1, Entropy1, SyncSafe1}
 import izumi.fundamentals.platform.functional.Identity
@@ -22,14 +22,15 @@ import izumi.fundamentals.platform.functional.Identity
 class AnyCatsEffectSupportModule[F[_]: TagK] extends ModuleDef {
   include(CatsEffectInstancesModule[F])
 
-  make[QuasiIO[F]].from {
-    implicit F: Sync[F] => QuasiIO.fromCats
-  }
+  make[QuasiIO[F]]
+    .aliased[QuasiPrimitives[F]]
+    .aliased[QuasiApplicative[F]]
+    .aliased[QuasiFunctor[F]]
+    .from {
+      implicit F: Sync[F] => QuasiIO.fromCats
+    }
   make[QuasiAsync[F]].from {
     implicit F: Async[F] => QuasiAsync.fromCats
-  }
-  make[QuasiApplicative[F]].from {
-    implicit F: Applicative[F] => QuasiApplicative.fromCats
   }
   make[SyncSafe1[F]].from {
     implicit F: Sync[F] => SyncSafe1.fromSync

--- a/distage/distage-extension-config/src/test/scala/izumi/distage/impl/OptionalDependencyTest.scala
+++ b/distage/distage-extension-config/src/test/scala/izumi/distage/impl/OptionalDependencyTest.scala
@@ -3,7 +3,7 @@ package izumi.distage.impl
 import java.io.ByteArrayInputStream
 import distage.Lifecycle
 import izumi.distage.model.definition.ModuleDef
-import izumi.distage.model.effect.QuasiIO
+import izumi.distage.model.effect.{QuasiApplicative, QuasiFunctor, QuasiIO, QuasiPrimitives}
 import izumi.distage.modules.DefaultModule
 import izumi.functional.bio.{Applicative2, ApplicativeError2, Arrow3, ArrowChoice3, Ask3, Async2, Bifunctor2, Bracket2, Concurrent2, Error2, F, Fork2, Functor2, Guarantee2, IO2, IO3, Local3, Monad2, MonadAsk3, Panic2, Parallel2, Primitives2, PrimitivesM2, Profunctor3, Ref3, Temporal2}
 import izumi.fundamentals.platform.functional.{Identity, Identity2, Identity3}
@@ -86,6 +86,9 @@ class OptionalDependencyTest extends AnyWordSpec with GivenWhenThen {
       }
     }
 
+    assert(new optSearch1[QuasiFunctor].find == QuasiFunctor.quasiFunctorIdentity)
+    assert(new optSearch1[QuasiApplicative].find == QuasiApplicative.quasiApplicativeIdentity)
+    assert(new optSearch1[QuasiPrimitives].find == QuasiPrimitives.quasiPrimitivesIdentity)
     assert(new optSearch1[QuasiIO].find == QuasiIO.quasiIOIdentity)
 
     try QuasiIO.fromBIO(null)

--- a/fundamentals/fundamentals-bio/src/main/scala-3/izumi/functional/bio/Convert3To2VersionSpecific.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala-3/izumi/functional/bio/Convert3To2VersionSpecific.scala
@@ -18,8 +18,8 @@ trait BlockingIOLowPriorityVersionSpecific {
     implicit BlockingIO3: C[FR] {
       type Divergence = Nondivergent; type IsPredefined = T // `IsPredefined = T` is required only on Scala 3
     }
-  ): Divergent.Of[BlockingIO2[FR[R, + _, + _]]] { type IsPredefined = T } = {
-    BlockingIO3.asInstanceOf[Divergent.Of[BlockingIO2[FR[R, + _, + _]]] { type IsPredefined = T }]
+  ): Divergent.Of[BlockingIO2[FR[R, +_, +_]]] { type IsPredefined = T } = {
+    BlockingIO3.asInstanceOf[Divergent.Of[BlockingIO2[FR[R, +_, +_]]] { type IsPredefined = T }]
   }
 
 }


### PR DESCRIPTION
* Extract a subset of `QuasiIO` not dependent on Throwable into `QuasiPrimitives`