### PR TITLE
Remove RoleProvider.ReflectiveImpl

### DIFF
--- a/distage/distage-framework-api/src/main/scala/izumi/distage/roles/model/meta/RoleBinding.scala
+++ b/distage/distage-framework-api/src/main/scala/izumi/distage/roles/model/meta/RoleBinding.scala
@@ -6,7 +6,8 @@ import izumi.distage.roles.model.RoleDescriptor
 
 final case class RoleBinding(
   binding: Binding,
-  runtimeClass: Class[?],
-  tpe: SafeType,
+  implType: SafeType,
   descriptor: RoleDescriptor,
-)
+) {
+  val id: String = descriptor.id
+}

--- a/distage/distage-framework-api/src/main/scala/izumi/distage/roles/model/meta/RolesInfo.scala
+++ b/distage/distage-framework-api/src/main/scala/izumi/distage/roles/model/meta/RolesInfo.scala
@@ -25,13 +25,13 @@ object RolesInfo {
     roles =>
       import scala.collection.compat._
 
-      val requestedNames = roles.requiredRoleBindings.map(_.descriptor.id)
+      val requestedNames = roles.requiredRoleBindings.map(_.id)
       ArraySeq
         .unsafeWrapArray {
           roles.availableRoleBindings.iterator.map {
             r =>
-              val active = if (requestedNames.contains(r.descriptor.id)) "[+]" else "[ ]"
-              s"$active ${r.descriptor.id}, ${r.binding.key}, source=${r.descriptor.artifact.getOrElse("N/A")}"
+              val active = if (requestedNames.contains(r.id)) "[+]" else "[ ]"
+              s"$active ${r.id}, ${r.binding.key}, source=${r.descriptor.artifact.getOrElse("N/A")}"
           }.toArray
         }.sorted.niceList()
   }

--- a/distage/distage-framework/.jvm/src/main/scala/izumi/distage/framework/CheckableApp.scala
+++ b/distage/distage-framework/.jvm/src/main/scala/izumi/distage/framework/CheckableApp.scala
@@ -155,7 +155,7 @@ abstract class RoleCheckableApp[F[_]](override implicit val tagK: TagK[F]) exten
             namePredicateRoleProvider(!excluded(_))
 
           case RoleSelection.OnlySelected(selection) =>
-            @impl trait SelectedRoleProvider extends RoleProvider.ReflectiveImpl {
+            @impl trait SelectedRoleProvider extends RoleProvider.NonReflectiveImpl {
               override protected def getInfo(bindings: Set[Binding], requiredRoles: Set[String], roleType: SafeType): RolesInfo = {
                 requiredRoles.discard()
                 super.getInfo(bindings, selection, roleType)
@@ -174,7 +174,7 @@ abstract class RoleCheckableApp[F[_]](override implicit val tagK: TagK[F]) exten
 
       private def namePredicateRoleProvider(f: String => Boolean): Functoid[RoleProvider] = {
         // use Auto-Traits feature to override just the few specific methods of a class succinctly
-        @impl trait NamePredicateRoleProvider extends RoleProvider.ReflectiveImpl {
+        @impl trait NamePredicateRoleProvider extends RoleProvider.NonReflectiveImpl {
           override protected def isRoleEnabled(requiredRoles: Set[String])(b: RoleBinding): Boolean = {
             f(b.descriptor.id)
           }

--- a/distage/distage-framework/.jvm/src/main/scala/izumi/distage/framework/CheckableApp.scala
+++ b/distage/distage-framework/.jvm/src/main/scala/izumi/distage/framework/CheckableApp.scala
@@ -176,7 +176,7 @@ abstract class RoleCheckableApp[F[_]](override implicit val tagK: TagK[F]) exten
         // use Auto-Traits feature to override just the few specific methods of a class succinctly
         @impl trait NamePredicateRoleProvider extends RoleProvider.NonReflectiveImpl {
           override protected def isRoleEnabled(requiredRoles: Set[String])(b: RoleBinding): Boolean = {
-            f(b.descriptor.id)
+            f(b.id)
           }
           override protected def getInfo(bindings: Set[Binding], requiredRoles: Set[String], roleType: SafeType): RolesInfo = {
             requiredRoles.discard()

--- a/distage/distage-framework/.jvm/src/main/scala/izumi/distage/roles/RoleAppBootPlatformModule.scala
+++ b/distage/distage-framework/.jvm/src/main/scala/izumi/distage/roles/RoleAppBootPlatformModule.scala
@@ -7,6 +7,5 @@ class RoleAppBootPlatformModule() extends ModuleDef {
   include(new RoleAppBootConfigModule())
   include(new RoleAppBootLoggerModule())
 
-  make[RoleProvider].from[RoleProvider.ReflectiveImpl]
-
+  make[RoleProvider].from[RoleProvider.NonReflectiveImpl]
 }

--- a/distage/distage-framework/.jvm/src/main/scala/izumi/distage/roles/bundled/ConfigWriter.scala
+++ b/distage/distage-framework/.jvm/src/main/scala/izumi/distage/roles/bundled/ConfigWriter.scala
@@ -77,7 +77,7 @@ final class ConfigWriter[F[_]: TagK](
     allRoles.foreach {
       role =>
         try {
-          val roleId = role.descriptor.id
+          val roleId = role.id
           val roleVersion = if (options.useLauncherVersion) {
             Some(launcherVersion.version)
           } else {
@@ -106,7 +106,7 @@ final class ConfigWriter[F[_]: TagK](
           writeConfig(options, fileNameMinimized, min.config, Some(min.schema), subLogger)
         } catch {
           case exception: Throwable =>
-            logger.crit(s"Cannot process role ${role.descriptor.id}")
+            logger.crit(s"Cannot process role ${role.id}")
             throw exception
         }
     }

--- a/distage/distage-framework/src/main/scala/izumi/distage/roles/DebugProperties.scala
+++ b/distage/distage-framework/src/main/scala/izumi/distage/roles/DebugProperties.scala
@@ -26,21 +26,6 @@ object DebugProperties extends properties.DebugProperties {
   final val `izumi.distage.roles.ignore-mismatched-effect` = BoolProperty("izumi.distage.roles.ignore-mismatched-effect")
 
   /**
-    * Discover any component that inherits from [[izumi.distage.roles.model.AbstractRole]] and has a companion object that inherits [[izumi.distage.roles.model.RoleDescriptor]]
-    * as a role, not only those additionally added using [[izumi.distage.roles.model.definition.RoleModuleDef#makeRole]],
-    * companions of such components will be instantiated reflectively, unlike ones from `RoleModuleDef`.
-    *
-    * Default: `true`, for the sake of keeping compatibility with code written before [[izumi.distage.roles.model.definition.RoleModuleDef]],
-    *          however, reflective instantiation of role companions is deprecated and will be removed in the future,
-    *          you are advised to use `RoleModuleDef` instead.
-    *
-    * @note Flipping this or the corresponding `Boolean @Id("distage.roles.reflection")` component to `false` will speed up launch times
-    *
-    * @deprecated since 1.0.1
-    */
-  final val `izumi.distage.roles.reflection` = BoolProperty("izumi.distage.roles.reflection")
-
-  /**
     * Force JSON logging
     *
     * Can be set / overridden via command-line option `--log-format`/`-lf`

--- a/distage/distage-framework/src/main/scala/izumi/distage/roles/RoleAppBootModule.scala
+++ b/distage/distage-framework/src/main/scala/izumi/distage/roles/RoleAppBootModule.scala
@@ -102,7 +102,6 @@ class RoleAppBootModule[F[_]: TagK: DefaultModule](
   make[Activation].named("default").fromValue(StandardAxis.prodActivation)
   make[Activation].named("additional").fromValue(Activation.empty)
 
-  make[Boolean].named("distage.roles.reflection").from(DebugProperties.`izumi.distage.roles.reflection`.boolValue(default = true))
   make[Boolean].named("distage.roles.logs.json").from(DebugProperties.`izumi.distage.roles.logs.json`.boolValue(default = false))
   make[Boolean].named("distage.roles.ignore-mismatched-effect").from(DebugProperties.`izumi.distage.roles.ignore-mismatched-effect`.boolValue(default = false))
   make[Boolean].named("distage.roles.activation.ignore-unknown").from(DebugProperties.`izumi.distage.roles.activation.ignore-unknown`.boolValue(default = false))

--- a/distage/distage-framework/src/main/scala/izumi/distage/roles/launcher/RoleAppEntrypoint.scala
+++ b/distage/distage-framework/src/main/scala/izumi/distage/roles/launcher/RoleAppEntrypoint.scala
@@ -117,7 +117,7 @@ object RoleAppEntrypoint {
         b =>
           rolesLocator.lookupInstance[AbstractRole[F]](b.binding.key) match {
             case Some(value) =>
-              Seq(b.descriptor.id -> value)
+              Seq(b.id -> value)
             case _ =>
               Seq.empty
           }

--- a/distage/distage-framework/src/main/scala/izumi/distage/roles/launcher/RoleProvider.scala
+++ b/distage/distage-framework/src/main/scala/izumi/distage/roles/launcher/RoleProvider.scala
@@ -40,8 +40,8 @@ object RoleProvider {
       val availableRoleBindings = findRoleBindings(bindings, roleType)
       val requiredRoleBindings = availableRoleBindings.filter(isRoleEnabled(requiredRoles))
 
-      val roleNames = availableRoleBindings.map(_.descriptor.id)
-      val requiredRoleNames = requiredRoleBindings.iterator.map(_.descriptor.id).toSet
+      val roleNames = availableRoleBindings.map(_.id)
+      val requiredRoleNames = requiredRoleBindings.iterator.map(_.id).toSet
       val unrequiredRoleNames = roleNames.diff(requiredRoleNames)
 
       val rolesInfo = RolesInfo(
@@ -53,7 +53,7 @@ object RoleProvider {
         unrequiredRoleNames = unrequiredRoleNames,
       )
 
-      val missing = requiredRoles.diff(availableRoleBindings.map(_.descriptor.id))
+      val missing = requiredRoles.diff(availableRoleBindings.map(_.id))
       if (missing.nonEmpty) {
         logger.crit(s"Missing ${missing.niceList() -> "roles"}")
         throw new DIAppBootstrapException(s"""Unknown roles:${missing.niceList("    ")}
@@ -89,9 +89,9 @@ object RoleProvider {
     }
 
     protected def checkRoleType(implType: SafeType, roleType: SafeType, log: Boolean): Boolean = {
-      val res = implType <:< roleType
-      if (!res && log) logger.warn(s"Found role binding with incompatible effect type $implType (expected to be a subtype of $roleType)")
-      res
+      val isCompatible = implType <:< roleType
+      if (!isCompatible && log) logger.warn(s"Found role binding with incompatible effect type $implType (expected to be a subtype of $roleType)")
+      isCompatible
     }
 
     protected def mkRoleBinding(roleBinding: ImplBinding, roleDescriptor: RoleDescriptor): RoleBinding = {

--- a/distage/distage-framework/src/main/scala/izumi/distage/roles/launcher/RoleProvider.scala
+++ b/distage/distage-framework/src/main/scala/izumi/distage/roles/launcher/RoleProvider.scala
@@ -85,7 +85,7 @@ object RoleProvider {
     }
 
     protected def isRoleEnabled(requiredRoles: Set[String])(b: RoleBinding): Boolean = {
-      requiredRoles.contains(b.descriptor.id) || requiredRoles.contains(b.tpe.tag.shortName.toLowerCase)
+      requiredRoles.contains(b.id)
     }
 
     protected def checkRoleType(implType: SafeType, roleType: SafeType, log: Boolean): Boolean = {

--- a/distage/distage-framework/src/main/scala/izumi/distage/roles/launcher/RoleProvider.scala
+++ b/distage/distage-framework/src/main/scala/izumi/distage/roles/launcher/RoleProvider.scala
@@ -74,7 +74,7 @@ object RoleProvider {
         case s: ImplBinding if s.tags.exists(_.isInstanceOf[RoleTag]) && checkRoleType(s.implementation.implType, roleType, log = !ignoreMismatchedEffect) =>
           mkRoleBinding(s, s.tags.collectFirst { case RoleTag(roleDescriptor) => roleDescriptor }.get)
 
-        case s: ImplBinding if s.implementation.implType <:< roleType =>
+        case s: ImplBinding if s.implementation.implType <:< roleType && !s.isMutator =>
           handleMissingStaticMetadata(roleType, s)
       }
     }

--- a/distage/distage-framework/src/main/scala/izumi/distage/roles/launcher/RoleProvider.scala
+++ b/distage/distage-framework/src/main/scala/izumi/distage/roles/launcher/RoleProvider.scala
@@ -9,9 +9,7 @@ import izumi.distage.roles.model.exceptions.DIAppBootstrapException
 import izumi.distage.roles.model.meta.{RoleBinding, RolesInfo}
 import izumi.distage.roles.model.{AbstractRole, RoleDescriptor}
 import izumi.fundamentals.platform.cli.model.RoleAppArgs
-import izumi.fundamentals.platform.{IzPlatform, ScalaPlatform}
 import izumi.fundamentals.platform.strings.IzString.toRichIterable
-import izumi.fundamentals.reflection.TypeUtil
 import izumi.logstage.api.IzLogger
 
 import scala.annotation.unused
@@ -97,62 +95,8 @@ object RoleProvider {
     }
 
     protected def mkRoleBinding(roleBinding: ImplBinding, roleDescriptor: RoleDescriptor): RoleBinding = {
-      val runtimeClass = roleBinding.key.tpe.closestClass
       val implType = roleBinding.implementation.implType
-      RoleBinding(roleBinding, runtimeClass, implType, roleDescriptor)
-    }
-  }
-
-  open class ReflectiveImpl(
-    logger: IzLogger @Id("early"),
-    ignoreMismatchedEffect: Boolean @Id("distage.roles.ignore-mismatched-effect"),
-    reflectionEnabled: Boolean @Id("distage.roles.reflection"),
-    parameters: RoleAppArgs,
-  ) extends NonReflectiveImpl(logger, ignoreMismatchedEffect, parameters) {
-
-    protected val isReflectionEnabled: Boolean = reflectionEnabled && IzPlatform.platform != ScalaPlatform.GraalVMNativeImage
-
-    override protected def handleMissingStaticMetadata(roleType: SafeType, s: ImplBinding): RoleBinding = {
-      if (isReflectionEnabled) {
-        reflectCompanionBinding(s)
-      } else {
-        super.handleMissingStaticMetadata(roleType, s)
-      }
-    }
-
-    protected def reflectCompanionBinding(roleBinding: ImplBinding): RoleBinding = {
-      if (isReflectionEnabled) {
-        reflectCompanionDescriptor(roleBinding.key.tpe) match {
-          case Some(descriptor) =>
-            logger.warn(
-              s"""${roleBinding.key -> "role"} defined ${roleBinding.origin -> "at"}: using deprecated reflective look-up of `RoleDescriptor` companion object.
-                 |Please use `RoleModuleDef` & `makeRole` to create a role binding explicitly, instead.
-                 |
-                 |Reflective lookup of `RoleDescriptor` will be removed in a future version.""".stripMargin
-            )
-            mkRoleBinding(roleBinding, descriptor)
-
-          case None =>
-            logger.crit(s"${roleBinding.key -> "role"} defined ${roleBinding.origin -> "at"} has no companion object inherited from RoleDescriptor")
-            throw new DIAppBootstrapException(s"role=${roleBinding.key} defined at=${roleBinding.origin} has no companion object inherited from RoleDescriptor")
-        }
-      } else {
-        logger.crit(s"${roleBinding.key -> "role"} defined ${roleBinding.origin -> "at"} has no RoleDescriptor, companion reflection is disabled")
-        throw new DIAppBootstrapException(s"role=${roleBinding.key} defined at=${roleBinding.origin} has no RoleDescriptor, companion reflection is disabled")
-      }
-    }
-
-    protected def reflectCompanionDescriptor(role: SafeType): Option[RoleDescriptor] = {
-      val roleClassName = role.closestClass.getName
-      try {
-        Some(TypeUtil.instantiateObject[RoleDescriptor](Class.forName(s"$roleClassName$$")))
-      } catch {
-        case t: Throwable =>
-          logger.crit(s"""Failed to reflect RoleDescriptor companion object for $role: $t
-                         |Please create a companion object extending `izumi.distage.roles.model.RoleDescriptor` for `$roleClassName`
-                         |""".stripMargin)
-          None
-      }
+      RoleBinding(roleBinding, implType, roleDescriptor)
     }
   }
 


### PR DESCRIPTION
Reflective Role discovery was deprecated all the way back in 1.0.1, time to drop it