### PR TITLE
Handle null logger name for acceptable check

### DIFF
--- a/logstage/logstage-core/.jvm/src/main/scala/izumi/logstage/adapter/jul/LogstageJulLogger.scala
+++ b/logstage/logstage-core/.jvm/src/main/scala/izumi/logstage/adapter/jul/LogstageJulLogger.scala
@@ -19,7 +19,8 @@ import scala.collection.compat.immutable.ArraySeq
 class LogstageJulLogger(router: LogRouter) extends java.util.logging.Handler with JULTools with AutoCloseable {
   override def publish(record: LogRecord): Unit = {
     val level = toLevel(record)
-    if (router.acceptable(Log.LoggerId(record.getLoggerName), level)) {
+    val loggerName = Option(record.getLoggerName).getOrElse("unknown")
+    if (router.acceptable(Log.LoggerId(loggerName), level)) {
       router.log(mkEntry(record))
     }
   }

--- a/logstage/logstage-core/.jvm/src/main/scala/izumi/logstage/adapter/jul/LogstageJulLogger.scala
+++ b/logstage/logstage-core/.jvm/src/main/scala/izumi/logstage/adapter/jul/LogstageJulLogger.scala
@@ -19,7 +19,7 @@ import scala.collection.compat.immutable.ArraySeq
 class LogstageJulLogger(router: LogRouter) extends java.util.logging.Handler with JULTools with AutoCloseable {
   override def publish(record: LogRecord): Unit = {
     val level = toLevel(record)
-    val loggerName = Option(record.getLoggerName).getOrElse("unknown")
+    val loggerName = record.getLoggerName match { case null => "null"; case s => s }
     if (router.acceptable(Log.LoggerId(loggerName), level)) {
       router.log(mkEntry(record))
     }


### PR DESCRIPTION
The `acceptable` check doesn't handle null logger names as the `mkEntry` does. This prevents it from failing for that null value.

This is an addition to a previous change. https://github.com/7mind/izumi/pull/1990

Let me know if this isn't the desired behavior and if records with null logger names should either always be accepted or never accepted.

```
[error]   NullPointerException
[error] 
[error]   StringOps.scala:836               scala.collection.StringOps$#split$extension
[error]   LogConfigServiceImpl.scala:21     izumi.logstage.api.routing.LogConfigServiceImpl#threshold
[error]   ConfigurableLogRouter.scala:38    izumi.logstage.api.routing.ConfigurableLogRouter#acceptable
[error]   LogstageJulLogger.scala:22        izumi.logstage.adapter.jul.LogstageJulLogger#publish
[error]   Logger.java:979                   java.util.logging.Logger#log
```