### PR TITLE
distage-config: add field names and structure metadata to auto-derived config codecs

### DIFF
--- a/distage/distage-extension-config/.jvm/src/main/scala-2/izumi/distage/config/codec/PureconfigAutoDerive.scala
+++ b/distage/distage-extension-config/.jvm/src/main/scala-2/izumi/distage/config/codec/PureconfigAutoDerive.scala
@@ -33,7 +33,9 @@ import scala.reflect.macros.blackbox
   *   }
   * }}}
   */
-final class PureconfigAutoDerive[A](val value: ConfigReader[A]) extends AnyVal
+final class PureconfigAutoDerive[A](val value: ConfigReader[A]) extends AnyVal {
+  def fieldsMeta: ConfigMeta = ConfigReaderWithConfigMeta.maybeFieldsFromConfigReader(value)
+}
 
 object PureconfigAutoDerive {
   @inline def apply[A](implicit ev: PureconfigAutoDerive[A]): ConfigReader[A] = ev.value
@@ -49,10 +51,10 @@ object PureconfigAutoDerive {
         // Yes, this is legal /_\ !! We add an import so that implicit scope is enhanced
         // by new config codecs that aren't in ConfigReader companion object
         q"""{
-           import _root_.pureconfig.module.magnolia.auto.reader._
+           import _root_.izumi.distage.config.codec.PureconfigInstances.auto._
            import _root_.izumi.distage.config.codec.PureconfigInstances._
 
-           new ${weakTypeOf[PureconfigAutoDerive[A]]}(_root_.pureconfig.module.magnolia.auto.reader.exportReader[${weakTypeOf[A]}].instance)
+           new ${weakTypeOf[PureconfigAutoDerive[A]]}(_root_.izumi.distage.config.codec.PureconfigInstances.auto.exportReader[${weakTypeOf[A]}].instance)
          }"""
       }
     }

--- a/distage/distage-extension-config/.jvm/src/main/scala-3/izumi/distage/config/codec/PureconfigAutoDerive.scala
+++ b/distage/distage-extension-config/.jvm/src/main/scala-3/izumi/distage/config/codec/PureconfigAutoDerive.scala
@@ -35,7 +35,9 @@ import scala.language.implicitConversions
   *   }
   * }}}
   */
-final class PureconfigAutoDerive[A](val value: ConfigReader[A]) extends AnyVal
+final class PureconfigAutoDerive[A](val value: ConfigReader[A]) extends AnyVal {
+  def fieldsMeta: ConfigMeta = ConfigReaderWithConfigMeta.maybeFieldsFromConfigReader(value)
+}
 
 object PureconfigAutoDerive {
   @inline def apply[A](implicit ev: PureconfigAutoDerive[A]): ConfigReader[A] = ev.value
@@ -44,7 +46,7 @@ object PureconfigAutoDerive {
 
   inline implicit def materialize[A](implicit m: Mirror.Of[A]): PureconfigAutoDerive[A] = {
     import izumi.distage.config.codec.PureconfigInstances.auto.exportDerivedConfigReader
-    import izumi.distage.config.codec.PureconfigInstances.configReaderDerivation
-    new PureconfigAutoDerive[A](configReaderDerivation.derived[A](using m))
+    import izumi.distage.config.codec.PureconfigInstances.given
+    new PureconfigAutoDerive[A](izumi.distage.config.codec.PureconfigInstances.configReaderDerivation.derived[A](using m))
   }
 }

--- a/distage/distage-extension-config/.jvm/src/main/scala/izumi/distage/config/codec/ConfigReaderWithConfigMeta.scala
+++ b/distage/distage-extension-config/.jvm/src/main/scala/izumi/distage/config/codec/ConfigReaderWithConfigMeta.scala
@@ -1,0 +1,15 @@
+package izumi.distage.config.codec
+
+import pureconfig.ConfigReader
+
+trait ConfigReaderWithConfigMeta[A] extends ConfigReader[A] {
+  def fieldsMeta: ConfigMeta
+}
+object ConfigReaderWithConfigMeta {
+  def maybeFieldsFromConfigReader(configReader: ConfigReader[?]): ConfigMeta = {
+    configReader match {
+      case withMeta: ConfigReaderWithConfigMeta[?] => withMeta.fieldsMeta
+      case _ => ConfigMeta.ConfigMetaUnknown()
+    }
+  }
+}

--- a/distage/distage-extension-config/.jvm/src/main/scala/izumi/distage/config/codec/PureconfigSharedInstances.scala
+++ b/distage/distage-extension-config/.jvm/src/main/scala/izumi/distage/config/codec/PureconfigSharedInstances.scala
@@ -1,0 +1,17 @@
+package izumi.distage.config.codec
+
+import pureconfig.{ConfigCursor, ConfigReader, ReadsMissingKeys}
+
+trait PureconfigSharedInstances {
+
+  implicit final def optionReaderWithFields[A](implicit configReader: ConfigReader[A]): ConfigReaderWithConfigMeta[Option[A]] = {
+    val inner = ConfigReader.optionReader[A](configReader)
+    val fields = ConfigReaderWithConfigMeta.maybeFieldsFromConfigReader(configReader)
+    new ConfigReaderWithConfigMeta[Option[A]] with ReadsMissingKeys {
+      override def from(cur: ConfigCursor): ConfigReader.Result[Option[A]] = inner.from(cur)
+
+      override def fieldsMeta: ConfigMeta = fields
+    }
+  }
+
+}

--- a/distage/distage-extension-config/.jvm/src/test/resources/anyval-test.conf
+++ b/distage/distage-extension-config/.jvm/src/test/resources/anyval-test.conf
@@ -1,0 +1,3 @@
+AnyValClass {
+  anyValInt: 5
+}

--- a/distage/distage-extension-config/.jvm/src/test/scala/com/github/pshirshov/configapp/TestConfigReaders.scala
+++ b/distage/distage-extension-config/.jvm/src/test/scala/com/github/pshirshov/configapp/TestConfigReaders.scala
@@ -11,7 +11,7 @@ case class MapCaseClass(mymap: Map[String, HostPort])
 
 case class ListCaseClass(mylist: IndexedSeq[ListSet[Wrapper[HostPort]]])
 
-case class OptionCaseClass(optInt: Option[Int])
+case class OptionCaseClass(optInt: Option[Int], optCustomObject: Option[NestedObject])
 
 case class BackticksCaseClass(`boo-lean`: Boolean)
 
@@ -20,9 +20,9 @@ case class SealedCaseClass(sealedTrait1: SealedTrait1)
 case class TupleCaseClass(tuple: (Int, String, Boolean, Option[Either[Boolean, List[String]]]))
 
 case class CustomCaseClass(
-  customObject: CustomObject,
-  mapCustomObject: Map[String, CustomObject],
-  mapListCustomObject: Map[String, List[CustomObject]],
+  customObject: CustomCodecObject,
+  mapCustomObject: Map[String, CustomCodecObject],
+  mapListCustomObject: Map[String, List[CustomCodecObject]],
 )
 
 case class PrivateCaseClass(
@@ -37,12 +37,14 @@ case class PartiallyPrivateCaseClass(
   val customFieldName = `private-custom-field-name`
 }
 
-case class CustomObject(value: Int)
-object CustomObject {
-  implicit val pureconfigReader: ConfigReader[CustomObject] = ConfigReader.fromStringOpt {
-    case "eaaxacaca" => Some(CustomObject(453))
-    case "a" => Some(CustomObject(45))
-    case _ => Some(CustomObject(1))
+case class NestedObject(value: Int)
+
+case class CustomCodecObject(value: Int)
+object CustomCodecObject {
+  implicit val pureconfigReader: ConfigReader[CustomCodecObject] = ConfigReader.fromStringOpt {
+    case "eaaxacaca" => Some(CustomCodecObject(453))
+    case "a" => Some(CustomCodecObject(45))
+    case _ => Some(CustomCodecObject(1))
   }
 }
 
@@ -60,6 +62,10 @@ object SealedTrait2 {
 
 case class Wrapper[A](wrap: A)
 case class Service[A](conf: A)
+
+case class AnyValClass(anyValInt: AnyValInt)
+
+final class AnyValInt(val int: Int) extends AnyVal
 
 object TestConfigReaders {
   final val mapDefinition = PlannerInput.everything(new ConfigModuleDef {
@@ -106,4 +112,11 @@ object TestConfigReaders {
     make[Service[PartiallyPrivateCaseClass]]
     makeConfig[PartiallyPrivateCaseClass]("PartiallyPrivateCaseClass")
   })
+
+  // Derivation for AnyVals is not supported on Scala 3, requires a custom macro / library like
+  // https://github.com/softwaremill/tapir/blob/84e4b3cb3bb209ac6c4fde3aecb13ca71afe6609/core/src/main/scala-3/sttp/tapir/internal/CodecValueClassMacro.scala
+//  final val anyvalCodecDefinition = PlannerInput.everything(new ConfigModuleDef {
+//    make[Service[AnyValClass]]
+//    makeConfig[AnyValClass]("AnyValClass")
+//  })
 }

--- a/distage/distage-extension-config/.jvm/src/test/scala/izumi/distage/config/ConfigMetaTest.scala
+++ b/distage/distage-extension-config/.jvm/src/test/scala/izumi/distage/config/ConfigMetaTest.scala
@@ -1,0 +1,130 @@
+package izumi.distage.config
+
+import com.github.pshirshov.configapp.TestConfigReaders
+import izumi.distage.config.codec.ConfigMeta
+import izumi.distage.config.model.ConfTag
+import izumi.distage.model.PlannerInput
+import org.scalatest.wordspec.AnyWordSpec
+
+final class ConfigMetaTest extends AnyWordSpec {
+
+  def getConfTag(plannerInput: PlannerInput): ConfTag = {
+    val tags = plannerInput.bindings.iterator.flatMap {
+      b => b.tags.collect { case c: ConfTag => c }
+    }.toSeq
+    assert(tags.size == 1)
+    tags.head
+  }
+
+  "Config fields meta" should {
+
+    "be unknown for config maps" in {
+      val c = getConfTag(TestConfigReaders.mapDefinition)
+      assert(c.fieldsMeta == ConfigMeta.ConfigMetaCaseClass(Seq("mymap" -> ConfigMeta.ConfigMetaUnknown())))
+    }
+
+    "be unknown for config lists" in {
+      val c = getConfTag(TestConfigReaders.listDefinition)
+      assert(c.fieldsMeta == ConfigMeta.ConfigMetaCaseClass(Seq("mylist" -> ConfigMeta.ConfigMetaUnknown())))
+    }
+
+    "be as expected for config options" in {
+      val c = getConfTag(TestConfigReaders.optDefinition)
+      assert(
+        c.fieldsMeta == ConfigMeta.ConfigMetaCaseClass(
+          Seq(
+            "optInt" -> ConfigMeta.ConfigMetaUnknown(),
+            "optCustomObject" -> ConfigMeta.ConfigMetaCaseClass(Seq("value" -> ConfigMeta.ConfigMetaUnknown())),
+          )
+        )
+      )
+    }
+
+    "be unknown for config tuples" in {
+      val c = getConfTag(TestConfigReaders.tupleDefinition)
+      assert(c.fieldsMeta == ConfigMeta.ConfigMetaCaseClass(Seq("tuple" -> ConfigMeta.ConfigMetaUnknown())))
+    }
+
+    "be unknown for custom codecs" in {
+      val c = getConfTag(TestConfigReaders.customCodecDefinition)
+      assert(
+        c.fieldsMeta == ConfigMeta.ConfigMetaCaseClass(
+          Seq(
+            "customObject" -> ConfigMeta.ConfigMetaUnknown(),
+            "mapCustomObject" -> ConfigMeta.ConfigMetaUnknown(),
+            "mapListCustomObject" -> ConfigMeta.ConfigMetaUnknown(),
+          )
+        )
+      )
+    }
+
+    "be as expected for backticks" in {
+      val c = getConfTag(TestConfigReaders.backticksDefinition)
+
+      assert(c.fieldsMeta == ConfigMeta.ConfigMetaCaseClass(Seq("boo-lean" -> ConfigMeta.ConfigMetaUnknown())))
+    }
+
+    "be as expected for case classes with private fields" in {
+      val c = getConfTag(TestConfigReaders.privateFieldsCodecDefinition)
+
+      assert(c.fieldsMeta == ConfigMeta.ConfigMetaCaseClass(Seq("private-custom-field-name" -> ConfigMeta.ConfigMetaUnknown())))
+    }
+
+    "be as expected for case classes with partially private fields" in {
+      val c = getConfTag(TestConfigReaders.partiallyPrivateFieldsCodecDefinition)
+
+      assert(
+        c.fieldsMeta == ConfigMeta.ConfigMetaCaseClass(
+          Seq(
+            "private-custom-field-name" -> ConfigMeta.ConfigMetaUnknown(),
+            "publicField" -> ConfigMeta.ConfigMetaUnknown(),
+          )
+        )
+      )
+    }
+
+    "be as exptected for sealed traits" in {
+      val c = getConfTag(TestConfigReaders.sealedDefinition)
+
+      assert(
+        c.fieldsMeta ==
+        ConfigMeta.ConfigMetaCaseClass(
+          Seq(
+            "sealedTrait1" ->
+            ConfigMeta.ConfigMetaSealedTrait(
+              Set(
+                "CaseClass1" -> ConfigMeta.ConfigMetaCaseClass(
+                  Seq(
+                    "int" -> ConfigMeta.ConfigMetaUnknown(),
+                    "string" -> ConfigMeta.ConfigMetaUnknown(),
+                    "boolean" -> ConfigMeta.ConfigMetaUnknown(),
+                    "sealedTrait2" -> ConfigMeta.ConfigMetaSealedTrait(
+                      Set(
+                        "Yes" -> ConfigMeta.ConfigMetaCaseClass(Seq()),
+                        "No" -> ConfigMeta.ConfigMetaCaseClass(Seq()),
+                      )
+                    ),
+                  )
+                ),
+                "CaseClass2" -> ConfigMeta.ConfigMetaCaseClass(
+                  Seq(
+                    "int" -> ConfigMeta.ConfigMetaUnknown(),
+                    "boolean" -> ConfigMeta.ConfigMetaUnknown(),
+                    "sealedTrait2" -> ConfigMeta.ConfigMetaSealedTrait(
+                      Set(
+                        "Yes" -> ConfigMeta.ConfigMetaCaseClass(Seq()),
+                        "No" -> ConfigMeta.ConfigMetaCaseClass(Seq()),
+                      )
+                    ),
+                  )
+                ),
+              )
+            )
+          )
+        )
+      )
+    }
+
+  }
+
+}

--- a/distage/distage-extension-config/.jvm/src/test/scala/izumi/distage/config/ConfigTest.scala
+++ b/distage/distage-extension-config/.jvm/src/test/scala/izumi/distage/config/ConfigTest.scala
@@ -87,7 +87,7 @@ final class ConfigTest extends AnyWordSpec {
 
       val context = injector.produce(plan).unsafeGet()
 
-      assert(context.get[Service[OptionCaseClass]].conf == OptionCaseClass(optInt = None))
+      assert(context.get[Service[OptionCaseClass]].conf == OptionCaseClass(optInt = None, optCustomObject = None))
     }
 
     "resolve config tuples" in {
@@ -103,9 +103,9 @@ final class ConfigTest extends AnyWordSpec {
 
       assert(
         context.get[Service[CustomCaseClass]].conf == CustomCaseClass(
-          CustomObject(453),
-          Map("a" -> CustomObject(453), "b" -> CustomObject(45)),
-          Map("x" -> List(CustomObject(45), CustomObject(453), CustomObject(1))),
+          CustomCodecObject(453),
+          Map("a" -> CustomCodecObject(453), "b" -> CustomCodecObject(45)),
+          Map("x" -> List(CustomCodecObject(45), CustomCodecObject(453), CustomCodecObject(1))),
         )
       )
     }
@@ -116,7 +116,7 @@ final class ConfigTest extends AnyWordSpec {
 
       val context = injector.produce(plan).unsafeGet()
 
-      assert(context.get[Service[OptionCaseClass]].conf == OptionCaseClass(optInt = None))
+      assert(context.get[Service[OptionCaseClass]].conf == OptionCaseClass(optInt = None, optCustomObject = None))
     }
 
     "resolve backticks" in {
@@ -139,6 +139,15 @@ final class ConfigTest extends AnyWordSpec {
 
       assert(context.get[Service[PartiallyPrivateCaseClass]].conf == PartiallyPrivateCaseClass("super secret value", true))
     }
+
+    // Derivation for AnyVals is not supported on Scala 3, requires a custom macro / library like
+    // https://github.com/softwaremill/tapir/blob/84e4b3cb3bb209ac6c4fde3aecb13ca71afe6609/core/src/main/scala-3/sttp/tapir/internal/CodecValueClassMacro.scala
+//    "resolve case classes with AnyVal fields" in {
+//      val context = Injector()
+//        .produce(mkConfigModule("anyval-test.conf")(TestConfigReaders.anyvalCodecDefinition)).unsafeGet()
+//
+//      assert(context.get[Service[AnyValClass]].conf == AnyValClass(new AnyValInt(5)))
+//    }
 
     "resolve config sealed traits (with progression test for https://github.com/scala/bug/issues/11645)" in {
       // FIXME: pureconfig-magnolia can't read enumerations properly

--- a/distage/distage-extension-config/src/main/scala/izumi/distage/config/codec/AbstractDIConfigReader.scala
+++ b/distage/distage-extension-config/src/main/scala/izumi/distage/config/codec/AbstractDIConfigReader.scala
@@ -6,7 +6,9 @@ import izumi.reflect.Tag
 
 import scala.util.Try
 
-trait AbstractDIConfigReader[A] {
+private[codec] trait AbstractDIConfigReader[A] {
+  def fieldsMeta: ConfigMeta
+
   def decodeConfig(config: DistageConfigImpl): Try[A]
 
   def decodeConfig(path: String)(config: DistageConfigImpl)(implicit tag: Tag[A]): A

--- a/distage/distage-extension-config/src/main/scala/izumi/distage/config/codec/ConfigMeta.scala
+++ b/distage/distage-extension-config/src/main/scala/izumi/distage/config/codec/ConfigMeta.scala
@@ -1,0 +1,9 @@
+package izumi.distage.config.codec
+
+sealed trait ConfigMeta
+object ConfigMeta {
+  final case class ConfigMetaCaseClass(fields: Seq[(String, ConfigMeta)]) extends ConfigMeta
+  final case class ConfigMetaSealedTrait(branches: Set[(String, ConfigMeta)]) extends ConfigMeta
+  final case class ConfigMetaEmpty() extends ConfigMeta
+  final case class ConfigMetaUnknown() extends ConfigMeta
+}

--- a/distage/distage-extension-config/src/main/scala/izumi/distage/config/model/ConfTag.scala
+++ b/distage/distage-extension-config/src/main/scala/izumi/distage/config/model/ConfTag.scala
@@ -1,5 +1,11 @@
 package izumi.distage.config.model
 
+import izumi.distage.config.codec.ConfigMeta
 import izumi.distage.model.definition.BindingTag
 
-final case class ConfTag(confPath: String)(val parser: AppConfig => Any) extends BindingTag
+final case class ConfTag(
+  confPath: String
+)(/* excluded from equals/hashCode */
+  val parser: AppConfig => Any,
+  val fieldsMeta: ConfigMeta,
+) extends BindingTag

--- a/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/model/Docker.scala
+++ b/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/model/Docker.scala
@@ -1,6 +1,6 @@
 package izumi.distage.docker.model
 
-import izumi.distage.config.codec.{DIConfigReader, PureconfigAutoDerive}
+import izumi.distage.config.codec.DIConfigReader
 import izumi.distage.docker.ContainerNetworkDef.ContainerNetwork
 import izumi.distage.docker.healthcheck.ContainerHealthCheck
 import izumi.distage.docker.model.Docker.ClientConfig.parseReusePolicy
@@ -246,8 +246,7 @@ object Docker {
   }
 
   object ClientConfig {
-    implicit val configReader: ConfigReader[ClientConfig] = PureconfigAutoDerive.derived
-    implicit val diConfigReader: DIConfigReader[ClientConfig] = DIConfigReader.deriveFromPureconfigConfigReader
+    implicit val diConfigReader: DIConfigReader[ClientConfig] = DIConfigReader.deriveFromPureconfigAutoDerive[ClientConfig]
 
     val defaultReusePolicy: DockerReusePolicy = {
       DebugProperties.`izumi.distage.docker.reuse`


### PR DESCRIPTION
First step towards fixing https://github.com/7mind/izumi/pull/2058