### PR TITLE
Remove direct dependency on `circe-derivation` 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1007,8 +1007,8 @@ lazy val `fundamentals-json-circe` = project.in(file("fundamentals/fundamentals-
     ),
     libraryDependencies ++= { if (scalaVersion.value.startsWith("2.")) Seq(
       compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full),
-      "io.circe" %% "circe-derivation" % V.circe_derivation,
-      "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided
+      "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided,
+      "io.circe" %% "circe-derivation" % V.circe_derivation % Test
     ) else Seq.empty },
     libraryDependencies ++= {
       val version = scalaVersion.value
@@ -1164,7 +1164,9 @@ lazy val `fundamentals-json-circe` = project.in(file("fundamentals/fundamentals-
       )
       case (_, _) => Seq.empty
     } },
-    Test / packageDoc / publishArtifact := false
+    Test / packageDoc / publishArtifact := false,
+    Compile / libraryDependencySchemes += "io.circe" %% "circe-core" % VersionScheme.Always,
+    Compile / libraryDependencySchemes += "io.circe" %% "circe-core_sjs1" % VersionScheme.Always
   )
   .disablePlugins(AssemblyPlugin)
 
@@ -3524,13 +3526,13 @@ lazy val `logstage-core` = project.in(file("logstage/logstage-core"))
 
 lazy val `logstage-rendering-circe` = project.in(file("logstage/logstage-rendering-circe"))
   .dependsOn(
-    `fundamentals-json-circe` % "test->compile;compile->compile",
     `logstage-core` % "test->test;compile->compile"
   )
   .settings(
     libraryDependencies ++= Seq(
       "org.scala-lang.modules" %% "scala-collection-compat" % V.collection_compat,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
+      "io.circe" %% "circe-core" % V.circe,
       "org.typelevel" %% "jawn-parser" % V.jawn % Test,
       "io.circe" %% "circe-parser" % V.circe % Test,
       "io.circe" %% "circe-literal" % V.circe % Test,
@@ -4057,7 +4059,8 @@ lazy val `microsite` = project.in(file("doc/microsite"))
       "dev.zio" %% "zio-interop-cats" % V.zio_interop_cats excludeAll("dev.zio" %% "izumi-reflect"),
       "dev.zio" %% "izumi-reflect" % V.izumi_reflect,
       "org.tpolecat" %% "doobie-core" % V.doobie,
-      "org.tpolecat" %% "doobie-postgres" % V.doobie
+      "org.tpolecat" %% "doobie-postgres" % V.doobie,
+      "io.circe" %% "circe-generic" % V.circe
     ),
     libraryDependencies ++= { if (scalaVersion.value.startsWith("2.")) Seq(
       compilerPlugin("org.typelevel" % "kind-projector" % V.kind_projector cross CrossVersion.full)
@@ -4695,9 +4698,7 @@ lazy val `izumi` = (project in file("."))
     ThisBuild / developers := List(
               Developer(id = "7mind", name = "Septimal Mind", url = url("https://github.com/7mind"), email = "team@7mind.io"),
             ),
-    ThisBuild / scmInfo := Some(ScmInfo(url("https://github.com/7mind/izumi"), "scm:git:https://github.com/7mind/izumi.git")),
-    ThisBuild / libraryDependencySchemes += "io.circe" %% "circe-core" % VersionScheme.Always,
-    ThisBuild / libraryDependencySchemes += "io.circe" %% "circe-core_sjs1" % VersionScheme.Always
+    ThisBuild / scmInfo := Some(ScmInfo(url("https://github.com/7mind/izumi"), "scm:git:https://github.com/7mind/izumi.git"))
   )
   .disablePlugins(AssemblyPlugin)
   .aggregate(

--- a/doc/microsite/src/main/scala/com/example/Entity.scala
+++ b/doc/microsite/src/main/scala/com/example/Entity.scala
@@ -6,5 +6,5 @@ import io.circe.Encoder
 
 final case class Entity(id: UUID)
 object Entity {
-  implicit val enc: Encoder.AsObject[Entity] = io.circe.derivation.deriveEncoder[Entity]
+  implicit val enc: Encoder.AsObject[Entity] = io.circe.generic.semiauto.deriveEncoder[Entity]
 }

--- a/doc/microsite/src/main/tut/logstage/00_logstage.md
+++ b/doc/microsite/src/main/tut/logstage/00_logstage.md
@@ -323,14 +323,14 @@ Example:
 
 ```scala mdoc:reset:to-string
 import io.circe.Codec
-import io.circe.derivation
+import io.circe.generic.semiauto
 import logstage.LogstageCodec
 import logstage.circe.LogstageCirceCodec
 
 final case class KV(key: String, value: Int)
 
 object KV {
-  implicit val circeCodec: Codec[KV] = derivation.deriveCodec[KV]
+  implicit val circeCodec: Codec[KV] = semiauto.deriveCodec[KV]
   implicit val logstageCodec: LogstageCodec[KV] = LogstageCirceCodec.derived[KV]
 }
 ```

--- a/fundamentals/fundamentals-json-circe/src/main/scala-2/izumi/fundamentals/json/circe/CirceTool.scala
+++ b/fundamentals/fundamentals-json-circe/src/main/scala-2/izumi/fundamentals/json/circe/CirceTool.scala
@@ -1,4 +1,4 @@
-package izumi.fundamentals.reflection
+package izumi.fundamentals.json.circe
 
 import scala.collection.mutable
 import scala.language.experimental.macros
@@ -9,7 +9,7 @@ object CirceTool {
 }
 
 class CirceToolMacro(val c: blackbox.Context) {
-  import c.universe._
+  import c.universe.*
 
   @inline def make[T: c.WeakTypeTag](): c.Expr[Unit] = {
     val all = new mutable.HashSet[Type]()

--- a/fundamentals/fundamentals-json-circe/src/main/scala-2/izumi/fundamentals/json/circe/MaterializeDerivationMacros.scala
+++ b/fundamentals/fundamentals-json-circe/src/main/scala-2/izumi/fundamentals/json/circe/MaterializeDerivationMacros.scala
@@ -1,13 +1,12 @@
 package izumi.fundamentals.json.circe
 
-import io.circe.derivation.DerivationMacros
 import io.circe.{Codec, Decoder, Encoder}
 
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
 
 // TODO: merge upstream, also with @JsonCodec
-final class MaterializeDerivationMacros(override val c: blackbox.Context) extends DerivationMacros(c) {
+final class MaterializeDerivationMacros(val c: blackbox.Context) {
   import c.universe.*
 
   def materializeEncoderImpl[A: c.WeakTypeTag]: c.Expr[DerivationDerivedEncoder[A]] =

--- a/fundamentals/fundamentals-json-circe/src/main/scala-2/izumi/fundamentals/json/circe/WithCirce.scala
+++ b/fundamentals/fundamentals-json-circe/src/main/scala-2/izumi/fundamentals/json/circe/WithCirce.scala
@@ -3,6 +3,9 @@ package izumi.fundamentals.json.circe
 import io.circe.Codec
 
 /**
+  * Requires library dependency on `"io.circe" %% "circe-derivation" % "0.13.0-M5"`
+  * or later (NOT brought in as a dependency automatically)
+  *
   * Provides circe codecs for case classes and sealed traits
   *
   * {{{
@@ -38,6 +41,3 @@ abstract class WithCirce[A]()(implicit derivedCodec: DerivationDerivedCodec[A]) 
 
   implicit val codec: Codec.AsObject[A] = derivedCodec.value
 }
-
-
-

--- a/fundamentals/fundamentals-json-circe/src/main/scala/izumi/fundamentals/json/flat/JsonFlattener.scala
+++ b/fundamentals/fundamentals-json-circe/src/main/scala/izumi/fundamentals/json/flat/JsonFlattener.scala
@@ -7,8 +7,8 @@ import izumi.functional.IzEither.EitherBiAggregate
 import scala.annotation.switch
 import scala.collection.mutable.ArrayBuffer
 import scala.util.control.NonFatal
-import JsonFlattener._
-import PathElement._
+import JsonFlattener.*
+import PathElement.*
 import izumi.fundamentals.platform.strings.IzEscape
 
 class JsonFlattener {


### PR DESCRIPTION
Due to https://github.com/circe/circe-derivation/issues/346

* Remove internal dependency on `fundamentals-json-circe` (unused)
* Move `CirceTool` from fundamentals-reflection to fundamentals-json-circe