### PR TITLE
Draft: add an order to apply on sequential

### DIFF
--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/PlannerInput.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/PlannerInput.scala
@@ -86,4 +86,5 @@ object PlannerInput {
   def apply(bindings: ModuleBase, activation: Activation, root: DIKey, roots: DIKey*): PlannerInput =
     PlannerInput(bindings, Roots(root, roots*), activation, DefaultPrivacy)
 
+  implicit def plannerInputOrdering: Ordering[PlannerInput] = Ordering.by(_.hashCode())
 }

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/plan/Plan.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/plan/Plan.scala
@@ -226,4 +226,6 @@ object Plan {
     }
   }
 
+  implicit def planOrdering: Ordering[Plan] = Ordering.by(_.input)
+
 }

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/model/TestGroup.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/model/TestGroup.scala
@@ -5,12 +5,20 @@ import izumi.distage.model.plan.Plan
 import izumi.distage.model.reflection.DIKey
 import izumi.distage.testkit.runner.impl.services.Timed
 import izumi.fundamentals.collections.nonempty.NEList
+import scala.math.Ordering
 
 final case class PreparedTest[F[_]](
   test: DistageTest[F],
   timedPlan: Timed[Plan],
   roots: Set[DIKey],
 )
+
+object PreparedTest {
+  implicit def orderedPreparedTest[F[_]]: Ordering[PreparedTest[F[_]]] =
+    Ordering.by { case PreparedTest(test, _, _) =>
+      (test.testMeta.pos.file, test.testMeta.pos.line)
+    }
+}
 
 final case class FailedTest[F[_]](
   test: DistageTest[F],

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/model/TestTree.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/model/TestTree.scala
@@ -80,3 +80,8 @@ final case class TestTree[F[_]](
     }
   }
 }
+
+object TestTree {
+  implicit def testTreeOrdering[F[_]]: Ordering[TestTree[F[_]]] = Ordering.by(_.levelPlan)
+}
+

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/runner/impl/DistageTestRunner.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/runner/impl/DistageTestRunner.scala
@@ -17,6 +17,13 @@ import scala.concurrent.duration.FiniteDuration
 
 object DistageTestRunner {
   case class SuiteData(id: SuiteId, meta: SuiteMeta, suiteParallelism: Parallelism)
+
+  object SuiteData {
+    implicit def suiteDataOrdering: Ordering[SuiteData] = Ordering.by {
+      case SuiteData(id, meta, suiteParallelism) =>
+        (id.suiteId, meta.suiteName, meta.suiteClassName, suiteParallelism.toString())
+    }
+  }
 }
 
 class DistageTestRunner[F[_]: TagK, G[_]](

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/runner/impl/TestPlanner.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/runner/impl/TestPlanner.scala
@@ -63,6 +63,11 @@ object TestPlanner {
     highestDebugOutputInTests: Boolean,
   )
 
+  object PreparedTestEnv {
+    implicit def preparedTestEnvOrdering: Ordering[PreparedTestEnv] =
+      Ordering.by(_.runtimePlan)
+  }
+
   sealed trait PlanningFailure
   object PlanningFailure {
     final case class Exception(throwable: Throwable) extends PlanningFailure

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/runner/impl/TestTreeRunner.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/runner/impl/TestTreeRunner.scala
@@ -82,6 +82,8 @@ object TestTreeRunner {
       // note: scheduling here is custom also and tests may automatically run in parallel for any non-trivial monad
       // we assume that individual tests within a suite can't have different values of `parallelSuites`
       // (because of structure & that difference even if happens wouldn't be actionable at the level of suites anyway)
+      implicit def testsBySuiteOrdering[A]: Ordering[(DistageTestRunner.SuiteData, A)] = Ordering.by(_._1)
+
       parTraverse(testsBySuite)(_._1.suiteParallelism) {
         case (suiteData, preparedTests) =>
           F.bracket(

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/runner/impl/services/ExtParTraverse.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/runner/impl/services/ExtParTraverse.scala
@@ -5,7 +5,7 @@ import izumi.functional.quasi.{QuasiAsync, QuasiIO}
 import izumi.functional.quasi.QuasiIO.syntax.*
 
 trait ExtParTraverse[F[_]] {
-  def apply[A, B](
+  def apply[A: Ordering, B](
     l: Iterable[A]
   )(getParallelismGroup: A => Parallelism
   )(f: A => F[B]
@@ -18,7 +18,7 @@ object ExtParTraverse {
     F: QuasiIO[F],
     P: QuasiAsync[F],
   ) extends ExtParTraverse[F] {
-    def apply[A, B](
+    def apply[A: Ordering, B](
       l: Iterable[A]
     )(getParallelismGroup: A => Parallelism
     )(f: A => F[B]
@@ -31,7 +31,7 @@ object ExtParTraverse {
       F.traverse(sorted) {
         case (Parallelism.Fixed(n), l) if l.size > 1 => P.parTraverseN(n)(l)(f)
         case (Parallelism.Unlimited, l) if l.size > 1 => P.parTraverse(l)(f)
-        case (_, l) => F.traverse(l)(f)
+        case (_, l) => F.traverse(l.toSeq.sorted)(f)
       }.map(_.flatten)
     }
   }


### PR DESCRIPTION
WIP

See #2219 

This adds the minimum necessary to have `Sequential` result in a test case order that matches order in source file.

While this "works" - I'm not happy about the changes. This required adding an `Ordering` constraint to `ExtParTraverse`. Which seems odd. That requires adding an `Ordering` to several other structures where this is not applicable. 