### PR TITLE
Fix testkit on sbt launching tests defined in other test modules when depending on another test artifact

### DIFF
--- a/distage/distage-testkit-scalatest-sbt-module-filtering-test/src/test/scala/izumi/distage/testkit/modulefiltering/SbtModuleFilteringTest.scala
+++ b/distage/distage-testkit-scalatest-sbt-module-filtering-test/src/test/scala/izumi/distage/testkit/modulefiltering/SbtModuleFilteringTest.scala
@@ -1,0 +1,3 @@
+package izumi.distage.testkit.modulefiltering
+
+final class SbtModuleFilteringTest extends SbtModuleFilteringPoisonPillTest

--- a/distage/distage-testkit-scalatest/src/main/scala/org/scalatest/distage/DistageScalatestTestSuiteRunner.scala
+++ b/distage/distage-testkit-scalatest/src/main/scala/org/scalatest/distage/DistageScalatestTestSuiteRunner.scala
@@ -1,7 +1,7 @@
 package org.scalatest.distage
 
 import _root_.distage.TagK
-import io.github.classgraph.ClassGraph
+import io.github.classgraph.{ClassGraph, ClassInfo}
 import izumi.distage.modules.DefaultModule
 import izumi.distage.testkit.DebugProperties
 import izumi.distage.testkit.model.{DistageTest, SuiteId}
@@ -12,12 +12,14 @@ import izumi.distage.testkit.services.scalatest.dstest.{DistageTestsRegistrySing
 import izumi.distage.testkit.spec.AbstractDistageSpec
 import izumi.fundamentals.platform.console.TrivialLogger
 import izumi.fundamentals.platform.functional.Identity
+import izumi.fundamentals.platform.jvm.IzClasspath
 import org.scalatest.*
 import org.scalatest.exceptions.TestCanceledException
 
 import java.util.concurrent.atomic.AtomicBoolean
 import scala.collection.immutable.TreeSet
 import scala.util.Try
+import scala.util.chaining.scalaUtilChainingOps
 
 trait ScalatestInitWorkaround {
   def awaitTestsLoaded(): Unit
@@ -48,18 +50,23 @@ object ScalatestInitWorkaround {
         val scan = new ClassGraph()
           .enableClassInfo()
           .addClassLoader(classLoader)
+          .pipe(instance.modifyClasspathScan)
           .scan()
         try {
           val suiteClassName = classOf[DistageScalatestTestSuiteRunner[Identity]].getName
-          val testClasses = scan.getSubclasses(suiteClassName).asScala.filterNot(_.isAbstract)
+
+          val allTestClasses = scan.getSubclasses(suiteClassName).asScala.filterNot(_.isAbstract)
+          val onlyTestClassesInCurrentModule = allTestClasses.filter(instance._sbtIsClassDefinedInCurrentTestModule(classLoader))
+
           lazy val debugLogger = TrivialLogger.make[ScalatestInitWorkaroundImpl.type](DebugProperties.`izumi.distage.testkit.debug`.name)
-          testClasses.foreach(
+          onlyTestClassesInCurrentModule.foreach(
             classInfo =>
               Try {
                 debugLogger.log(s"Added scanned class `${classInfo.getName}` to current test run")
                 classInfo.loadClass().getDeclaredConstructor().newInstance()
               }
           )
+
           DistageTestsRegistrySingleton.disableRegistration()
           latch.countDown()
         } finally {
@@ -77,13 +84,50 @@ abstract class DistageScalatestTestSuiteRunner[F[_]](
 ) extends TestSuite
   with AbstractDistageSpec[F] {
 
-  /** Modify test discovery options for SBT test runner only.
+  /**
+    * Modify test discovery options for SBT test runner only.
     * Overriding this with [[withWhitelistJarsOnly]] will slightly boost test start-up speed,
     * but will disable the ability to discover tests that inherit [[izumi.distage.testkit.services.scalatest.dstest.DistageAbstractScalatestSpec]]
     * indirectly through a different library JAR. (this does not affect local sbt modules)
     */
-  protected def modifyClasspathScan: ClassGraph => ClassGraph = identity
+  def modifyClasspathScan: ClassGraph => ClassGraph = identity
   protected final def withWhitelistJarsOnly: ClassGraph => ClassGraph = _.acceptJars("distage-testkit-scalatest*")
+
+  /**
+    * Override this to change the heuristic by which testkit determines that a test class is defined in the current SBT module.
+    *
+    * Affects SBT test runner only.
+    *
+    * By default we assume that classes with classfiles located in the first directory on the classpath
+    * which contains `test-classes` in its pathname are the classes defined in the current SBT test module.
+    *
+    * @see [[_sbtFindCurrentTestModuleClasspathElement]] - override this to change just the method for finding the `test-classes` directory not all the logic
+    */
+  def _sbtIsClassDefinedInCurrentTestModule(classLoader: ClassLoader): ClassInfo => Boolean = {
+    val classpathElems = IzClasspath.safeClasspathSeq(classLoader)
+    _sbtFindCurrentTestModuleClasspathElement(classpathElems) match {
+      case Some(firstTestClassesDir) =>
+        (classInfo: ClassInfo) => {
+          val file = classInfo.getClasspathElementFile
+          file.isDirectory && file.toString == firstTestClassesDir
+        }
+      case None =>
+        import izumi.fundamentals.platform.strings.IzString.*
+        System.err.println(
+          s"""DISTAGE-TESTKIT CRITICAL: Couldn't find a `test-classes` directory on the classpath, disabling fix preventing launch of tests defined in other sbt modules.
+             |Classpath was = ${classpathElems.niceList()}""".stripMargin
+        )
+        _ => true
+    }
+  }
+
+  /**
+    * Override this to change the method for finding the `test-classes` directory for [[_sbtIsClassDefinedInCurrentTestModule]]
+    */
+  protected def _sbtFindCurrentTestModuleClasspathElement(classpathElems: Seq[String]): Option[String] = {
+    val firstTestClassesDir = classpathElems.find(_.contains("test-classes"))
+    firstTestClassesDir
+  }
 
   // initialize status early, so that runner can set it to `true` even before this test is discovered
   // by scalatest, if it was already executed by that time

--- a/distage/distage-testkit-scalatest/src/test/scala/izumi/distage/testkit/modulefiltering/SbtModuleFilteringPoisonPillTest.scala
+++ b/distage/distage-testkit-scalatest/src/test/scala/izumi/distage/testkit/modulefiltering/SbtModuleFilteringPoisonPillTest.scala
@@ -1,0 +1,22 @@
+package izumi.distage.testkit.modulefiltering
+
+import izumi.distage.testkit.scalatest.SpecIdentity
+
+import java.util.concurrent.atomic.AtomicReference
+
+object SbtModuleFilteringPoisonPillTest {
+  val poisonPillTestsLaunched: AtomicReference[Int] = new AtomicReference(0)
+}
+
+open class SbtModuleFilteringPoisonPillTest extends SpecIdentity {
+
+  "SBT test module filtering fix" should {
+
+    "prevent `sbt test` task in `distage-testkit-scalatest-sbt-module-filtering-test` from launching test classes defined in `distage-testkit-scalatest` test scope" in {
+      val testsLaunched = SbtModuleFilteringPoisonPillTest.poisonPillTestsLaunched.updateAndGet(_ + 1)
+      assert(testsLaunched == 1)
+    }
+
+  }
+
+}

--- a/project/Deps.sc
+++ b/project/Deps.sc
@@ -365,6 +365,7 @@ object Izumi {
       final lazy val framework = ArtifactId("distage-framework")
       final lazy val testkitCore = ArtifactId("distage-testkit-core")
       final lazy val testkitScalatest = ArtifactId("distage-testkit-scalatest")
+      final lazy val testkitScalatestSbtModuleFilteringTest = ArtifactId("distage-testkit-scalatest-sbt-module-filtering-test")
       final lazy val extensionLogstage = ArtifactId("distage-extension-logstage")
     }
 
@@ -633,6 +634,17 @@ object Izumi {
           // and scoverage requires scala-xml v1 on Scala 2.12,
           // introduced when updating scoverage to 2.0.0 https://github.com/7mind/izumi/pull/1754
           "libraryDependencySchemes" += """"org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always""".raw
+        ),
+      ),
+      Artifact(
+        name = Projects.distage.testkitScalatestSbtModuleFilteringTest,
+        libs = Nil,
+        depends = Seq(
+          Projects.distage.testkitScalatest tin Scope.Test.all
+        ),
+        platforms = Targets.jvm3,
+        settings = Seq(
+          "skip" in SettingScope.Raw("publish") := true
         ),
       ),
     ),

--- a/sbtgen.sc
+++ b/sbtgen.sc
@@ -1,5 +1,5 @@
 #!/bin/sh
-cs launch com.lihaoyi:ammonite_2.13.0:1.6.9 --fork -M ammonite.Main -- sbtgen.sc $*
+cs launch com.lihaoyi:ammonite_2.13.12:2.5.11 --fork -M ammonite.Main -- sbtgen.sc $*
 exit
 !#
 import $file.project.Deps, Deps._


### PR DESCRIPTION
This workaround alters the classpath scanning logic to only consider classes defined in the first `test-classes` directory encountered on the classpath to be those defined in 'current module'. It seems that for SBT the heuristic that the current test module classes will be placed in the first `test-classes` dir on the classpath generally holds. However, if it fails, you may be able to fix test running by overriding `_sbtIsClassDefinedInCurrentTestModule` or `_sbtFindCurrentTestModuleClasspathElement` in your tests to suit your needs.


Also fix `DistageScalatestTestSuiteRunner#modifyClasspathScan` modifier not being applied (it was never applied, ugh...)