### PR TITLE
Distage: Testkit memoization tree cleanup

### DIFF
--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/errors/DIError.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/errors/DIError.scala
@@ -19,7 +19,7 @@ sealed trait DIError
 
 object DIError {
   implicit class DIResultExt[A](private val result: Either[List[DIError], A]) extends AnyVal {
-    def cumulateErrors: Either[InjectorFailed, A] = {
+    def aggregateErrors: Either[InjectorFailed, A] = {
       result match {
         case Left(errors) =>
           val i = new DIFailureInterpreter()
@@ -29,7 +29,7 @@ object DIError {
           Right(resolved)
       }
     }
-    def getOrThrow(): A = cumulateErrors match {
+    def getOrThrow(): A = aggregateErrors match {
       case Left(value) => throw value
       case Right(value) => value
     }

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/services/dstest/DistageTestRunner.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/services/dstest/DistageTestRunner.scala
@@ -364,7 +364,7 @@ class DistageTestRunner[F[_]: TagK: DefaultModule](
     val newAppModule = appModule.drop(allSharedKeys)
     val newRoots = testPlan.keys -- allSharedKeys ++ groupStrengthenedKeys.intersect(newAppModule.keys)
     val maybeNewTestPlan = if (newRoots.nonEmpty) {
-      testInjector.plan(PlannerInput(newAppModule, activation, newRoots)).cumulateErrors
+      testInjector.plan(PlannerInput(newAppModule, activation, newRoots)).aggregateErrors
     } else {
       Right(Plan.empty)
     }

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/services/dstest/DistageTestRunner.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/services/dstest/DistageTestRunner.scala
@@ -585,7 +585,7 @@ object DistageTestRunner {
       (groups.iterator.flatMap(_.preparedTests) ++ children.iterator.flatMap(_._2.getAllTests)).toSeq
     }
 
-]    def addGroup(group: MemoizationLevelGroup[F]): Unit = {
+    def addGroup(group: MemoizationLevelGroup[F]): Unit = {
       groups.synchronized(groups.append(group))
       ()
     }

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/services/dstest/TestEnvironment.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/services/dstest/TestEnvironment.scala
@@ -63,9 +63,7 @@ object TestEnvironment {
     test: DistageTest[F],
     appModule: Module,
     testPlan: Plan,
-    activationInfo: ActivationInfo,
     activation: Activation,
-    planner: Planner, // 0.11.0: remove
   )
 
 }


### PR DESCRIPTION
@neko-kai I think we can remove bootstrap module rewrite here:
```scala
    val locatorWithOverriddenPlannerAndActivationInfo: LocatorDef = new LocatorDef {
      // we override ActivationInfo <s>(& Activation)</s> because the test can have _different_ activation from the memoized part
      // FIXME: Activation will be part of PlannerInput in 0.11.0 & perhaps ActivationInfo should be derived from Bootloader/PlannerInput as well instead of injected externally      
```