### PR TITLE
extractSelf convenience helper

### DIFF
--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/dsl/AbstractBindingDefDSL.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/dsl/AbstractBindingDefDSL.scala
@@ -355,6 +355,10 @@ object AbstractBindingDefDSL {
       addOp(SubcontextInstruction.SetExtractor(f))(toSame)
     }
 
+    final def extractSelf: Self = {
+      addOp(SubcontextInstruction.SetExtractor(Functoid.identity[T]))(toSame)
+    }
+
     final def localDependency[B: Tag]: Self = {
       localDependency(DIKey[B])
     }

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/dsl/AbstractBindingDefDSL.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/dsl/AbstractBindingDefDSL.scala
@@ -355,7 +355,7 @@ object AbstractBindingDefDSL {
       addOp(SubcontextInstruction.SetExtractor(f))(toSame)
     }
 
-    final def extractSelf: Self = {
+    final def extractSelf(implicit t: Tag[T]): Self = {
       addOp(SubcontextInstruction.SetExtractor(Functoid.identity[T]))(toSame)
     }
 


### PR DESCRIPTION
I'm not sure if this is the best option. Maybe we should do this by default and override with `extractWith`.