### PR TITLE
Add command-line option `--ignore-all-reference-configs`/`-nc`.

### DIFF
--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/BindingTag.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/BindingTag.scala
@@ -17,6 +17,6 @@ object BindingTag {
 
   final case class AxisTag(choice: AxisChoice) extends BindingTag
 
-  final case object Confined extends BindingTag
-  final case object Exposed extends BindingTag
+  case object Confined extends BindingTag
+  case object Exposed extends BindingTag
 }

--- a/distage/distage-extension-config/.jvm/src/main/scala/izumi/distage/config/model/AppConfig.scala
+++ b/distage/distage-extension-config/.jvm/src/main/scala/izumi/distage/config/model/AppConfig.scala
@@ -26,37 +26,33 @@ object AppConfig {
 }
 
 sealed trait GenericConfigSource
-
 object GenericConfigSource {
-  case class ConfigFile(file: File) extends GenericConfigSource
+  final case class ConfigFile(file: File) extends GenericConfigSource
 
   case object ConfigDefault extends GenericConfigSource
 }
 
-case class RoleConfig(role: String, active: Boolean, configSource: GenericConfigSource)
+final case class RoleConfig(role: String, active: Boolean, configSource: GenericConfigSource)
 
-case class LoadedRoleConfigs(roleConfig: RoleConfig, loaded: Seq[ConfigLoadResult.Success])
+final case class LoadedRoleConfigs(roleConfig: RoleConfig, loaded: Seq[ConfigLoadResult.Success])
 
 sealed trait ConfigLoadResult {
   def clue: String
-
   def src: ConfigSource
-
+  def isExplicit: Boolean
   def toEither: Either[ConfigLoadResult.Failure, ConfigLoadResult.Success]
 }
-
 object ConfigLoadResult {
-  case class Success(clue: String, src: ConfigSource, config: Config) extends ConfigLoadResult {
+  final case class Success(clue: String, src: ConfigSource, isExplicit: Boolean, config: Config) extends ConfigLoadResult {
     override def toEither: Either[ConfigLoadResult.Failure, ConfigLoadResult.Success] = Right(this)
   }
 
-  case class Failure(clue: String, src: ConfigSource, failure: Throwable) extends ConfigLoadResult {
+  final case class Failure(clue: String, src: ConfigSource, isExplicit: Boolean, failure: Throwable) extends ConfigLoadResult {
     override def toEither: Either[ConfigLoadResult.Failure, ConfigLoadResult.Success] = Left(this)
   }
 }
 
 sealed trait ConfigSource
-
 object ConfigSource {
   final case class Resource(name: String) extends ConfigSource {
     override def toString: String = s"resource:$name"

--- a/distage/distage-framework/.js/src/main/scala/izumi/distage/framework/services/ConfigMerger.scala
+++ b/distage/distage-framework/.js/src/main/scala/izumi/distage/framework/services/ConfigMerger.scala
@@ -1,5 +1,3 @@
 package izumi.distage.framework.services
 
-import distage.config.AppConfig
-
 trait ConfigMerger

--- a/distage/distage-framework/.js/src/main/scala/izumi/distage/framework/services/ConfigMerger.scala
+++ b/distage/distage-framework/.js/src/main/scala/izumi/distage/framework/services/ConfigMerger.scala
@@ -1,0 +1,5 @@
+package izumi.distage.framework.services
+
+import distage.config.AppConfig
+
+trait ConfigMerger

--- a/distage/distage-framework/.jvm/src/main/scala/izumi/distage/framework/model/PlanCheckInput.scala
+++ b/distage/distage-framework/.jvm/src/main/scala/izumi/distage/framework/model/PlanCheckInput.scala
@@ -22,7 +22,7 @@ final case class PlanCheckInput[F[_]](
   bsPlugins: LoadedPlugins,
 )
 object PlanCheckInput {
-  private val emptyConfigArgs = ConfigArgsProvider.const(ConfigLoader.Args(None, List.empty, alwaysIncludeReferenceRoleConfigs = true))
+  private val emptyConfigArgs = ConfigArgsProvider.const(ConfigLoader.Args(None, List.empty, true, true, false))
 
   def apply[F[_]](
     module: ModuleBase,

--- a/distage/distage-framework/.jvm/src/main/scala/izumi/distage/framework/model/PlanCheckInput.scala
+++ b/distage/distage-framework/.jvm/src/main/scala/izumi/distage/framework/model/PlanCheckInput.scala
@@ -2,7 +2,7 @@ package izumi.distage.framework.model
 
 import distage.Injector
 import izumi.distage.framework.services.ConfigMerger.ConfigMergerImpl
-import izumi.distage.framework.services.{ConfigArgsProvider, ConfigLoader, ConfigLocationProvider}
+import izumi.distage.framework.services.{ConfigArgsProvider, ConfigFilteringStrategy, ConfigLoader, ConfigLocationProvider}
 import izumi.distage.model.definition.ModuleBase
 import izumi.distage.model.plan.Roots
 import izumi.distage.model.reflection.DIKey
@@ -22,7 +22,7 @@ final case class PlanCheckInput[F[_]](
   bsPlugins: LoadedPlugins,
 )
 object PlanCheckInput {
-  private val emptyConfigArgs = ConfigArgsProvider.const(ConfigLoader.Args(None, List.empty, true, true, false))
+  private val emptyConfigArgs = ConfigArgsProvider.const(ConfigLoader.Args(None, List.empty))
 
   def apply[F[_]](
     module: ModuleBase,
@@ -30,7 +30,7 @@ object PlanCheckInput {
     roleNames: Set[String] = Set.empty,
     configLoader: ConfigLoader = {
       val logger = IzLogger()
-      val merger = new ConfigMergerImpl(logger)
+      val merger = new ConfigMergerImpl(logger, new ConfigFilteringStrategy.Raw(true, true, ignoreAll = false))
       new ConfigLoader.LocalFSImpl(logger, merger, ConfigLocationProvider.Default, emptyConfigArgs)
     },
     appPlugins: LoadedPlugins = LoadedPlugins.empty,

--- a/distage/distage-framework/.jvm/src/main/scala/izumi/distage/framework/services/ConfigArgsProvider.scala
+++ b/distage/distage-framework/.jvm/src/main/scala/izumi/distage/framework/services/ConfigArgsProvider.scala
@@ -1,7 +1,6 @@
 package izumi.distage.framework.services
 
 import izumi.distage.config.model.{GenericConfigSource, RoleConfig}
-import izumi.distage.model.definition.Id
 import izumi.distage.roles.RoleAppMain
 import izumi.distage.roles.model.meta.RolesInfo
 import izumi.fundamentals.platform.cli.model.raw.RawAppArgs
@@ -16,7 +15,7 @@ trait ConfigArgsProvider {
 object ConfigArgsProvider {
   def const(args: ConfigLoader.Args): ConfigArgsProvider = new ConfigArgsProvider.Const(args)
 
-  open class Const(args0: ConfigLoader.Args) extends ConfigArgsProvider {
+  class Const(args0: ConfigLoader.Args) extends ConfigArgsProvider {
     override def args(): ConfigLoader.Args = args0
   }
 
@@ -24,9 +23,6 @@ object ConfigArgsProvider {
   class Default(
     parameters: RawAppArgs,
     rolesInfo: RolesInfo,
-    alwaysIncludeReferenceRoleConfigs: Boolean @Id("distage.roles.always-include-reference-role-configs"),
-    alwaysIncludeReferenceCommonConfigs: Boolean @Id("distage.roles.always-include-reference-common-configs"),
-    ignoreAllReferenceConfigs: Boolean @Id("distage.roles.ignore-all-reference-configs"),
   ) extends ConfigArgsProvider {
 
     override def args(): ConfigLoader.Args = {
@@ -48,11 +44,7 @@ object ConfigArgsProvider {
       }
       val maybeGlobalConfig = parameters.globalParameters.findValue(RoleAppMain.Options.configParam).asFile
 
-      val ignoreAll = ignoreAllReferenceConfigs || parameters.globalParameters.hasFlag(RoleAppMain.Options.ignoreAllReferenceConfigs)
-      val includeRole = !ignoreAll && alwaysIncludeReferenceRoleConfigs
-      val includeCommon = !ignoreAll && alwaysIncludeReferenceCommonConfigs
-
-      ConfigLoader.Args(maybeGlobalConfig, roleConfigs, includeRole, includeCommon, ignoreAll)
+      ConfigLoader.Args(maybeGlobalConfig, roleConfigs)
     }
   }
 }

--- a/distage/distage-framework/.jvm/src/main/scala/izumi/distage/framework/services/ConfigArgsProvider.scala
+++ b/distage/distage-framework/.jvm/src/main/scala/izumi/distage/framework/services/ConfigArgsProvider.scala
@@ -25,7 +25,10 @@ object ConfigArgsProvider {
     parameters: RawAppArgs,
     rolesInfo: RolesInfo,
     alwaysIncludeReferenceRoleConfigs: Boolean @Id("distage.roles.always-include-reference-role-configs"),
+    alwaysIncludeReferenceCommonConfigs: Boolean @Id("distage.roles.always-include-reference-common-configs"),
+    ignoreAllReferenceConfigs: Boolean @Id("distage.roles.ignore-all-reference-configs"),
   ) extends ConfigArgsProvider {
+
     override def args(): ConfigLoader.Args = {
       import scala.collection.compat.*
 
@@ -45,7 +48,11 @@ object ConfigArgsProvider {
       }
       val maybeGlobalConfig = parameters.globalParameters.findValue(RoleAppMain.Options.configParam).asFile
 
-      ConfigLoader.Args(maybeGlobalConfig, roleConfigs, alwaysIncludeReferenceRoleConfigs)
+      val ignoreAll = ignoreAllReferenceConfigs || parameters.globalParameters.hasFlag(RoleAppMain.Options.ignoreAllReferenceConfigs)
+      val includeRole = !ignoreAll && alwaysIncludeReferenceRoleConfigs
+      val includeCommon = !ignoreAll && alwaysIncludeReferenceCommonConfigs
+
+      ConfigLoader.Args(maybeGlobalConfig, roleConfigs, includeRole, includeCommon, ignoreAll)
     }
   }
 }

--- a/distage/distage-framework/.jvm/src/main/scala/izumi/distage/framework/services/ConfigFilteringStrategy.scala
+++ b/distage/distage-framework/.jvm/src/main/scala/izumi/distage/framework/services/ConfigFilteringStrategy.scala
@@ -1,0 +1,65 @@
+package izumi.distage.framework.services
+
+import izumi.distage.config.model.{ConfigLoadResult, LoadedRoleConfigs}
+import izumi.distage.model.definition.Id
+import izumi.distage.roles.RoleAppMain
+import izumi.fundamentals.platform.cli.model.raw.RawAppArgs
+
+trait ConfigFilteringStrategy {
+  def filterSharedConfigs(shared: List[ConfigLoadResult.Success]): List[ConfigLoadResult.Success]
+  def filterRoleConfigs(role: List[LoadedRoleConfigs]): List[LoadedRoleConfigs]
+}
+
+object ConfigFilteringStrategy {
+  def apply(
+    filterShared: List[ConfigLoadResult.Success] => List[ConfigLoadResult.Success],
+    filterRole: List[LoadedRoleConfigs] => List[LoadedRoleConfigs],
+  ): ConfigFilteringStrategy = {
+    new ConfigFilteringStrategy {
+      override def filterSharedConfigs(shared: List[ConfigLoadResult.Success]): List[ConfigLoadResult.Success] = filterShared(shared)
+      override def filterRoleConfigs(role: List[LoadedRoleConfigs]): List[LoadedRoleConfigs] = filterRole(role)
+    }
+  }
+
+  class Default(
+    parameters: RawAppArgs,
+    alwaysIncludeReferenceRoleConfigs: Boolean @Id("distage.roles.always-include-reference-role-configs"),
+    alwaysIncludeReferenceCommonConfigs: Boolean @Id("distage.roles.always-include-reference-common-configs"),
+    ignoreAllReferenceConfigs: Boolean @Id("distage.roles.ignore-all-reference-configs"),
+  ) extends ConfigFilteringStrategy.Raw(
+      alwaysIncludeReferenceRoleConfigs = alwaysIncludeReferenceRoleConfigs,
+      alwaysIncludeReferenceCommonConfigs = alwaysIncludeReferenceCommonConfigs,
+      ignoreAll = ignoreAllReferenceConfigs || parameters.globalParameters.hasFlag(RoleAppMain.Options.ignoreAllReferenceConfigs),
+    )
+
+  open class Raw(
+    alwaysIncludeReferenceRoleConfigs: Boolean,
+    alwaysIncludeReferenceCommonConfigs: Boolean,
+    protected val ignoreAll: Boolean,
+  ) extends ConfigFilteringStrategy {
+
+    protected val includeRoleReferences: Boolean = !ignoreAll && alwaysIncludeReferenceRoleConfigs
+    protected val includeCommonReferences: Boolean = !ignoreAll && alwaysIncludeReferenceCommonConfigs
+
+    override def filterSharedConfigs(shared: List[ConfigLoadResult.Success]): List[ConfigLoadResult.Success] = {
+      if (ignoreAll || (shared.exists(_.isExplicit) && !includeCommonReferences)) {
+        shared.filter(_.isExplicit)
+      } else {
+        shared
+      }
+    }
+
+    override def filterRoleConfigs(role: List[LoadedRoleConfigs]): List[LoadedRoleConfigs] = {
+      role.map {
+        roleConfigs =>
+          if (ignoreAll || (roleConfigs.loaded.exists(_.isExplicit) && !includeRoleReferences)) {
+            roleConfigs.copy(loaded = roleConfigs.loaded.filter(_.isExplicit))
+          } else {
+            roleConfigs
+          }
+      }
+    }
+
+  }
+
+}

--- a/distage/distage-framework/.jvm/src/main/scala/izumi/distage/roles/RoleAppBootConfigModule.scala
+++ b/distage/distage-framework/.jvm/src/main/scala/izumi/distage/roles/RoleAppBootConfigModule.scala
@@ -1,16 +1,17 @@
 package izumi.distage.roles
 
 import izumi.distage.config.model.AppConfig
-import izumi.distage.framework.services.{ConfigArgsProvider, ConfigLoader, ConfigLocationProvider, ConfigMerger}
+import izumi.distage.framework.services.{ConfigArgsProvider, ConfigFilteringStrategy, ConfigLoader, ConfigLocationProvider, ConfigMerger}
 import izumi.distage.model.definition.ModuleDef
 import izumi.distage.modules.DefaultModule
 import izumi.reflect.TagK
 
-class RoleAppBootConfigModule[F[_]: TagK: DefaultModule]() extends ModuleDef {
+class RoleAppBootConfigModule[F[_]: TagK: DefaultModule] extends ModuleDef {
   make[ConfigLoader].from[ConfigLoader.LocalFSImpl]
   make[ConfigMerger].from[ConfigMerger.ConfigMergerImpl]
   make[ConfigLocationProvider].from(ConfigLocationProvider.Default)
   make[ConfigArgsProvider].from[ConfigArgsProvider.Default]
+  make[ConfigFilteringStrategy].from[ConfigFilteringStrategy.Default]
   make[AppConfig].from {
     (configLoader: ConfigLoader) =>
       configLoader.loadConfig("application startup")

--- a/distage/distage-framework/.jvm/src/main/scala/izumi/distage/roles/RoleAppBootConfigModule.scala
+++ b/distage/distage-framework/.jvm/src/main/scala/izumi/distage/roles/RoleAppBootConfigModule.scala
@@ -11,7 +11,6 @@ class RoleAppBootConfigModule[F[_]: TagK: DefaultModule]() extends ModuleDef {
   make[ConfigMerger].from[ConfigMerger.ConfigMergerImpl]
   make[ConfigLocationProvider].from(ConfigLocationProvider.Default)
   make[ConfigArgsProvider].from[ConfigArgsProvider.Default]
-  make[Boolean].named("distage.roles.always-include-reference-role-configs").fromValue(false)
   make[AppConfig].from {
     (configLoader: ConfigLoader) =>
       configLoader.loadConfig("application startup")

--- a/distage/distage-framework/.jvm/src/main/scala/izumi/distage/roles/RoleAppMain.scala
+++ b/distage/distage-framework/.jvm/src/main/scala/izumi/distage/roles/RoleAppMain.scala
@@ -208,6 +208,7 @@ object RoleAppMain {
   object Options extends ParserDef {
     final val logLevelRootParam = arg("log-level-root", "ll", "root log level", "{trace|debug|info|warn|error|critical}")
     final val logFormatParam = arg("log-format", "lf", "log format", "{text|json}")
+    final val ignoreAllReferenceConfigs = flag("ignore-all-reference-configs", "nc", "ignore all bundled reference configs")
     final val configParam = arg("config", "c", "path to config file", "<path>")
     final val dumpContext = flag("debug-dump-graph", "dump DI graph for debugging")
     final val use = arg("use", "u", "activate a choice on functionality axis", "<axis>:<choice>")

--- a/distage/distage-framework/.jvm/src/main/scala/izumi/distage/roles/launcher/ActivationParser.scala
+++ b/distage/distage-framework/.jvm/src/main/scala/izumi/distage/roles/launcher/ActivationParser.scala
@@ -12,10 +12,9 @@ import izumi.logstage.api.IzLogger
   * Note, besides replacing this class, activation parsing strategy can also be changed by using bootstrap modules or plugins
   * and adding an override for `make[Activation].named("roleapp")` to [[izumi.distage.roles.RoleAppMain#roleAppBootOverrides]]
   */
-trait ActivationParser extends AbstractActivationParser {}
+trait ActivationParser extends AbstractActivationParser
 
 object ActivationParser {
-  private final val syspropWarnUnsetActivations = DebugProperties.`izumi.distage.roles.activation.warn-unset`.boolValue(true)
 
   class Impl(
     parser: RoleAppActivationParser,
@@ -43,7 +42,7 @@ object ActivationParser {
         cmdActivations // commandline choices override values in config
 
       val unsetActivations = activationInfo.availableChoices.keySet diff resultActivation.activeChoices.keySet
-      if (unsetActivations.nonEmpty && warnUnsetActivations && syspropWarnUnsetActivations) {
+      if (unsetActivations.nonEmpty && warnUnsetActivations) {
         logger.raw.warn {
           s"""Some activation choices were left unspecified both on the commandline and in default configuration:
              |

--- a/distage/distage-framework/.jvm/src/test/resources/configtest-common-override.conf
+++ b/distage/distage-framework/.jvm/src/test/resources/configtest-common-override.conf
@@ -1,7 +1,7 @@
 
 configTest {
   commonReferenceDev = 8
-  commonReference = 8
+  commonReference = ${?configTest.commonReference}8
   common = 8
   applicationReference = 8
   application = 8

--- a/distage/distage-framework/.jvm/src/test/resources/configtest-role-override.conf
+++ b/distage/distage-framework/.jvm/src/test/resources/configtest-role-override.conf
@@ -1,6 +1,6 @@
 
 configTest {
-  commonReference = 9
+  commonReference = ${?configTest.commonReference}9
   applicationReference = 9
   roleReference = 9
 }

--- a/distage/distage-framework/.jvm/src/test/resources/testrole00-override.conf
+++ b/distage/distage-framework/.jvm/src/test/resources/testrole00-override.conf
@@ -1,0 +1,3 @@
+testservice {
+  explicitInt: 999
+}

--- a/distage/distage-framework/.jvm/src/test/resources/testrole00-reference.conf
+++ b/distage/distage-framework/.jvm/src/test/resources/testrole00-reference.conf
@@ -10,6 +10,7 @@ testservice {
   intval: 123
   strval: "xxx"
   overridenInt: 555
+  explicitInt: 111
 
   systemPropInt: 222
   systemPropList: [1, 2, 3]
@@ -51,4 +52,3 @@ wrapped.path.two = {
 wrapped {
   value = 3
 }
-

--- a/distage/distage-framework/.jvm/src/test/scala/izumi/distage/roles/test/RoleAppTest.scala
+++ b/distage/distage-framework/.jvm/src/test/scala/izumi/distage/roles/test/RoleAppTest.scala
@@ -403,19 +403,34 @@ class RoleAppTest extends AnyWordSpec with WithProperties {
       TestEntrypoint.main(Array("-ll", logLevel, ":" + ConfigTestRole.id, "-c", roleOverrideConf))
 
       assert(configTestConfig.commonReferenceDev == 1, "common-reference-dev")
-      assert(configTestConfig.commonReference == 9, "common-reference")
+      assert(configTestConfig.commonReference == 29, "common-reference")
       assert(configTestConfig.common == 3, "common")
       assert(configTestConfig.applicationReference == 9, "application-reference")
       assert(configTestConfig.application == 5, "application")
       assert(configTestConfig.roleReference == 9, "role-reference")
-      assert(configTestConfig.role == 5, "role")
+      assert(configTestConfig.role == 7, "role")
+
+      withProperties(
+        DebugProperties.`distage.roles.always-include-reference-role-configs`.name -> "false"
+      ) {
+        TestEntrypoint.main(Array("-ll", logLevel, ":" + ConfigTestRole.id, "-c", roleOverrideConf))
+
+        assert(configTestConfig.commonReferenceDev == 1, "common-reference-dev")
+        assert(configTestConfig.commonReference == 29, "common-reference")
+        assert(configTestConfig.common == 3, "common")
+        assert(configTestConfig.applicationReference == 9, "application-reference")
+        assert(configTestConfig.application == 5, "application")
+        assert(configTestConfig.roleReference == 9, "role-reference")
+        assert(configTestConfig.role == 5, "role")
+        ()
+      }
 
       val commonOverrideConf = getClass.getResource("/configtest-common-override.conf").getPath
 
       TestEntrypoint.main(Array("-c", commonOverrideConf, "-ll", logLevel, ":" + ConfigTestRole.id))
 
       assert(configTestConfig.commonReferenceDev == 8, "common-reference-dev")
-      assert(configTestConfig.commonReference == 8, "common-reference")
+      assert(configTestConfig.commonReference == 28, "common-reference")
       assert(configTestConfig.common == 8, "common")
       assert(configTestConfig.applicationReference == 8, "application-reference")
       assert(configTestConfig.application == 8, "application")
@@ -425,12 +440,58 @@ class RoleAppTest extends AnyWordSpec with WithProperties {
       TestEntrypoint.main(Array("-c", commonOverrideConf, "-ll", logLevel, ":" + ConfigTestRole.id, "-c", roleOverrideConf))
 
       assert(configTestConfig.commonReferenceDev == 8, "common-reference-dev")
-      assert(configTestConfig.commonReference == 9, "common-reference")
+      assert(configTestConfig.commonReference == 289, "common-reference")
       assert(configTestConfig.common == 8, "common")
       assert(configTestConfig.applicationReference == 9, "application-reference")
       assert(configTestConfig.application == 8, "application")
       assert(configTestConfig.roleReference == 9, "role-reference")
-      assert(configTestConfig.role == 8, "role")
+      assert(configTestConfig.role == 7, "role") // role reference beats explicit common config
+
+      withProperties(
+        DebugProperties.`distage.roles.always-include-reference-common-configs`.name -> "false"
+      ) {
+        TestEntrypoint.main(Array("-c", commonOverrideConf, "-ll", logLevel, ":" + ConfigTestRole.id))
+
+        assert(configTestConfig.commonReferenceDev == 8, "common-reference-dev")
+        assert(configTestConfig.commonReference == 8, "common-reference")
+        assert(configTestConfig.common == 8, "common")
+        assert(configTestConfig.applicationReference == 8, "application-reference")
+        assert(configTestConfig.application == 8, "application")
+        assert(configTestConfig.roleReference == 6, "role-reference")
+        assert(configTestConfig.role == 7, "role")
+        ()
+      }
+
+      withProperties(
+        DebugProperties.`distage.roles.always-include-reference-role-configs`.name -> "false"
+      ) {
+        TestEntrypoint.main(Array("-c", commonOverrideConf, "-ll", logLevel, ":" + ConfigTestRole.id, "-c", roleOverrideConf))
+
+        assert(configTestConfig.commonReferenceDev == 8, "common-reference-dev")
+        assert(configTestConfig.commonReference == 289, "common-reference")
+        assert(configTestConfig.common == 8, "common")
+        assert(configTestConfig.applicationReference == 9, "application-reference")
+        assert(configTestConfig.application == 8, "application")
+        assert(configTestConfig.roleReference == 9, "role-reference")
+        assert(configTestConfig.role == 8, "role")
+        ()
+      }
+
+      withProperties(
+        DebugProperties.`distage.roles.always-include-reference-role-configs`.name -> "false",
+        DebugProperties.`distage.roles.always-include-reference-common-configs`.name -> "false",
+      ) {
+        TestEntrypoint.main(Array("-c", commonOverrideConf, "-ll", logLevel, ":" + ConfigTestRole.id, "-c", roleOverrideConf))
+
+        assert(configTestConfig.commonReferenceDev == 8, "common-reference-dev")
+        assert(configTestConfig.commonReference == 89, "common-reference")
+        assert(configTestConfig.common == 8, "common")
+        assert(configTestConfig.applicationReference == 9, "application-reference")
+        assert(configTestConfig.application == 8, "application")
+        assert(configTestConfig.roleReference == 9, "role-reference")
+        assert(configTestConfig.role == 8, "role")
+        ()
+      }
     }
 
     "roles do not have access to components from MainAppModule" in {

--- a/distage/distage-framework/.jvm/src/test/scala/izumi/distage/roles/test/RoleAppTest.scala
+++ b/distage/distage-framework/.jvm/src/test/scala/izumi/distage/roles/test/RoleAppTest.scala
@@ -477,21 +477,15 @@ class RoleAppTest extends AnyWordSpec with WithProperties {
         ()
       }
 
-      withProperties(
-        DebugProperties.`distage.roles.always-include-reference-role-configs`.name -> "false",
-        DebugProperties.`distage.roles.always-include-reference-common-configs`.name -> "false",
-      ) {
-        TestEntrypoint.main(Array("-c", commonOverrideConf, "-ll", logLevel, ":" + ConfigTestRole.id, "-c", roleOverrideConf))
+      TestEntrypoint.main(Array("-c", commonOverrideConf, "-nc", "-ll", logLevel, ":" + ConfigTestRole.id, "-c", roleOverrideConf))
 
-        assert(configTestConfig.commonReferenceDev == 8, "common-reference-dev")
-        assert(configTestConfig.commonReference == 89, "common-reference")
-        assert(configTestConfig.common == 8, "common")
-        assert(configTestConfig.applicationReference == 9, "application-reference")
-        assert(configTestConfig.application == 8, "application")
-        assert(configTestConfig.roleReference == 9, "role-reference")
-        assert(configTestConfig.role == 8, "role")
-        ()
-      }
+      assert(configTestConfig.commonReferenceDev == 8, "common-reference-dev")
+      assert(configTestConfig.commonReference == 89, "common-reference")
+      assert(configTestConfig.common == 8, "common")
+      assert(configTestConfig.applicationReference == 9, "application-reference")
+      assert(configTestConfig.application == 8, "application")
+      assert(configTestConfig.roleReference == 9, "role-reference")
+      assert(configTestConfig.role == 8, "role")
     }
 
     "roles do not have access to components from MainAppModule" in {

--- a/distage/distage-framework/.jvm/src/test/scala/izumi/distage/roles/test/RoleAppTest.scala
+++ b/distage/distage-framework/.jvm/src/test/scala/izumi/distage/roles/test/RoleAppTest.scala
@@ -285,7 +285,7 @@ class RoleAppTest extends AnyWordSpec with WithProperties {
     "produce config dumps and support minimization" in {
       val version = ArtifactVersion(s"0.0.0-${UUID.randomUUID().toString}")
       withProperties(overrides ++ Map(TestPluginCatsIO.versionProperty -> version.version)) {
-        TestEntrypoint.main(Array("-ll", logLevel, "-u", "axiscomponentaxis:incorrect", ":configwriter", "-t", targetPath))
+        TestEntrypoint.main(Array("-nc", "-ll", logLevel, "-u", "axiscomponentaxis:incorrect", ":configwriter", "-t", targetPath))
       }
 
       val cwCfg = cfg("configwriter-full", version)

--- a/distage/distage-framework/.jvm/src/test/scala/izumi/distage/roles/test/RoleAppTest.scala
+++ b/distage/distage-framework/.jvm/src/test/scala/izumi/distage/roles/test/RoleAppTest.scala
@@ -284,8 +284,12 @@ class RoleAppTest extends AnyWordSpec with WithProperties {
 
     "produce config dumps and support minimization" in {
       val version = ArtifactVersion(s"0.0.0-${UUID.randomUUID().toString}")
-      withProperties(overrides ++ Map(TestPluginCatsIO.versionProperty -> version.version)) {
-        TestEntrypoint.main(Array("-nc", "-ll", logLevel, "-u", "axiscomponentaxis:incorrect", ":configwriter", "-t", targetPath))
+      val role00OverrideConf = getClass.getResource("/testrole00-override.conf").getPath
+      withProperties(
+        overrides ++
+        Map(TestPluginCatsIO.versionProperty -> version.version)
+      ) {
+        TestEntrypoint.main(Array("-nc", "-c", role00OverrideConf, "-ll", logLevel, "-u", "axiscomponentaxis:incorrect", ":configwriter", "-t", targetPath))
       }
 
       val cwCfg = cfg("configwriter-full", version)
@@ -328,6 +332,9 @@ class RoleAppTest extends AnyWordSpec with WithProperties {
       // ConfigWriter DOES NOT consider system properties!
       assert(role0CfgMinParsed.getInt("testservice.systemPropInt") == 222)
       assert(role0CfgMinParsed.getList("testservice.systemPropList").unwrapped().asScala.toList == List(1, 2, 3))
+
+      // ConfigWriter DOES NOT consider non-reference configs!
+      assert(role0CfgMinParsed.getInt("testservice.explicitInt") == 111)
 
       val role3 = cfg("testrole03-full", version)
       val role3Min = cfg("testrole03-minimized", version)

--- a/distage/distage-framework/.jvm/src/test/scala/izumi/distage/roles/test/fixtures/Fixture.scala
+++ b/distage/distage-framework/.jvm/src/test/scala/izumi/distage/roles/test/fixtures/Fixture.scala
@@ -40,6 +40,7 @@ object Fixture {
     @ConfigDoc("docstest: field doc") intval: Int,
     strval: String,
     overridenInt: Int,
+    explicitInt: Int,
     systemPropInt: Int,
     systemPropList: List[Int],
     a: A,

--- a/distage/distage-framework/src/main/scala/izumi/distage/framework/services/ModuleProvider.scala
+++ b/distage/distage-framework/src/main/scala/izumi/distage/framework/services/ModuleProvider.scala
@@ -106,6 +106,7 @@ object ModuleProvider {
           new ModuleDef {
             make[LocatorRef].named("roleapp").fromValue(outerLocator)
             make[RoleAppPlanner].from((_: LocatorRef @Id("roleapp")).get.get[RoleAppPlanner])
+            make[ConfigMerger].from((_: LocatorRef @Id("roleapp")).get.get[ConfigMerger])
           }
       }
     }

--- a/distage/distage-framework/src/main/scala/izumi/distage/roles/DebugProperties.scala
+++ b/distage/distage-framework/src/main/scala/izumi/distage/roles/DebugProperties.scala
@@ -39,4 +39,38 @@ object DebugProperties extends properties.DebugProperties {
     * @deprecated since 1.0.1
     */
   final val `izumi.distage.roles.reflection` = BoolProperty("izumi.distage.roles.reflection")
+
+  /**
+    * Force JSON logging
+    *
+    * Can be set / overridden via command-line option `--log-format`/`-lf`
+    *
+    * Default: `false`
+    */
+  final val `izumi.distage.roles.logs.json` = BoolProperty("izumi.distage.roles.logs.json")
+
+  /**
+    * Include reference role configs as fallback configs if an explicit role config is passed on the command-line.
+    *
+    * If `false`, explicit role config fully replaces reference role configs instead of overriding them.
+    *
+    * Default: `true`
+    */
+  final val `distage.roles.always-include-reference-role-configs` = BoolProperty("distage.roles.always-include-reference-role-configs")
+
+  /**
+    * Include reference common configs as fallback configs if an explicit common config is passed on the command-line.
+    *
+    * If `false`, explicit common config fully replaces reference common configs instead of overriding them.
+    *
+    * Default: `true`
+    */
+  final val `distage.roles.always-include-reference-common-configs` = BoolProperty("distage.roles.always-include-reference-common-configs")
+
+  /**
+    * Don't use any reference configs, role or common, only read configs passed on the command-line and system properties.
+    *
+    * Default: `false`
+    */
+  final val `distage.roles.ignore-all-reference-configs` = BoolProperty("distage.roles.ignore-all-reference-configs")
 }

--- a/distage/distage-framework/src/main/scala/izumi/distage/roles/RoleAppBootModule.scala
+++ b/distage/distage-framework/src/main/scala/izumi/distage/roles/RoleAppBootModule.scala
@@ -92,11 +92,16 @@ class RoleAppBootModule[F[_]: TagK: DefaultModule](
   make[Activation].named("default").fromValue(StandardAxis.prodActivation)
   make[Activation].named("additional").fromValue(Activation.empty)
 
-  make[Boolean].named("distage.roles.reflection").fromValue(true)
-  make[Boolean].named("distage.roles.logs.json").fromValue(false)
-  make[Boolean].named("distage.roles.ignore-mismatched-effect").fromValue(false)
-  make[Boolean].named("distage.roles.activation.ignore-unknown").fromValue(false)
-  make[Boolean].named("distage.roles.activation.warn-unset").fromValue(true)
+  make[Boolean].named("distage.roles.reflection").from(DebugProperties.`izumi.distage.roles.reflection`.boolValue(default = true))
+  make[Boolean].named("distage.roles.logs.json").from(DebugProperties.`izumi.distage.roles.logs.json`.boolValue(default = false))
+  make[Boolean].named("distage.roles.ignore-mismatched-effect").from(DebugProperties.`izumi.distage.roles.ignore-mismatched-effect`.boolValue(default = false))
+  make[Boolean].named("distage.roles.activation.ignore-unknown").from(DebugProperties.`izumi.distage.roles.activation.ignore-unknown`.boolValue(default = false))
+  make[Boolean].named("distage.roles.activation.warn-unset").from(DebugProperties.`izumi.distage.roles.activation.warn-unset`.boolValue(default = true))
+
+  make[Boolean].named("distage.roles.always-include-reference-role-configs").from(DebugProperties.`distage.roles.always-include-reference-role-configs`.boolValue(true))
+  make[Boolean]
+    .named("distage.roles.always-include-reference-common-configs").from(DebugProperties.`distage.roles.always-include-reference-common-configs`.boolValue(true))
+  make[Boolean].named("distage.roles.ignore-all-reference-configs").from(DebugProperties.`distage.roles.ignore-all-reference-configs`.boolValue(default = false))
 
   make[PluginMergeStrategy].named("bootstrap").fromValue(SimplePluginMergeStrategy)
   make[PluginMergeStrategy].named("main").fromValue(SimplePluginMergeStrategy)

--- a/distage/distage-framework/src/main/scala/izumi/distage/roles/launcher/RoleAppActivationParser.scala
+++ b/distage/distage-framework/src/main/scala/izumi/distage/roles/launcher/RoleAppActivationParser.scala
@@ -13,7 +13,6 @@ trait RoleAppActivationParser {
 }
 
 object RoleAppActivationParser {
-  private final val sysPropIgnoreUnknownActivations = DebugProperties.`izumi.distage.roles.activation.ignore-unknown`.boolValue(false)
 
   class Impl(
     logger: IzLogger,
@@ -45,7 +44,7 @@ object RoleAppActivationParser {
             case None =>
               logger.warn(s"Unknown choice on axis $axisName: $choiceName")
               logger.warn(s"All available $choices")
-              if (ignoreUnknownActivations || sysPropIgnoreUnknownActivations) {
+              if (ignoreUnknownActivations ) {
                 None
               } else {
                 throw new DIAppBootstrapException(
@@ -57,7 +56,7 @@ object RoleAppActivationParser {
         case None =>
           logger.warn(s"Unknown axis: $axisName")
           logger.warn(s"All available $choices")
-          if (ignoreUnknownActivations || sysPropIgnoreUnknownActivations) {
+          if (ignoreUnknownActivations ) {
             None
           } else {
             throw new DIAppBootstrapException(

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/runner/impl/services/BootstrapFactory.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/runner/impl/services/BootstrapFactory.scala
@@ -45,6 +45,8 @@ object BootstrapFactory {
           None,
           List(RoleConfig(configBaseName, active = true, GenericConfigSource.ConfigDefault)),
           alwaysIncludeReferenceRoleConfigs = true, // we expect no user-provided role configs in tests
+          alwaysIncludeReferenceCommonConfigs = true,
+          ignoreAllReferenceConfigs = false,
         )
       )
       val merger = new ConfigMergerImpl(logger)

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/runner/impl/services/BootstrapFactory.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/runner/impl/services/BootstrapFactory.scala
@@ -5,7 +5,7 @@ import izumi.distage.config.model.{GenericConfigSource, RoleConfig}
 import izumi.distage.framework.config.PlanningOptions
 import izumi.distage.framework.model.ActivationInfo
 import izumi.distage.framework.services.ConfigMerger.ConfigMergerImpl
-import izumi.distage.framework.services.{ConfigArgsProvider, ConfigLoader, ConfigLocationProvider, ModuleProvider}
+import izumi.distage.framework.services.{ConfigArgsProvider, ConfigFilteringStrategy, ConfigLoader, ConfigLocationProvider, ModuleProvider}
 import izumi.distage.model.definition.Activation
 import izumi.distage.roles.launcher.AppShutdownInitiator
 import izumi.distage.roles.model.meta.RolesInfo
@@ -44,12 +44,16 @@ object BootstrapFactory {
         ConfigLoader.Args(
           None,
           List(RoleConfig(configBaseName, active = true, GenericConfigSource.ConfigDefault)),
-          alwaysIncludeReferenceRoleConfigs = true, // we expect no user-provided role configs in tests
-          alwaysIncludeReferenceCommonConfigs = true,
-          ignoreAllReferenceConfigs = false,
         )
       )
-      val merger = new ConfigMergerImpl(logger)
+      val merger = new ConfigMergerImpl(
+        logger,
+        new ConfigFilteringStrategy.Raw(
+          alwaysIncludeReferenceRoleConfigs = true, // we expect no user-provided role configs in tests
+          alwaysIncludeReferenceCommonConfigs = true,
+          ignoreAll = false,
+        ),
+      )
       val locationProvider = makeConfigLocationProvider(configBaseName)
       new ConfigLoader.LocalFSImpl(logger, merger, locationProvider, argsProvider)
     }


### PR DESCRIPTION
* Add role app boot bindings to control inclusion of reference role configs and reference common configs.

* Change default behavior of explicit role configs: include role reference configs as fallbacks by default.

* Read `DebugProperties` sysprops directly in role app boot bindings instead of merging `DebugProperties` sysprops with bindings later