### PR TITLE
bio: in `Panic2.sandbox` rethrow external interruption if caught when uninterruptible

### DIFF
--- a/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/impl/AsyncZio.scala
+++ b/fundamentals/fundamentals-bio/src/main/scala/izumi/functional/bio/impl/AsyncZio.scala
@@ -210,12 +210,31 @@ open class AsyncZio[R] extends Async2[ZIO[R, +_, +_]] {
   @inline override final def sandbox[E, A](r: ZIO[R, E, A]): ZIO[R, Exit.FailureUninterrupted[E], A] = {
     implicit val trace: zio.Trace = Tracer.instance.empty
 
-    // Assume no *external* interruption:
-    // either we're interrupted here - ergo we don't return from here anyway,
-    // or we're in an uninterruptible region - ergo we're not interrupted.
-    // In BIO (and cats-effect), only external interruption counts as 'interruption'
-    // Internal interruption is not a valid state (and is treated as a defect - Exit.Termination)
-    r.sandbox.mapError(ZIOExit.toExitUninterrupted)
+    r.foldCauseZIO[R, Exit.FailureUninterrupted[E], A](
+      failure = cause =>
+        ZIOExit.withIsInterruptedF {
+          extInterrupted =>
+            ZIOExit.toExit(cause)(extInterrupted) match {
+              case _: Exit.Interruption =>
+                // Due to https://github.com/zio/zio/issues/10260 we CAN actually catch
+                // external interruption with ZIO.sandbox, and we HAVE to rethrow it because
+                // BIO has to be portable and the equivalent of ZIO.sandbox cannot be
+                // implemented on Cats Effect
+                val interruptedCause0 = cause.stripFailures
+                val interruptedCause = if (interruptedCause0.isInterrupted) {
+                  interruptedCause0
+                } else {
+                  zio.Cause.interrupt(zio.FiberId.None) ++ interruptedCause0
+                }
+                ZIO.failCause(interruptedCause)
+              case uninterrupted: Exit.FailureUninterrupted[E] =>
+                // In BIO (and cats-effect), only external interruption counts as 'interruption'
+                // Internal interruption is not a valid state (and is treated as a defect - Exit.Termination)
+                ZIO.fail(uninterrupted)
+            }
+        },
+      success = ZIO.succeed(_),
+    )
   }
 
   @inline override final def yieldNow: ZIO[Any, Nothing, Unit] = ZIO.yieldNow(Tracer.instance.empty)

--- a/fundamentals/fundamentals-bio/src/test/scala/izumi/functional/bio/test/BIOConcurrentForkExpectedBehaviorTest.scala
+++ b/fundamentals/fundamentals-bio/src/test/scala/izumi/functional/bio/test/BIOConcurrentForkExpectedBehaviorTest.scala
@@ -12,18 +12,17 @@ abstract class BIOConcurrentForkExpectedBehaviorTest[F[+_, +_]: TagKK: Concurren
 ) extends AsyncWordSpec {
   val F: Panic2[F] = Concurrent2[F].InnerF
 
-  s"implementor ${TagKK[F].tag} of {Concurrent2,Primitives2,Fork2}" should {
+  s"implementation of {Concurrent2,Primitives2,Fork2} of ${TagKK[F].tag}" should {
 
     "have sandbox not catch external interruption, even when uninterruptible" in {
       val test: F[Nothing, Assertion] = for {
         caughtExtInterrupt <- F.mkRef(false)
         l1 <- F.mkLatch
-        l2 <- F.mkLatch
         fib = F.uninterruptibleExcept {
           restore =>
-            restore(l1.succeed(()) *> l2.await).sandbox.catchAll(_ => caughtExtInterrupt.set(true))
+            restore(l1.succeed(()) *> F.never).sandbox.catchAll(_ => caughtExtInterrupt.set(true))
         }
-        _ <- F.fork(fib).flatMap(_.interrupt)
+        _ <- F.fork(fib).flatMap(l1.await *> _.interrupt)
         caught <- caughtExtInterrupt.get
       } yield {
         assert(!caught)

--- a/fundamentals/fundamentals-bio/src/test/scala/izumi/functional/bio/test/BIOConcurrentForkExpectedBehaviorTest.scala
+++ b/fundamentals/fundamentals-bio/src/test/scala/izumi/functional/bio/test/BIOConcurrentForkExpectedBehaviorTest.scala
@@ -1,0 +1,36 @@
+package izumi.functional.bio.test
+
+import izumi.functional.bio.{Concurrent2, Fork2, Panic2, Primitives2, UnsafeRun2}
+import izumi.reflect.TagKK
+import org.scalatest.Assertion
+import org.scalatest.wordspec.AsyncWordSpec
+
+final class BIOConcurrentForkExpectedBehaviorTestZIO extends BIOConcurrentForkExpectedBehaviorTest[zio.IO](UnsafeRun2.createZIO())
+
+abstract class BIOConcurrentForkExpectedBehaviorTest[F[+_, +_]: TagKK: Concurrent2: Primitives2: Fork2](
+  runner: UnsafeRun2[F]
+) extends AsyncWordSpec {
+  val F: Panic2[F] = Concurrent2[F].InnerF
+
+  s"implementor ${TagKK[F].tag} of {Concurrent2,Primitives2,Fork2}" should {
+
+    "have sandbox not catch external interruption, even when uninterruptible" in {
+      val test: F[Nothing, Assertion] = for {
+        caughtExtInterrupt <- F.mkRef(false)
+        l1 <- F.mkLatch
+        l2 <- F.mkLatch
+        fib = F.uninterruptibleExcept {
+          restore =>
+            restore(l1.succeed(()) *> l2.await).sandbox.catchAll(_ => caughtExtInterrupt.set(true))
+        }
+        _ <- F.fork(fib).flatMap(_.interrupt)
+        caught <- caughtExtInterrupt.get
+      } yield {
+        assert(!caught)
+      }
+      runner.unsafeRunAsyncAsFuture(test).map(_.toThrowableEither.toTry.get)
+    }
+
+  }
+
+}

--- a/fundamentals/fundamentals-bio/src/test/scala/izumi/functional/bio/test/BIOConcurrentForkExpectedBehaviorTest.scala
+++ b/fundamentals/fundamentals-bio/src/test/scala/izumi/functional/bio/test/BIOConcurrentForkExpectedBehaviorTest.scala
@@ -5,12 +5,16 @@ import izumi.reflect.TagKK
 import org.scalatest.Assertion
 import org.scalatest.wordspec.AsyncWordSpec
 
-final class BIOConcurrentForkExpectedBehaviorTestZIO extends BIOConcurrentForkExpectedBehaviorTest[zio.IO](UnsafeRun2.createZIO())
+import scala.concurrent.ExecutionContext
+
+final class BIOConcurrentForkExpectedBehaviorTestZIO
+  extends BIOConcurrentForkExpectedBehaviorTest[zio.IO](ec => UnsafeRun2.createZIO(Some(zio.Executor.fromExecutionContext(ec))))
 
 abstract class BIOConcurrentForkExpectedBehaviorTest[F[+_, +_]: TagKK: Concurrent2: Primitives2: Fork2](
-  runner: UnsafeRun2[F]
+  mkRunner: ExecutionContext => UnsafeRun2[F]
 ) extends AsyncWordSpec {
   val F: Panic2[F] = Concurrent2[F].InnerF
+  val runner: UnsafeRun2[F] = mkRunner(this.executionContext)
 
   s"implementation of {Concurrent2,Primitives2,Fork2} of ${TagKK[F].tag}" should {
 


### PR DESCRIPTION
this could happen because of https://github.com/zio/zio/issues/10260