### PR TITLE
Add a new DSL to define functions that mutate modules outside of module definitions

### DIFF
--- a/distage/distage-core-api/src/main/scala-2/izumi/distage/model/definition/dsl/AbstractBindingDefDSLMacro.scala
+++ b/distage/distage-core-api/src/main/scala-2/izumi/distage/model/definition/dsl/AbstractBindingDefDSLMacro.scala
@@ -4,6 +4,6 @@ import izumi.distage.constructors.macros.AnyConstructorMacro
 
 import scala.language.experimental.macros
 
-trait AbstractBindingDefDSLMacro[BindDSL[_], BindDSLAfterFrom[_], SetDSL[_]] { this: AbstractBindingDefDSL[BindDSL, BindDSLAfterFrom, SetDSL] =>
+trait AbstractBindingDefDSLMacro[BindDSL[_]] {
   final protected[this] def make[T]: BindDSL[T] = macro AnyConstructorMacro.make[BindDSL, T]
 }

--- a/distage/distage-core-api/src/main/scala-3/izumi/distage/constructors/AnyConstructorMacro.scala
+++ b/distage/distage-core-api/src/main/scala-3/izumi/distage/constructors/AnyConstructorMacro.scala
@@ -1,8 +1,6 @@
 package izumi.distage.constructors
 
-import izumi.distage.constructors.{AnyConstructor, AnyConstructorOptionalMakeDSL, ClassConstructor, ClassConstructorMacro, FactoryConstructor, TraitConstructor, TraitConstructorMacro}
-import izumi.distage.model.definition.{Bindings, ModuleBase}
-import izumi.distage.model.definition.dsl.AbstractBindingDefDSL.SingletonRef
+import izumi.distage.constructors.{AnyConstructor, AnyConstructorOptionalMakeDSL, ClassConstructorMacro, TraitConstructor, TraitConstructorMacro}
 import izumi.distage.model.definition.dsl.ModuleDefDSL
 import izumi.distage.model.providers.Functoid
 import izumi.fundamentals.platform.language.CodePositionMaterializer

--- a/distage/distage-core-api/src/main/scala-3/izumi/distage/model/definition/dsl/AbstractBindingDefDSLMacro.scala
+++ b/distage/distage-core-api/src/main/scala-3/izumi/distage/model/definition/dsl/AbstractBindingDefDSLMacro.scala
@@ -2,6 +2,6 @@ package izumi.distage.model.definition.dsl
 
 import izumi.distage.constructors.AnyConstructorMacro
 
-trait AbstractBindingDefDSLMacro[BindDSL[_], BindDSLAfterFrom[_], SetDSL[_]] { this: AbstractBindingDefDSL[BindDSL, BindDSLAfterFrom, SetDSL] =>
+trait AbstractBindingDefDSLMacro[BindDSL[_]] {
   inline final protected[this] def make[T]: BindDSL[T] = ${ AnyConstructorMacro.makeMethod[T, BindDSL[T]] }
 }

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/Lifecycle.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/Lifecycle.scala
@@ -436,7 +436,8 @@ object Lifecycle extends LifecycleInstances {
   }
 
   implicit final class SyntaxUnsafeGet[F[_], A](private val resource: Lifecycle[F, A]) extends AnyVal {
-    /** Unsafely acquire the resource and throw away the finalizer,
+    /**
+      * Unsafely acquire the resource and throw away the finalizer,
       * this will leak the resource and cause it to never be cleaned up.
       *
       * This function only makes sense in code examples or at top-level,

--- a/distage/distage-core/src/main/scala/izumi/distage/model/Injector.scala
+++ b/distage/distage-core/src/main/scala/izumi/distage/model/Injector.scala
@@ -246,6 +246,7 @@ trait Injector[F[_]] extends Planner with Producer {
     *
     * @see [[https://izumi.7mind.io/distage/distage-framework.html#compile-time-checks Compile-Time Checks]]
     *
+    * @return Unit
     * @throws PlanCheckException on found issues
     */
   final def assert(
@@ -272,7 +273,7 @@ trait Injector[F[_]] extends Planner with Producer {
     * @see [[https://izumi.7mind.io/distage/distage-framework.html#compile-time-checks Compile-Time Checks]]
     *
     * @return Set of issues if any.
-    *         Does not throw.
+    * @throws Nothing Does not throw.
     */
   final def verify(
     bindings: ModuleBase,


### PR DESCRIPTION

Use this to create utility functions that add bindings mutably to the current module,
as opposed to creating new modules and `include`ing them.

Example:

```scala
import distage.{AnyConstructor, Tag, ModuleDef}
import izumi.distage.model.definition.dsl.ModuleDefDSL

trait RegisteredComponent
class RegisteredComponentImpl extends RegisteredComponent

def addAndRegister[T <: RegisteredComponent: Tag: AnyConstructor](implicit mutateModule: ModuleDefDSL#MutationContext): Unit = {
  new mutateModule.dsl {
    make[T]

    many[RegisteredComponent]
      .weak[T]
  }
}

new ModuleDef {
  addAndRegister[RegisteredComponentImpl]
}
```
