### PR TITLE
Fix Scala 3 HasConstructor: support more than 2 dependencies

### DIFF
--- a/distage/distage-core-api/src/main/scala-3/izumi/distage/model/providers/FunctoidMacroMethods.scala
+++ b/distage/distage-core-api/src/main/scala-3/izumi/distage/model/providers/FunctoidMacroMethods.scala
@@ -275,7 +275,7 @@ object FunctoidMacro {
           val strExpr = Expr(str)
           '{ new DIKey.IdKey($safeTpe, $strExpr, None)(scala.compiletime.summonInline[IdContract[String]]) }
         case None =>
-          '{ new DIKey.TypeKey($safeTpe) }
+          '{ new DIKey.TypeKey($safeTpe, None) }
       }
     }
 

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/ZIOHasInjectionTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/ZIOHasInjectionTest.scala
@@ -294,6 +294,28 @@ class ZIOHasInjectionTest extends AnyWordSpec with MkInjector {
       assert(context.get[TestTrait].anyValDep.d eq context.get[Dep])
     }
 
+    "Scala 3 regression test: support more than 2 dependencies in HasConstructor" in {
+      trait OpenTracingService
+
+      type OpenTracing = Has[OpenTracingService]
+
+      trait SttpBackend[F[_], +P]
+
+      trait MyEndpoints[F[_, _]]
+
+      trait ZioStreams
+      trait WebSockets
+
+      trait MyPublisher
+      trait MyClient
+
+      object MyPlugin extends ModuleDef {
+        make[MyClient].fromHas[OpenTracing with Has[MyPublisher] with Has[SttpBackend[Task, ZioStreams with WebSockets]] with Has[MyEndpoints[IO]], Nothing, MyClient] {
+          ??? : zio.ZIO[OpenTracing with Has[MyPublisher] with Has[SttpBackend[Task, ZioStreams with WebSockets]] with Has[MyEndpoints[IO]], Nothing, MyClient]
+        }
+      }
+    }
+
   }
 
 }


### PR DESCRIPTION
* Fix invalid types inferred inside quasiquotes in HasConstructorMacro

Reported in https://github.com/DmytroOrlov/distage-repro