### PR TITLE
Fix TrivialLogger ignoring set DebugProperties

### DIFF
--- a/fundamentals/fundamentals-platform/src/main/scala/izumi/fundamentals/platform/console/TrivialLogger.scala
+++ b/fundamentals/fundamentals-platform/src/main/scala/izumi/fundamentals/platform/console/TrivialLogger.scala
@@ -109,23 +109,13 @@ object TrivialLogger {
         System.getProperty(path).asBoolean().getOrElse(default)
       }
 
-      var idx = 0
-      var out = false
-      var current = parts.head
-      val tail = parts.tail
-
-      while (idx < tail.length) {
-        out = cond(current)
-        if (out) {
-          idx = Int.MaxValue
-        } else {
-          val p = tail(idx)
-          current = s"$current.$p"
-          idx = idx + 1
-        }
-      }
-
-      out
+      parts
+        .foldLeft((false, "")) {
+          case (done @ (true, _), _) => done
+          case ((_, prev), p) =>
+            val current = if (prev.isEmpty) p else s"$prev.$p"
+            (cond(current), current)
+        }._1
     }
 
     config.forceLog || enabled.getOrElseUpdate(sysProperty, check())

--- a/fundamentals/fundamentals-platform/src/test/scala/izumi/fundamentals/platform/TrivialLoggerTest.scala
+++ b/fundamentals/fundamentals-platform/src/test/scala/izumi/fundamentals/platform/TrivialLoggerTest.scala
@@ -1,0 +1,42 @@
+package izumi.fundamentals.platform
+
+import izumi.fundamentals.platform.console.{AbstractStringTrivialSink, TrivialLogger}
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.collection.mutable
+
+class TrivialLoggerTest extends AnyWordSpec {
+
+  "system properties work in TrivialLogger" in {
+
+    System.setProperty("demotestizumi1", "true")
+    System.setProperty("demotestizumi2.demo", "true")
+    System.setProperty("demotestizumi3.demo.test", "true")
+
+    val signals = mutable.Set.empty[String]
+
+    val signalSink = new AbstractStringTrivialSink {
+      override def flush(value: => String): Unit = signals += value
+      override def flushError(value: => String): Unit = signals += value
+    }
+
+    val logger1 = TrivialLogger.make[TrivialLoggerTest]("demotestizumi1.demo.test", TrivialLogger.Config(signalSink))
+    val logger2 = TrivialLogger.make[TrivialLoggerTest]("demotestizumi2.demo.test", TrivialLogger.Config(signalSink))
+    val logger3 = TrivialLogger.make[TrivialLoggerTest]("demotestizumi3.demo.test", TrivialLogger.Config(signalSink))
+    val logger4 = TrivialLogger.make[TrivialLoggerTest]("demotestizumi4.demo.test", TrivialLogger.Config(signalSink))
+
+    logger1.log("1")
+    logger2.log("2")
+    logger3.log("3")
+    logger4.log("4")
+
+    assert(
+      signals.toSet == Set(
+        "TrivialLoggerTest: 1",
+        "TrivialLoggerTest: 2",
+        "TrivialLoggerTest: 3",
+      )
+    )
+  }
+
+}


### PR DESCRIPTION
last part of system property was ignored, setting `-Da.b=true` would work, but not `-Da.b.c=true`

was broken in 7d3b0090a6ece2af3d295156ad600da751fd4a7f