### PR TITLE
Fix config merge order, add test

### DIFF
--- a/distage/distage-framework/.jvm/src/main/scala/izumi/distage/framework/services/ConfigLocationProvider.scala
+++ b/distage/distage-framework/.jvm/src/main/scala/izumi/distage/framework/services/ConfigLocationProvider.scala
@@ -19,9 +19,11 @@ object ConfigLocationProvider {
     }
   }
 
+  // ascending priority. application overrides common
   private def defaultBaseConfigs: Seq[String] = Seq("application", "common")
 
   private def defaultConfigReferences(name: String): Seq[ConfigSource] = {
+    // ascending priority x.conf overrides x-reference.conf
     Seq(
       ConfigSource.Resource(s"$name.conf"),
       ConfigSource.Resource(s"$name-reference.conf"),

--- a/distage/distage-framework/.jvm/src/main/scala/izumi/distage/framework/services/ConfigMerger.scala
+++ b/distage/distage-framework/.jvm/src/main/scala/izumi/distage/framework/services/ConfigMerger.scala
@@ -27,7 +27,7 @@ object ConfigMerger {
       val roleConfigs = role.flatMap(_.loaded)
       val nonEmptyRole = roleConfigs.filterNot(_.config.isEmpty)
 
-      val toMerge = (shared ++ role.filter(filter).flatMap(_.loaded)).filterNot(_.config.isEmpty)
+      val toMerge = (role.filter(filter).flatMap(_.loaded) ++ shared).filterNot(_.config.isEmpty)
 
       val folded = foldConfigs(toMerge)
 
@@ -47,11 +47,9 @@ object ConfigMerger {
     }
 
     def foldConfigs(roleConfigs: List[ConfigLoadResult.Success]): Config = {
-      val fallbackOrdered = roleConfigs.reverse // rightmost config has the highest priority, so we need it to become leftmost
+      verifyConfigs(roleConfigs)
 
-      verifyConfigs(fallbackOrdered)
-
-      fallbackOrdered.foldLeft(ConfigFactory.empty()) {
+      roleConfigs.foldLeft(ConfigFactory.empty()) {
         case (acc, loaded) =>
           acc.withFallback(loaded.config)
       }

--- a/distage/distage-framework/.jvm/src/test/resources/application-reference.conf
+++ b/distage/distage-framework/.jvm/src/test/resources/application-reference.conf
@@ -1,0 +1,7 @@
+
+configTest {
+  applicationReference = 4
+  application = 4
+  roleReference = 4
+  role = 4
+}

--- a/distage/distage-framework/.jvm/src/test/resources/application.conf
+++ b/distage/distage-framework/.jvm/src/test/resources/application.conf
@@ -1,0 +1,6 @@
+
+configTest {
+  application = 5
+  roleReference = 5
+  role = 5
+}

--- a/distage/distage-framework/.jvm/src/test/resources/common-reference-dev.conf
+++ b/distage/distage-framework/.jvm/src/test/resources/common-reference-dev.conf
@@ -1,0 +1,9 @@
+configTest {
+  commonReferenceDev = 1
+  commonReference = 1
+  common = 1
+  applicationReference = 1
+  application = 1
+  roleReference = 1
+  role = 1
+}

--- a/distage/distage-framework/.jvm/src/test/resources/common-reference.conf
+++ b/distage/distage-framework/.jvm/src/test/resources/common-reference.conf
@@ -20,3 +20,12 @@ listconf {
 setElementConfig {
   abc = bca
 }
+
+configTest {
+  commonReference = 2
+  common = 2
+  applicationReference = 2
+  application = 2
+  roleReference = 2
+  role = 2
+}

--- a/distage/distage-framework/.jvm/src/test/resources/common.conf
+++ b/distage/distage-framework/.jvm/src/test/resources/common.conf
@@ -1,0 +1,8 @@
+
+configTest {
+  common = 3
+  applicationReference = 3
+  application = 3
+  roleReference = 3
+  role = 3
+}

--- a/distage/distage-framework/.jvm/src/test/resources/configtest-reference.conf
+++ b/distage/distage-framework/.jvm/src/test/resources/configtest-reference.conf
@@ -1,0 +1,5 @@
+
+configTest {
+  roleReference = 6
+  role = 6
+}

--- a/distage/distage-framework/.jvm/src/test/resources/configtest.conf
+++ b/distage/distage-framework/.jvm/src/test/resources/configtest.conf
@@ -1,0 +1,4 @@
+
+configTest {
+  role = 7
+}

--- a/distage/distage-framework/.jvm/src/test/scala/izumi/distage/roles/test/RoleAppTest.scala
+++ b/distage/distage-framework/.jvm/src/test/scala/izumi/distage/roles/test/RoleAppTest.scala
@@ -178,9 +178,6 @@ class RoleAppTest extends AnyWordSpec with WithProperties {
         bsModule = BootstrapModule.empty,
         bootloader = Injector.bootloader[Identity](BootstrapModule.empty, Activation.empty, DefaultModule.empty, PlannerInput(definition, Activation.empty, roots)),
         logger = logger,
-//        parser = new ActivationParser {
-//          override def parseActivation(config: AppConfig): Activation = ???
-//        },
       )
 
       val plans = roleAppPlanner.makePlan(roots)
@@ -218,9 +215,6 @@ class RoleAppTest extends AnyWordSpec with WithProperties {
         bsModule = BootstrapModule.empty,
         bootloader = Injector.bootloader[Identity](BootstrapModule.empty, Activation.empty, DefaultModule.empty, PlannerInput(definition, Activation.empty, roots)),
         logger = logger,
-//        parser = new ActivationParser {
-//          override def parseActivation(config: AppConfig): Activation = ???
-//        },
       )
 
       val plans = roleAppPlanner.makePlan(roots)
@@ -262,9 +256,6 @@ class RoleAppTest extends AnyWordSpec with WithProperties {
         bsModule = BootstrapModule.empty,
         bootloader = Injector.bootloader[Identity](BootstrapModule.empty, Activation.empty, DefaultModule.empty, PlannerInput(definition, Activation.empty, roots)),
         logger = logger,
-//        parser = new ActivationParser {
-//          override def parseActivation(config: AppConfig): Activation = ???
-//        },
       )
 
       val plans = roleAppPlanner.makePlan(roots)
@@ -391,6 +382,10 @@ class RoleAppTest extends AnyWordSpec with WithProperties {
 
       assert(role5CfgMinParsed.hasPath("rolelocal2"))
       assert(role5CfgMinParsed.hasPath("rolelocal2.bool"))
+    }
+
+    "prioritize configs as expected" in {
+      TestEntrypoint.main(Array("-ll", logLevel, ":" + ConfigTestRole.id))
     }
 
     "roles do not have access to components from MainAppModule" in {

--- a/distage/distage-framework/.jvm/src/test/scala/izumi/distage/roles/test/fixtures/TestPlugin.scala
+++ b/distage/distage-framework/.jvm/src/test/scala/izumi/distage/roles/test/fixtures/TestPlugin.scala
@@ -18,11 +18,14 @@ import izumi.reflect.TagK
 class TestPluginBase[F[_]: TagK] extends PluginDef with ConfigModuleDef with RoleModuleDef {
   tag(Mode.Prod)
 
-  include(BundledRolesModule[F] overriddenBy new ModuleDef {
-    make[ArtifactVersion].named("launcher-version").from(ArtifactVersion(version))
-  }, TagMergePolicy.UseOnlyInner)
+  include(
+    BundledRolesModule[F] overriddenBy new ModuleDef {
+      make[ArtifactVersion].named("launcher-version").from(ArtifactVersion(version))
+    },
+    TagMergePolicy.UseOnlyInner,
+  )
 
-  private def version = Option(System.getProperty(TestPluginCatsIO.versionProperty)) match {
+  private def version: String = Option(System.getProperty(TestPluginCatsIO.versionProperty)) match {
     case Some(value) =>
       value
     case None =>
@@ -50,9 +53,10 @@ class TestPluginBase[F[_]: TagK] extends PluginDef with ConfigModuleDef with Rol
   make[TestRole00Resource[F]]
   make[TestRole00ResourceIntegrationCheck[F]]
 
+  makeRole[ConfigTestRole[F]]
+  makeConfig[ConfigTestConfig]("configTest")
+
   make[NotCloseable].from[InheritedCloseable]
-//  makeRole[ConfigWriter[F]]
-//  makeRole[Help[F]]
 
   make[AxisComponent].from(AxisComponentCorrect).tagged(AxisComponentAxis.Correct)
   make[AxisComponent].from(AxisComponentIncorrect).tagged(AxisComponentAxis.Incorrect)

--- a/distage/distage-framework/.jvm/src/test/scala/izumi/distage/roles/test/fixtures/TestRole00.scala
+++ b/distage/distage-framework/.jvm/src/test/scala/izumi/distage/roles/test/fixtures/TestRole00.scala
@@ -2,7 +2,6 @@ package izumi.distage.roles.test.fixtures
 
 import izumi.distage.framework.services.RoleAppPlanner
 import izumi.distage.model.definition.{Id, Lifecycle}
-import izumi.functional.quasi.QuasiIO
 import izumi.distage.model.provisioning.IntegrationCheck
 import izumi.distage.model.recursive.LocatorRef
 import izumi.distage.roles.launcher.AppResourceProvider.FinalizerFilters
@@ -11,6 +10,7 @@ import izumi.distage.roles.test.fixtures.Fixture.*
 import izumi.distage.roles.test.fixtures.ResourcesPlugin.Conflict
 import izumi.distage.roles.test.fixtures.TestPluginCatsIO.NotCloseable
 import izumi.distage.roles.test.fixtures.roles.TestRole00.TestRole00Resource
+import izumi.functional.quasi.QuasiIO
 import izumi.fundamentals.platform.cli.model.raw.RawEntrypointParams
 import izumi.fundamentals.platform.cli.model.schema.{ParserDef, RoleParserSchema}
 import izumi.fundamentals.platform.integration.ResourceCheck
@@ -183,3 +183,29 @@ class FailingRole02[F[_]: QuasiIO](
 object FailingRole02 extends RoleDescriptor {
   override final val id = "failingrole02"
 }
+
+final class ConfigTestRole[F[_]: QuasiIO](configTestConfig: ConfigTestConfig) extends RoleTask[F] {
+  override def start(roleParameters: RawEntrypointParams, freeArgs: Vector[String]): F[Unit] = QuasiIO[F].maybeSuspend {
+    require(configTestConfig.commonReferenceDev == 1, "common-reference-dev")
+    require(configTestConfig.commonReference == 2, "common-reference")
+    require(configTestConfig.common == 3, "common")
+    require(configTestConfig.applicationReference == 4, "application-reference")
+    require(configTestConfig.application == 5, "application")
+    require(configTestConfig.roleReference == 6, "role-reference")
+    require(configTestConfig.role == 7, "role")
+  }
+}
+
+object ConfigTestRole extends RoleDescriptor {
+  override final val id = "configtest"
+}
+
+final case class ConfigTestConfig(
+  commonReferenceDev: Int,
+  commonReference: Int,
+  common: Int,
+  applicationReference: Int,
+  application: Int,
+  roleReference: Int,
+  role: Int,
+)

--- a/distage/distage-testkit-scalatest/src/test/resources/common-reference.conf
+++ b/distage/distage-testkit-scalatest/src/test/resources/common-reference.conf
@@ -21,3 +21,13 @@ listconf {
 setElementConfig {
   abc = bca
 }
+
+configTest {
+  commonReferenceDev = 1
+  commonReference = 1
+  common = 1
+  applicationReference = 1
+  application = 1
+  roleReference = 1
+  role = 1
+}


### PR DESCRIPTION
Config merge order was reversed (common was higher application, *-reference was higher than regular)