### PR TITLE
Remove ZManaged

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3036,7 +3036,6 @@ lazy val `distage-framework-docker` = project.in(file("distage/distage-framework
       "org.typelevel" %% "cats-core" % V.cats % Test,
       "org.typelevel" %% "cats-effect" % V.cats_effect % Test,
       "dev.zio" %% "zio" % V.zio % Test excludeAll("dev.zio" %% "izumi-reflect"),
-      "dev.zio" %% "zio-managed" % V.zio % Test excludeAll("dev.zio" %% "izumi-reflect"),
       "dev.zio" %% "izumi-reflect" % V.izumi_reflect % Test,
       "com.github.docker-java" % "docker-java-core" % V.docker_java,
       "com.github.docker-java" % "docker-java-transport-zerodep" % V.docker_java
@@ -3356,7 +3355,6 @@ lazy val `distage-testkit-scalatest` = project.in(file("distage/distage-testkit-
       "org.typelevel" %% "cats-core" % V.cats % Optional,
       "org.typelevel" %% "cats-effect" % V.cats_effect % Optional,
       "dev.zio" %% "zio" % V.zio % Optional excludeAll("dev.zio" %% "izumi-reflect"),
-      "dev.zio" %% "zio-managed" % V.zio % Optional excludeAll("dev.zio" %% "izumi-reflect"),
       "dev.zio" %% "izumi-reflect" % V.izumi_reflect % Optional,
       "org.scalatest" %% "scalatest" % V.scalatest
     ),
@@ -4216,7 +4214,6 @@ lazy val `microsite` = project.in(file("doc/microsite"))
       "org.typelevel" %% "cats-core" % V.cats,
       "org.typelevel" %% "cats-effect" % V.cats_effect,
       "dev.zio" %% "zio" % V.zio excludeAll("dev.zio" %% "izumi-reflect"),
-      "dev.zio" %% "zio-managed" % V.zio excludeAll("dev.zio" %% "izumi-reflect"),
       "dev.zio" %% "zio-interop-cats" % V.zio_interop_cats excludeAll("dev.zio" %% "izumi-reflect"),
       "dev.zio" %% "izumi-reflect" % V.izumi_reflect,
       "org.tpolecat" %% "doobie-core" % V.doobie,

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/dsl/LifecycleAdapters.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/dsl/LifecycleAdapters.scala
@@ -8,7 +8,6 @@ import izumi.functional.bio.Local3
 import izumi.fundamentals.platform.language.Quirks.Discarder
 import izumi.reflect.{Tag, TagK, TagK3}
 import zio.*
-import zio.managed.ZManaged
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 object LifecycleAdapters {
@@ -69,21 +68,7 @@ object LifecycleAdapters {
     }
 
     /**
-      * Allows you to bind [[zio.managed.ZManaged]]-based constructor functions in `ModuleDef`:
-      */
-    implicit final def providerFromZIOProvider[R, E, A]: AdaptFunctoid.Aux[ZManaged[R, E, A], Lifecycle.FromZIO[R, E, A]] = {
-      new AdaptFunctoid[ZManaged[R, E, A]] {
-        type Out = Lifecycle.FromZIO[R, E, A]
-
-        override def apply(a: Functoid[ZManaged[R, E, A]])(implicit tag: LifecycleTag[Lifecycle.FromZIO[R, E, A]]): Functoid[Lifecycle.FromZIO[R, E, A]] = {
-          import tag.tagFull
-          a.map(Lifecycle.fromZIO(_))
-        }
-      }
-    }
-
-    /**
-      * Allows you to bind [[zio.managed.ZManaged]]-based constructor functions in `ModuleDef`:
+      * Allows you to bind [[zio.ZLayer]]-based constructor functions in `ModuleDef`:
       */
     implicit final def providerFromZLayerProvider[R, E, A: Tag]: AdaptFunctoid.Aux[ZLayer[R, E, A], Lifecycle.FromZIO[R, E, A]] = {
       new AdaptFunctoid[ZLayer[R, E, A]] {

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/dsl/ModuleDefDSL.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/dsl/ModuleDefDSL.scala
@@ -15,7 +15,6 @@ import izumi.fundamentals.platform.functional.Identity
 import izumi.fundamentals.platform.language.CodePositionMaterializer
 import izumi.reflect.{Tag, TagK}
 import zio.*
-import zio.managed.ZManaged
 
 import scala.annotation.unused
 import scala.collection.immutable.HashSet
@@ -503,13 +502,6 @@ object ModuleDefDSL {
         dsl.fromEffect[IO[E, _], I](function.map2(ZEnvConstructor[R])(_.provideEnvironment(_)))
       }
 
-      def fromZEnv[R: ZEnvConstructor, E: Tag, I <: T: Tag](resource: ZManaged[R, E, I]): AfterBind = {
-        dsl.fromResource(ZEnvConstructor[R].map(resource.provideEnvironment(_)))
-      }
-      def fromZEnv[R: ZEnvConstructor, E: Tag, I <: T: Tag](function: Functoid[ZManaged[R, E, I]])(implicit d1: DummyImplicit): AfterBind = {
-        dsl.fromResource(function.map2(ZEnvConstructor[R])(_.provideEnvironment(_)))
-      }
-
       def fromZEnv[R: ZEnvConstructor, E: Tag, I <: T: Tag](layer: ZLayer[R, E, I]): AfterBind = {
         dsl.fromResource(ZEnvConstructor[R].map(ZLayer.succeedEnvironment(_) >>> layer))
       }
@@ -587,17 +579,6 @@ object ModuleDefDSL {
       }
       def addHas[R: ZEnvConstructor, E: Tag, I <: T: Tag](function: Functoid[ZIO[R, E, I]])(implicit pos: CodePositionMaterializer): AfterAdd = {
         dsl.addEffect[IO[E, _], I](function.map2(ZEnvConstructor[R])(_.provideEnvironment(_)))
-      }
-
-      def addHas[R: ZEnvConstructor, E: Tag, I <: T: Tag](resource: ZManaged[R, E, I])(implicit pos: CodePositionMaterializer): AfterAdd = {
-        dsl.addResource(ZEnvConstructor[R].map(resource.provideEnvironment(_)))
-      }
-      def addHas[R: ZEnvConstructor, E: Tag, I <: T: Tag](
-        function: Functoid[ZManaged[R, E, I]]
-      )(implicit pos: CodePositionMaterializer,
-        d1: DummyImplicit,
-      ): AfterAdd = {
-        dsl.addResource(function.map2(ZEnvConstructor[R])(_.provideEnvironment(_)))
       }
 
       def addHas[R: ZEnvConstructor, E: Tag, I <: T: Tag](layer: ZLayer[R, E, I])(implicit pos: CodePositionMaterializer): AfterAdd = {

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/providers/Functoid.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/providers/Functoid.scala
@@ -10,7 +10,6 @@ import izumi.fundamentals.platform.language.CodePositionMaterializer
 import izumi.fundamentals.platform.language.Quirks.*
 import izumi.reflect.Tag
 import zio.ZEnvironment
-import zio.managed.ZManaged
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import scala.annotation.unchecked.uncheckedVariance
@@ -308,30 +307,9 @@ private[providers] trait FunctoidLifecycleAdapters {
   }
 
   /**
-    * Allows you to bind [[zio.managed.ZManaged]]-based constructors in `ModuleDef`:
-    */
-  implicit final def providerFromZIO[R, E, A](
-    managed: => ZManaged[R, E, A]
-  )(implicit tag: Tag[Lifecycle.FromZIO[R, E, A]]
-  ): Functoid[Lifecycle.FromZIO[R, E, A]] = {
-    Functoid.lift(Lifecycle.fromZIO(managed))
-  }
-
-  /**
-    * Allows you to bind [[zio.managed.ZManaged]]-based constructors in `ModuleDef`:
-    */
-  // workaround for inference issues with `E=Nothing`, scalac error: Couldn't find Tag[FromZIO[Any, E, Clock]] when binding ZManaged[Any, Nothing, Clock]
-  implicit final def providerFromZIONothing[R, A](
-    managed: => ZManaged[R, Nothing, A]
-  )(implicit tag: Tag[Lifecycle.FromZIO[R, Nothing, A]]
-  ): Functoid[Lifecycle.FromZIO[R, Nothing, A]] = {
-    Functoid.lift(Lifecycle.fromZIO(managed))
-  }
-
-  /**
     * Allows you to bind [[zio.ZLayer]]-based constructors in `ModuleDef`:
     */
-  implicit final def providerFromZLayerHas1[R, E, A: Tag](
+  implicit final def providerFromZLayer[R, E, A: Tag](
     layer: => ZLayer[R, E, A]
   )(implicit tag: Tag[Lifecycle.FromZIO[R, E, A]]
   ): Functoid[Lifecycle.FromZIO[R, E, A]] = {
@@ -341,8 +319,8 @@ private[providers] trait FunctoidLifecycleAdapters {
   /**
     * Allows you to bind [[zio.ZLayer]]-based constructors in `ModuleDef`:
     */
-  // workaround for inference issues with `E=Nothing`, scalac error: Couldn't find Tag[FromZIO[Any, E, Clock]] when binding ZManaged[Any, Nothing, Clock]
-  implicit final def providerFromZLayerNothingHas1[R, A: Tag](
+  // workaround for inference issues with `E=Nothing`, scalac error: Couldn't find Tag[FromZIO[Any, E, Clock]] when binding ZLayer[Any, Nothing, Clock]
+  implicit final def providerFromZLayerNothing[R, A: Tag](
     layer: => ZLayer[R, Nothing, A]
   )(implicit tag: Tag[Lifecycle.FromZIO[R, Nothing, A]]
   ): Functoid[Lifecycle.FromZIO[R, Nothing, A]] = {

--- a/doc/microsite/src/main/tut/distage/basics.md
+++ b/doc/microsite/src/main/tut/distage/basics.md
@@ -427,7 +427,7 @@ Try { Injector().produceRun(SpecificityModule, Activation(Style -> Style.Normal)
 ## Resource Bindings, Lifecycle
 
 You can specify object lifecycle by injecting @scaladoc[distage.Lifecycle](izumi.distage.model.definition.Lifecycle), [cats.effect.Resource](https://typelevel.org/cats-effect/datatypes/resource.html) or
-[zio.managed.ZManaged](https://zio.dev/docs/datatypes/datatypes_managed)
+[zio.ZLayer](https://zio.dev/reference/contextual/zlayer/)
 values specifying the allocation and finalization actions of an object.
 
 When ran, distage `Injector` itself returns a `Lifecycle` value that describes actions to create and finalize the object graph; the `Lifecycle` value is pure and can be reused multiple times.
@@ -524,7 +524,7 @@ println(closedInit.initialized)
 `Lifecycle` forms a monad and has the expected `.map`, `.flatMap`, `.evalMap`, `.mapK` methods.
 
 You can convert between a `Lifecycle` and `cats.effect.Resource` via `Lifecycle#toCats`/`Lifecycle.fromCats` methods,
-and between a `Lifecycle` and `zio.managed.ZManaged` via `Lifecycle#toZIO`/`Lifecycle.fromZIO` methods.
+and between a `Lifecycle` and `zio.ZLayer` via `Lifecycle#toZIO`/`Lifecycle.fromZIO` methods.
 
 ### Inheritance helpers
 
@@ -918,7 +918,7 @@ You need to specify your effect type when constructing `Injector`, as in `Inject
 
 ## ZIO Environment bindings
 
-You can inject into ZIO Environment using `make[_].fromZEnv` syntax for `ZLayer`, `ZManaged`, `ZIO` or any `F[_, _, _]: Local3`:
+You can inject into ZIO Environment using `make[_].fromZEnv` syntax for `ZLayer`, `ZIO` or any `F[_, _, _]: Local3`:
 
 ```scala mdoc:to-string
 import zio._
@@ -1510,6 +1510,6 @@ Cats & ZIO instances and syntax are available automatically in `distage-core`, w
 However, distage *won't* bring in `cats` or `zio` as dependencies if you don't already depend on them.
 (see [No More Orphans](https://blog.7mind.io/no-more-orphans.html) blog post for details on how that works)
 
-@ref[Cats Resource & ZIO ZManaged Bindings](basics.md#resource-bindings-lifecycle) also work out of the box without any magic imports.
+@ref[Cats Resource & ZIO ZLayer Bindings](basics.md#resource-bindings-lifecycle) also work out of the box without any magic imports.
 
 All relevant typeclass instances for chosen effect type, such as `ConcurrentEffect[F]`, are @ref[included by default](basics.md#out-of-the-box-typeclass-instances) (overridable by user bindings)

--- a/doc/microsite/src/main/tut/distage/distage-testkit.md
+++ b/doc/microsite/src/main/tut/distage/distage-testkit.md
@@ -339,8 +339,8 @@ The @ref[ZIO Has injection](basics.md#zio-environment-bindings) support extends 
 While this compiles just fine, this test cannot be run without the object graph containing a `BonusService` component!
 
 Our demonstration application includes `dummy` and `production` implementations for `BonusService`.
-For each implementation, we define a `ZManaged` value describing how to create and finalize it.
-After adding implementations for `BonusService` component using these `ZManaged`'s as constructors, our test cases will be able to use the component `BonusService`.
+For each implementation, we define a `ZLayer` value describing how to create and finalize it.
+After adding implementations for `BonusService` component using these `ZLayer`'s as constructors, our test cases will be able to use the component `BonusService`.
 
 ```scala mdoc:fakepackage:to-string
 "fakepackage app": Unit
@@ -450,7 +450,7 @@ object BonusServicePlugin extends PluginDef {
 
 Here we used @ref[ZIO Has injection](basics.md#zio-environment-bindings) `.fromZEnv` to supply the environment dependencies for `ProdBonusService.managed`, namely `Has[Console.Service]`.
 (Implementation for `Console.Service` is provided by default from @scaladoc[ZIOSupportModule](izumi.distage.modules.support.ZIOSupportModule))
-`.fromZEnv` can be used with `ZLayer`, `ZManaged` `ZIO` or any `F[-_, +_, +_]: Local3` (from @ref[BIO](../bio/00_bio.md) typeclasses).
+`.fromZEnv` can be used with `ZLayer`, `ZIO` or any `F[-_, +_, +_]: Local3` (from @ref[BIO](../bio/00_bio.md) typeclasses).
 
 Note that the `BonusServicePlugin` is not explicitly added to the `Test.config`:
 But, this `PluginDef` class is defined in the same package as the test, namely in `app`. By default the `pluginConfig`

--- a/project/Deps.sc
+++ b/project/Deps.sc
@@ -92,7 +92,7 @@ object Izumi {
 
     final val zio_core = Library("dev.zio", "zio", V.zio, LibraryType.Auto)
       .more(LibSetting.Raw("""excludeAll("dev.zio" %% "izumi-reflect")"""))
-    final val zio_all = Seq(zio_core, zio_managed)
+    final val zio_all = Seq(zio_core)
 
     final val zio_interop_cats = Library("dev.zio", "zio-interop-cats", V.zio_interop_cats, LibraryType.Auto)
       .more(LibSetting.Raw("""excludeAll("dev.zio" %% "izumi-reflect")"""))

--- a/project/Deps.sc
+++ b/project/Deps.sc
@@ -92,8 +92,6 @@ object Izumi {
 
     final val zio_core = Library("dev.zio", "zio", V.zio, LibraryType.Auto)
       .more(LibSetting.Raw("""excludeAll("dev.zio" %% "izumi-reflect")"""))
-    final val zio_managed = Library("dev.zio", "zio-managed", V.zio, LibraryType.Auto)
-      .more(LibSetting.Raw("""excludeAll("dev.zio" %% "izumi-reflect")"""))
     final val zio_all = Seq(zio_core, zio_managed)
 
     final val zio_interop_cats = Library("dev.zio", "zio-interop-cats", V.zio_interop_cats, LibraryType.Auto)


### PR DESCRIPTION
Distage currently has a required dependency on `ZManaged` if you want to use ZIO 2 with `Lifecycle`. This PR removes the `ZManaged` dependency.

This is change is done because ZIO no longer recommends using `ZManaged` and instead prefers `ZIO[Scope, _, _]`.