### PR TITLE
Scala 3: Avoid re-typing of macro results in CodePosition macros by wrapping everything in `Typed` nodes

### DIFF
--- a/fundamentals/fundamentals-language/src/main/scala-3/izumi/fundamentals/platform/language/CodePositionMaterializer.scala
+++ b/fundamentals/fundamentals-language/src/main/scala-3/izumi/fundamentals/platform/language/CodePositionMaterializer.scala
@@ -54,6 +54,7 @@ object CodePositionMaterializer {
         .map(_.trim)
         .mkString(".")
 
+      // Use Typed nodes to avoid retypechecking (this required internal.setType on Scala 2, but seems like Typed(..) achieves the same on Scala 3)
       Typed(Literal(StringConstant(applicationId)), TypeTree.of[String]).asExpr.asInstanceOf[Expr[String]]
     }
 

--- a/fundamentals/fundamentals-language/src/main/scala-3/izumi/fundamentals/platform/language/CodePositionMaterializer.scala
+++ b/fundamentals/fundamentals-language/src/main/scala-3/izumi/fundamentals/platform/language/CodePositionMaterializer.scala
@@ -38,6 +38,8 @@ object CodePositionMaterializer {
     }
 
     def getApplicationPointIdOf(chain: Seq[qctx.reflect.Symbol]): Expr[String] = {
+      import qctx.reflect.*
+
       val applicationId = chain.tail
         .flatMap {
           case s if s.isPackageDef =>
@@ -52,7 +54,7 @@ object CodePositionMaterializer {
         .map(_.trim)
         .mkString(".")
 
-      Expr(applicationId)
+      Typed(Literal(StringConstant(applicationId)), TypeTree.of[String]).asExpr.asInstanceOf[Expr[String]]
     }
 
     private def goodSymbol(using qctx: Quotes)(s: qctx.reflect.Symbol): Boolean = {
@@ -82,12 +84,12 @@ object CodePositionMaterializer {
       val sourcePos = SourceFilePositionMaterializer.SourceFilePositionMaterializerMacro.getSourceFilePosition()
       val applicationId = getApplicationPointId()
 
-      '{ CodePosition(${ sourcePos }, ${ applicationId }) }
+      '{ CodePosition(${ sourcePos }, ${ applicationId }): CodePosition }
     }
 
     def getCodePositionMaterializer()(using qctx: Quotes): Expr[CodePositionMaterializer] = {
       val pos = getEnclosingPosition()
-      '{ CodePositionMaterializer(${ pos }) }
+      '{ CodePositionMaterializer(${ pos }): CodePositionMaterializer }
     }
 
   }

--- a/fundamentals/fundamentals-language/src/main/scala-3/izumi/fundamentals/platform/language/SourceFilePositionMaterializer.scala
+++ b/fundamentals/fundamentals-language/src/main/scala-3/izumi/fundamentals/platform/language/SourceFilePositionMaterializer.scala
@@ -22,6 +22,7 @@ object SourceFilePositionMaterializer {
       val name = pos.sourceFile.name
       val line = pos.startLine + 1
 
+      // Use Typed nodes to avoid retypechecking (this required internal.setType on Scala 2, but seems like Typed(..) achieves the same on Scala 3)
       '{
         SourceFilePosition(
           ${ Literal(StringConstant(name)).asExpr.asInstanceOf[Expr[String]] }: String,

--- a/fundamentals/fundamentals-language/src/main/scala-3/izumi/fundamentals/platform/language/SourceFilePositionMaterializer.scala
+++ b/fundamentals/fundamentals-language/src/main/scala-3/izumi/fundamentals/platform/language/SourceFilePositionMaterializer.scala
@@ -12,15 +12,22 @@ object SourceFilePositionMaterializer {
   object SourceFilePositionMaterializerMacro {
     def getSourceFilePositionMaterializer(using qctx: Quotes): Expr[SourceFilePositionMaterializer] = {
       val pos = getSourceFilePosition()
-      '{ SourceFilePositionMaterializer(${ pos }) }
+      '{ SourceFilePositionMaterializer(${ pos }): SourceFilePositionMaterializer }
     }
 
     def getSourceFilePosition()(using qctx: Quotes): Expr[SourceFilePosition] = {
-      val pos = qctx.reflect.Position.ofMacroExpansion
+      import qctx.reflect.*
+
+      val pos = Position.ofMacroExpansion
       val name = pos.sourceFile.name
       val line = pos.startLine + 1
 
-      '{ SourceFilePosition(${ Expr(name) }, ${ Expr(line) }) }
+      '{
+        SourceFilePosition(
+          ${ Literal(StringConstant(name)).asExpr.asInstanceOf[Expr[String]] }: String,
+          ${ Literal(IntConstant(line)).asExpr.asInstanceOf[Expr[Int]] }: Int
+        ): SourceFilePosition
+      }
     }
   }
 }

--- a/fundamentals/fundamentals-language/src/main/scala-3/izumi/fundamentals/platform/language/SourcePackageMaterializer.scala
+++ b/fundamentals/fundamentals-language/src/main/scala-3/izumi/fundamentals/platform/language/SourcePackageMaterializer.scala
@@ -17,10 +17,12 @@ object SourcePackageMaterializer {
   object SourcePackageMaterializerMacro {
     def getSourcePackageMaterializer()(using qctx: Quotes): Expr[SourcePackageMaterializer] = {
       val packageStr = getSourcePackageString()
-      '{ SourcePackageMaterializer(SourcePackage(${ packageStr })) }
+      '{ SourcePackageMaterializer(SourcePackage(${ packageStr }): SourcePackage): SourcePackageMaterializer }
     }
 
     def getSourcePackageString()(using qctx: Quotes): Expr[String] = {
+      import qctx.reflect.*
+
       val st = CodePositionMaterializer.CodePositionMaterializerMacro.ownershipChain()
 
       val applicationIdPkgOnly = st.tail
@@ -33,7 +35,7 @@ object SourcePackageMaterializer {
         .map(_.toString.trim)
         .mkString(".")
 
-      Expr(applicationIdPkgOnly)
+      Typed(Literal(StringConstant(applicationIdPkgOnly)), TypeTree.of[String]).asExpr.asInstanceOf[Expr[String]]
     }
   }
 }

--- a/fundamentals/fundamentals-language/src/main/scala-3/izumi/fundamentals/platform/language/SourcePackageMaterializer.scala
+++ b/fundamentals/fundamentals-language/src/main/scala-3/izumi/fundamentals/platform/language/SourcePackageMaterializer.scala
@@ -35,6 +35,7 @@ object SourcePackageMaterializer {
         .map(_.toString.trim)
         .mkString(".")
 
+      // Use Typed notes to avoid retypechecking (this required internal.setType on Scala 2, but seems like Typed(..) achieves the same on Scala 3)
       Typed(Literal(StringConstant(applicationIdPkgOnly)), TypeTree.of[String]).asExpr.asInstanceOf[Expr[String]]
     }
   }


### PR DESCRIPTION


Confirmed in https://github.com/7mind/izumi/pull/2325 that using Typed nodes avoids typecheck step on macro result - same as `setType` on Scala 2