### PR TITLE
Sets in sub-locators extend parent sets

### DIFF
--- a/distage/distage-core/src/test/scala/izumi/distage/fixtures/SetCases.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/fixtures/SetCases.scala
@@ -61,4 +61,12 @@ object SetCases {
     }
   }
 
+  object SetCase4 {
+    trait Service
+
+    class Service1 extends Service
+
+    class Service2 extends Service
+  }
+
 }


### PR DESCRIPTION
Closes #330

I think this behavior is _more sound_ than the overrides we had previously. Though this is discussable.

Maybe we should make it configurable (but who may want to even know about such option bar changing it).