### PR TITLE
logstage: Fix withFiberId and withDynamic AbstractLoggerF-based constructors (#508, #1872)

### DIFF
--- a/logstage/logstage-core/.jvm/src/main/scala/izumi/logstage/adapter/jul/LogstageJulLogger.scala
+++ b/logstage/logstage-core/.jvm/src/main/scala/izumi/logstage/adapter/jul/LogstageJulLogger.scala
@@ -1,4 +1,5 @@
 package izumi.logstage.adapter.jul
+
 import izumi.fundamentals.platform.language.SourceFilePosition
 import izumi.logstage.api.Log
 import logstage.LogRouter

--- a/logstage/logstage-core/src/main/scala/logstage/LogIO.scala
+++ b/logstage/logstage-core/src/main/scala/logstage/LogIO.scala
@@ -36,22 +36,6 @@ object LogIO extends LowPriorityLogIOInstances {
     */
   @inline def log[F[_]](implicit l: LogIO[F]): l.type = l
 
-  def fromLogger[F[_]: SyncSafe1](logger: AbstractLoggerF[F]): LogIO[F] = {
-    new UnsafeLogIOSyncSafeInstanceF[F](logger)(SyncSafe1[F]) with LogIO[F] {
-      override def log(entry: Entry): F[Unit] = {
-        logger.log(entry)
-      }
-
-      override def log(logLevel: Level)(messageThunk: => Message)(implicit pos: CodePositionMaterializer): F[Unit] = {
-        logger.log(logLevel)(messageThunk)
-      }
-
-      override def withCustomContext(context: CustomContext): LogIO[F] = {
-        fromLogger[F](logger.withCustomContext(context))
-      }
-    }
-  }
-
   def fromLogger[F[_]: SyncSafe1](logger: AbstractLogger): LogIO[F] = {
     new UnsafeLogIOSyncSafeInstance[F](logger)(SyncSafe1[F]) with LogIO[F] {
       override def log(entry: Entry): F[Unit] = {
@@ -60,6 +44,22 @@ object LogIO extends LowPriorityLogIOInstances {
 
       override def log(logLevel: Level)(messageThunk: => Message)(implicit pos: CodePositionMaterializer): F[Unit] = {
         F.syncSafe(logger.log(logLevel)(messageThunk))
+      }
+
+      override def withCustomContext(context: CustomContext): LogIO[F] = {
+        fromLogger[F](logger.withCustomContext(context))
+      }
+    }
+  }
+
+  def fromLogger[F[_]: SyncSafe1](logger: AbstractLoggerF[F]): LogIO[F] = {
+    new UnsafeLogIOSyncSafeInstanceF[F](logger)(SyncSafe1[F]) with LogIO[F] {
+      override def log(entry: Entry): F[Unit] = {
+        logger.log(entry)
+      }
+
+      override def log(logLevel: Level)(messageThunk: => Message)(implicit pos: CodePositionMaterializer): F[Unit] = {
+        logger.log(logLevel)(messageThunk)
       }
 
       override def withCustomContext(context: CustomContext): LogIO[F] = {

--- a/logstage/logstage-core/src/main/scala/logstage/LogZIO.scala
+++ b/logstage/logstage-core/src/main/scala/logstage/LogZIO.scala
@@ -64,10 +64,7 @@ object LogZIO {
       }
 
       override protected[this] def wrap[A](f: AbstractLogger => A): IO[Nothing, A] = {
-        ZIO.descriptorWith {
-          descriptor =>
-            ZIO.succeed(f(logger.withCustomContext(CustomContext("fiberId" -> descriptor.id))))
-        }
+        addFiberIdToLogger(logger)(logger => ZIO.succeed(f(logger)))
       }
     }
   }
@@ -79,7 +76,7 @@ object LogZIO {
       }
 
       override protected[this] def wrap[A](f: AbstractLogger => A): ZIO[R, Nothing, A] = {
-        dynamic.flatMap(ctx => ZIO.succeed(f(logger.withCustomContext(ctx))))
+        dynamic.flatMap(dynCtx => ZIO.succeed(f(logger.withCustomContext(dynCtx))))
       }
     }
   }
@@ -90,10 +87,9 @@ object LogZIO {
         withFiberId(logger.withCustomContext(context))
       }
 
-      override def log(entry: Log.Entry): IO[Nothing, Unit] = logger.log(entry)
-
-      override def log(logLevel: _root_.izumi.logstage.api.Log.Level)(messageThunk: => Log.Message)(implicit pos: CodePositionMaterializer): IO[Nothing, Unit] =
-        logger.log(logLevel)(messageThunk)
+      override protected[this] def wrap[A](f: AbstractLoggerF[IO[Nothing, _]] => IO[Nothing, A]): IO[Nothing, A] = {
+        addFiberIdToLogger(logger)(f)
+      }
     }
   }
 
@@ -103,10 +99,16 @@ object LogZIO {
         withDynamicContext(logger.withCustomContext(context))(dynamic)
       }
 
-      override def log(entry: Log.Entry): ZIO[R, Nothing, Unit] = logger.log(entry)
+      override protected[this] def wrap[A](f: AbstractLoggerF[ZIO[R, Nothing, _]] => ZIO[R, Nothing, A]): ZIO[R, Nothing, A] = {
+        dynamic.flatMap(dynCtx => f(logger.withCustomContext(dynCtx)))
+      }
+    }
+  }
 
-      override def log(logLevel: _root_.izumi.logstage.api.Log.Level)(messageThunk: => Log.Message)(implicit pos: CodePositionMaterializer): ZIO[R, Nothing, Unit] =
-        logger.log(logLevel)(messageThunk)
+  def addFiberIdToLogger[G[_], R, E, A](logger: AbstractLoggerF[G])(f: logger.Self => ZIO[R, E, A]): ZIO[R, E, A] = {
+    ZIO.descriptorWith {
+      descriptor =>
+        f(logger.withCustomContext(CustomContext("fiberId" -> descriptor.id.threadName)))
     }
   }
 

--- a/logstage/logstage-core/src/main/scala/logstage/LogstageCats.scala
+++ b/logstage/logstage-core/src/main/scala/logstage/LogstageCats.scala
@@ -16,20 +16,19 @@ object LogstageCats {
       }
 
       override protected[this] def wrap[T](f: AbstractLogger => T): F[T] = {
-        dynamic.flatMap(ctx => SyncSafe1[F].syncSafe(f(logger.withCustomContext(ctx))))
+        dynamic.flatMap(dynCtx => SyncSafe1[F].syncSafe(f(logger.withCustomContext(dynCtx))))
       }
     }
   }
 
   def withDynamicContext[F[_]: Monad: SyncSafe1](logger: AbstractLoggerF[F])(dynamic: F[CustomContext]): LogIO[F] = {
     new WrappedLogIOF[F](logger)(SyncSafe1[F]) {
-
-      override def log(entry: Entry): F[Unit] = logger.log(entry)
-
-      override def log(logLevel: Log.Level)(messageThunk: => Message)(implicit pos: CodePositionMaterializer): F[Unit] = logger.log(logLevel)(messageThunk)
-
       override def withCustomContext(context: CustomContext): LogIO[F] = {
         withDynamicContext(logger.withCustomContext(context))(dynamic)
+      }
+
+      override protected[this] def wrap[A](f: AbstractLoggerF[F] => F[A]): F[A] = {
+        dynamic.flatMap(dynCtx => f(logger.withCustomContext(dynCtx)))
       }
     }
   }
@@ -50,5 +49,11 @@ object LogstageCats {
     logger: AbstractLoggerF[F]
   )(F: SyncSafe1[F]
   ) extends UnsafeLogIOSyncSafeInstanceF[F](logger)(F)
-    with LogIO[F] {}
+    with LogIO[F] {
+    protected[this] def wrap[A](f: AbstractLoggerF[F] => F[A]): F[A]
+
+    override final def unsafeLog(entry: Entry): F[Unit] = wrap(_.unsafeLog(entry))
+    override final def log(entry: Entry): F[Unit] = wrap(_.log(entry))
+    override final def log(logLevel: Level)(messageThunk: => Message)(implicit pos: CodePositionMaterializer): F[Unit] = wrap(_.log(logLevel)(messageThunk))
+  }
 }

--- a/logstage/logstage-core/src/main/scala/logstage/UnsafeLogIO.scala
+++ b/logstage/logstage-core/src/main/scala/logstage/UnsafeLogIO.scala
@@ -43,7 +43,11 @@ object UnsafeLogIO extends LowPriorityUnsafeLogIOInstances {
     }
   }
 
-  class UnsafeLogIOSyncSafeInstanceF[F[_]](logger: AbstractLoggerF[F])(F: SyncSafe1[F]) extends LogCreateIOSyncSafeInstance[F](F) with UnsafeLogIO[F] {
+  class UnsafeLogIOSyncSafeInstanceF[F[_]](
+    logger: AbstractLoggerF[F]
+  )(F: SyncSafe1[F] // Used in LogCreateIOSyncSafeInstance
+  ) extends LogCreateIOSyncSafeInstance[F](F)
+    with UnsafeLogIO[F] {
     override def unsafeLog(entry: Entry): F[Unit] = {
       logger.unsafeLog(entry)
     }


### PR DESCRIPTION
They weren't actually doing anything