### PR TITLE
Deprecate `make` without `.from`, use `make[T].fromSelf` instead

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -17,6 +17,10 @@
 #   https://scalacenter.github.io/bloop/docs/performance-guide#tweak-the-java-jit
 #   https://twitter.com/leifwickland/status/1179419045055086595
 -XX:MaxInlineLevel=18
+
+# Promote distage deprecation warnings (e.g. bare `make[T]`) to fatal compile-time errors.
+# See: distage-core `izumi.distage.DebugProperties`
+-Dizumi.distage.fatal-deprecations=true
 # These seem to cause sbt import slowdown :\
 #-XX:MaxInlineSize=270
 #-XX:MaxTrivialSize=12

--- a/distage/distage-core-api/src/main/scala-2/izumi/distage/constructors/constructors.scala
+++ b/distage/distage-core-api/src/main/scala-2/izumi/distage/constructors/constructors.scala
@@ -1,12 +1,10 @@
 package izumi.distage.constructors
 
 import izumi.distage.reflection.macros.constructors.*
-import izumi.distage.model.definition.dsl.ModuleDefDSL
-import izumi.distage.model.exceptions.macros.{TraitInitializationFailedException, UnsupportedDefinitionException}
+import izumi.distage.model.exceptions.macros.TraitInitializationFailedException
 import izumi.distage.model.providers.Functoid
 import izumi.distage.model.reflection.SafeType
-import izumi.fundamentals.platform.strings.IzString.toRichIterable
-import izumi.reflect.WeakTag
+import izumi.reflect.{Tag, WeakTag}
 import zio.ZEnvironment
 
 import scala.language.experimental.macros as enableMacros
@@ -116,20 +114,8 @@ object ClassConstructorOptionalMakeDSL {
     new ClassConstructorOptionalMakeDSL.Impl[T](functoid)
   }
 
-  def errorConstructor[T](tpe: String, nonWhitelistedMethods: List[String]): ClassConstructorOptionalMakeDSL.Impl[T] = {
-    ClassConstructorOptionalMakeDSL[T](Functoid.lift(throwError(tpe, nonWhitelistedMethods)))
-  }
-
-  def throwError(tpe: String, nonWhitelistedMethods: List[String]): Nothing = {
-
-    throw new UnsupportedDefinitionException(
-      s"""`make[$tpe]` DSL failure: Called an empty error constructor, because constructor for $tpe WAS NOT generated.
-         |Because after `make` there were following method calls in the same expression:${nonWhitelistedMethods.niceList()}
-         |
-         |These calls were assumed to be `.from`-like method calls, since they are not in the allowed list: ${ModuleDefDSL.MakeDSLNoOpMethodsWhitelist}
-         |The assumption is that all not explicitly allowed calls will eventually call any of `.from`/`.using`/`.todo` and fill in the constructor.
-         |""".stripMargin
-    )
+  def errorConstructor[T: Tag](tpe: String, nonWhitelistedMethods: List[String]): ClassConstructorOptionalMakeDSL.Impl[T] = {
+    ClassConstructorOptionalMakeDSL[T](Functoid._errorMakeWithoutFrom[T](tpe, nonWhitelistedMethods))
   }
 
   implicit def materialize[T]: ClassConstructorOptionalMakeDSL.Impl[T] = macro MakeMacro.classConstructorOptionalMakeDSL[T]

--- a/distage/distage-core-api/src/main/scala-2/izumi/distage/reflection/macros/constructors/MakeMacro.scala
+++ b/distage/distage-core-api/src/main/scala-2/izumi/distage/reflection/macros/constructors/MakeMacro.scala
@@ -2,6 +2,7 @@ package izumi.distage.reflection.macros.constructors
 
 import izumi.distage.constructors.{ClassConstructorOptionalMakeDSL, DebugProperties}
 import izumi.distage.model.definition.dsl.ModuleDefDSL
+import izumi.fundamentals.platform.strings.IzString.toRichString
 import izumi.fundamentals.reflection.TrivialMacroLogger
 
 import scala.annotation.nowarn
@@ -76,6 +77,32 @@ object MakeMacro {
         case Some(nonwhiteListedMethods) =>
           if (nonwhiteListedMethods.isEmpty) {
             logger.log(s"""For $tpe found no `.from`-like calls in $maybeTree""".stripMargin)
+
+            // `makeRole[T]` (and similar wrappers in user code that delegate through `MakeMacro.make`)
+            // expand to `make[T].tagged(...)` synthetically. The chain that reaches us only contains
+            // whitelisted methods, but the user did not write a bare `make[T]` — so don't emit the
+            // deprecation warning in that case. `MakeMacro.make` is invoked as a regular method from
+            // those wrappers, so `c.enclosingMacros(1)` points at the wrapping distage macro itself
+            // instead of `make`.
+            val calledFromAnotherDistageMacro = c.enclosingMacros.tail.exists {
+              ctx =>
+                val sym = ctx.macroApplication.symbol
+                sym != null && sym != NoSymbol &&
+                sym.fullName.startsWith("izumi.distage.") &&
+                sym.fullName != "izumi.distage.reflection.macros.constructors.MakeMacro.make" &&
+                !sym.fullName.endsWith(".classConstructorOptionalMakeDSL")
+            }
+
+            if (!calledFromAnotherDistageMacro) {
+              val message =
+                s"""`make[$tpe]` without a following `.from`-like call is deprecated and will fail at runtime in a future version.
+                   |Use `make[$tpe].fromSelf` (equivalent to `make[$tpe].from[$tpe]`) to keep auto-deriving the constructor for $tpe.""".stripMargin
+              if (System.getProperty("izumi.distage.fatal-deprecations").asBoolean().getOrElse(false)) {
+                c.error(c.enclosingPosition, message)
+              } else {
+                c.warning(c.enclosingPosition, message)
+              }
+            }
 
             q"""_root_.izumi.distage.constructors.ClassConstructorOptionalMakeDSL.apply[$tpe](${ClassConstructorMacro.mkClassConstructor[T](c)}.provider)"""
           } else {

--- a/distage/distage-core-api/src/main/scala-3/izumi/distage/constructors/MakeMacro.scala
+++ b/distage/distage-core-api/src/main/scala-3/izumi/distage/constructors/MakeMacro.scala
@@ -129,9 +129,30 @@ object MakeMacro {
     // FIXME remove redundant wrapping and .provider call
     val functoid: Expr[Functoid[T]] =
       if (fromLikeMethods.isEmpty) {
+        // `makeRole[T]` (and similar wrappers) splice in `MakeMacro.makeMethod[T, MakeDSL[T]]` and add
+        // synthetic methods like `.tagged(RoleTag(...))`. The user did not write a bare `make[T]`, so
+        // skip the deprecation in those cases. We detect them by inspecting the source text at the
+        // macro expansion position: a direct `make[...]` call starts with `make[`; `makeRole[T]` etc.
+        // start with a different identifier.
+        val callSource =
+          try Position.ofMacroExpansion.sourceCode.getOrElse("")
+          catch { case _: Throwable => "" }
+        val isDirectMakeCall = callSource.trim.startsWith("make[")
+
+        if (isDirectMakeCall) {
+          val tpeStr = Type.show[T]
+          val message =
+            s"""`make[$tpeStr]` without a following `.from`-like call is deprecated and will fail at runtime in a future version.
+               |Use `make[$tpeStr].fromSelf` (equivalent to `make[$tpeStr].from[$tpeStr]`) to keep auto-deriving the constructor for $tpeStr.""".stripMargin
+          if (java.lang.Boolean.parseBoolean(System.getProperty("izumi.distage.fatal-deprecations"))) {
+            report.errorAndAbort(message)
+          } else {
+            report.warning(message)
+          }
+        }
         '{ ${ ClassConstructorMacro.make[T] }.provider }
       } else {
-        '{ ClassConstructorOptionalMakeDSL.errorConstructor[T](${ Expr(Type.show[T]) }, ${ Expr(fromLikeMethods) }).provider }
+        '{ ClassConstructorOptionalMakeDSL.errorConstructor[T](${ Expr(Type.show[T]) }, ${ Expr(fromLikeMethods) })(using compiletime.summonInline[Tag[T]]).provider }
       }
 
     val res = applyMake[T, BT](outerClass)(functoid)

--- a/distage/distage-core-api/src/main/scala-3/izumi/distage/constructors/constructors.scala
+++ b/distage/distage-core-api/src/main/scala-3/izumi/distage/constructors/constructors.scala
@@ -1,10 +1,8 @@
 package izumi.distage.constructors
 
-import izumi.distage.model.definition.dsl.ModuleDefDSL
-import izumi.distage.model.exceptions.macros.{TraitInitializationFailedException, UnsupportedDefinitionException}
+import izumi.distage.model.exceptions.macros.TraitInitializationFailedException
 import izumi.distage.model.providers.Functoid
 import izumi.distage.model.reflection.SafeType
-import izumi.fundamentals.platform.strings.IzString.toRichIterable
 import izumi.reflect.{Tag, WeakTag}
 
 import zio.ZEnvironment
@@ -114,19 +112,7 @@ object ClassConstructorOptionalMakeDSL {
     new ClassConstructorOptionalMakeDSL.Impl[T](functoid)
   }
 
-  def errorConstructor[T](tpe: String, nonWhitelistedMethods: List[String]): ClassConstructorOptionalMakeDSL.Impl[T] = {
-    ClassConstructorOptionalMakeDSL[T](Functoid.lift[Nothing](throwError(tpe, nonWhitelistedMethods)))
-  }
-
-  def throwError(tpe: String, nonWhitelistedMethods: List[String]): Nothing = {
-
-    throw new UnsupportedDefinitionException(
-      s"""`make[$tpe]` DSL failure: Called an empty error constructor, because constructor for $tpe WAS NOT generated.
-         |Because after `make` there were following method calls in the same expression:${nonWhitelistedMethods.niceList()}
-         |
-         |These calls were assumed to be `.from`-like method calls, since they are not in the allowed list: ${ModuleDefDSL.MakeDSLNoOpMethodsWhitelist}
-         |The assumption is that all not explicitly allowed calls will eventually call any of `.from`/`.using`/`.todo` and fill in the constructor.
-         |""".stripMargin
-    )
+  def errorConstructor[T: Tag](tpe: String, nonWhitelistedMethods: List[String]): ClassConstructorOptionalMakeDSL.Impl[T] = {
+    ClassConstructorOptionalMakeDSL[T](Functoid._errorMakeWithoutFrom[T](tpe, nonWhitelistedMethods))
   }
 }

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/LocatorDef.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/LocatorDef.scala
@@ -156,6 +156,14 @@ object LocatorDef {
     final def fromValue[I <: T: Tag](instance: I): AfterBind =
       bind(ImplDef.InstanceImpl(SafeType.get[I], instance))
 
+    /**
+      * `LocatorDef` only supports value bindings, so this method exists purely to keep the
+      * deprecated bare-`make[T]` migration path uniform: it produces a non-`InstanceImpl` binding
+      * that `LocatorDef` will reject at construction time with `LocatorDefUninstantiatedBindingException`.
+      */
+    final def fromSelf(implicit ctor: izumi.distage.constructors.ClassConstructor[T]): AfterBind =
+      bind(ImplDef.ProviderImpl(ctor.provider.get.ret, ctor.provider.get))
+
     protected def bind(impl: ImplDef): AfterBind
   }
 

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/dsl/ModuleDefDSL.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/definition/dsl/ModuleDefDSL.scala
@@ -25,7 +25,7 @@ import scala.collection.immutable.HashSet
   * Example:
   * {{{
   * class Program[F[_]: TagK] extends ModuleDef {
-  *   make[TaglessProgram[F]]
+  *   make[TaglessProgram[F]].fromSelf
   * }
   *
   * object TryInterpreters extends ModuleDef {
@@ -38,7 +38,7 @@ import scala.collection.immutable.HashSet
   * }}}
   *
   * Singleton bindings:
-  *   - `make[X]` = create X using its constructor
+  *   - `make[X].fromSelf` = create X using its constructor (preferred over a bare `make[X]`, which is deprecated)
   *   - `makeTrait[X]` = create an abstract class or a trait `X` using [[izumi.distage.constructors.TraitConstructor]] ([[https://izumi.7mind.io/distage/basics.html#auto-traits Auto-Traits feature]])
   *   - `makeFactory[X]` = create a "factory-like" abstract class or a trait `X` using [[izumi.distage.constructors.FactoryConstructor]] ([[https://izumi.7mind.io/distage/basics.html#auto-factories Auto-Factories feature]])
   *   - `make[X].from[XImpl]` = bind X to its subtype XImpl using XImpl's constructor
@@ -107,6 +107,14 @@ trait ModuleDefDSL extends AbstractBindingDefDSL[MakeDSL, MakeDSLUnnamedAfterFro
 object ModuleDefDSL {
 
   trait MakeDSLBase[T, AfterBind] {
+    /**
+      * Bind `T` to its own auto-derived constructor. Equivalent to `make[T].from[T]`.
+      *
+      * Use this instead of a bare `make[T]` (which is deprecated and will fail at runtime in a future version).
+      */
+    final def fromSelf(implicit ctor: ClassConstructor[T]): AfterBind =
+      from(ctor.provider)
+
     final def from[I <: T: ClassConstructor]: AfterBind =
       from(ClassConstructor[I])
 
@@ -192,7 +200,7 @@ object ModuleDefDSL {
       *   trait T
       *   class T1 extends T
       *
-      *   make[T1]
+      *   make[T1].fromSelf
       *   make[T].using[T1]
       * }}}
       *
@@ -361,7 +369,7 @@ object ModuleDefDSL {
       *   trait T
       *   trait T1 extends T
       *
-      *   make[T1]
+      *   make[T1].fromSelf
       *   many[T].ref[T1]
       * }}}
       *

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/planning/PlanIssue.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/planning/PlanIssue.scala
@@ -59,6 +59,13 @@ object PlanIssue {
     override def key: DIKey = value.binding.key
   }
 
+  /**
+    * The user wrote `make[T]` without a following `.from`-like call. The macro records this with a
+    * `Functoid._errorMakeWithoutFrom` provider that survives into the bindings (because no `.from`-like
+    * method replaced it). PlanVerifier reports this as a verification failure with the deprecation message.
+    */
+  final case class BareMakeDeprecation(key: DIKey, op: OperationOrigin, tpeStr: String, methods: List[String], message: String) extends PlanIssue
+
   implicit class PlanIssueOps(private val issue: PlanIssue) extends AnyVal {
     def render: String = {
       issue match {
@@ -94,6 +101,8 @@ object PlanIssue {
         case l: CantVerifyLocalContext =>
           val explanation = l.value.errors.map(_.render).niceList()
           s"${l.key}: verification failed for subcontext ${l.value.impl.implType}: $explanation"
+        case d: BareMakeDeprecation =>
+          s"${d.key}: ${d.message.trim} ${d.op.toSourceFilePosition}"
       }
     }
   }

--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/providers/SimpleDistageFunctoids.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/providers/SimpleDistageFunctoids.scala
@@ -1,9 +1,12 @@
 package izumi.distage.model.providers
 
+import izumi.distage.model.exceptions.macros.UnsupportedDefinitionException
 import izumi.distage.model.exceptions.runtime.TODOBindingException
-import izumi.distage.model.reflection.Provider.ProviderType
-import izumi.distage.model.reflection.{DIKey, Provider}
+import izumi.distage.model.reflection.Provider.{ErrorMakeWithoutFromMarker, ProviderType}
+import izumi.distage.model.reflection.{DIKey, Provider, SafeType}
 import izumi.fundamentals.platform.language.CodePositionMaterializer
+import izumi.fundamentals.platform.strings.IzString.toRichIterable
+import izumi.reflect.Tag
 
 trait SimpleDistageFunctoids {
   def todoProvider(key: DIKey)(implicit pos: CodePositionMaterializer): Functoid[Nothing] = {
@@ -15,5 +18,47 @@ trait SimpleDistageFunctoids {
         providerType = ProviderType.Function,
       )
     )
+  }
+
+  /**
+    * Marker provider used as the placeholder for a `make[T]` binding that has not been completed with
+    * a follow-up `.from`-like call.
+    *
+    * `PlanVerifier` (and `PlanCheck`) detects bindings whose impl carries this provider type and fails
+    * verification with a deprecation message. If the user actually executes such a binding at runtime
+    * (which can happen if `PlanVerifier` is bypassed), the `fun` of this provider throws
+    * [[UnsupportedDefinitionException]] with the same message.
+    */
+  def _errorMakeWithoutFrom[T: Tag](tpeStr: String, nonWhitelistedMethods: List[String]): Functoid[T] = {
+    val message = SimpleDistageFunctoids.errorMakeWithoutFromMessage(tpeStr, nonWhitelistedMethods)
+    Functoid.create[T](
+      Provider.ProviderImpl(
+        parameters = Seq.empty,
+        ret = SafeType.get[T],
+        underlying = ErrorMakeWithoutFromMarker(tpeStr, nonWhitelistedMethods, message),
+        fun = (_: Seq[Any]) => throw new UnsupportedDefinitionException(message),
+        providerType = ProviderType.ErrorMakeWithoutFrom,
+      )
+    )
+  }
+}
+
+object SimpleDistageFunctoids {
+  def errorMakeWithoutFromMessage(tpeStr: String, nonWhitelistedMethods: List[String]): String = {
+    if (nonWhitelistedMethods.isEmpty) {
+      s"""`make[$tpeStr]` DSL deprecation: `make[$tpeStr]` without a following `.from`-like call is deprecated and will fail at runtime in a future version.
+         |Use `make[$tpeStr].fromSelf` (equivalent to `make[$tpeStr].from[$tpeStr]`) to keep auto-deriving the constructor for $tpeStr,
+         |or pick a different `.from`/`.fromValue`/`.fromResource`/`.using`/`.todo` binding.
+         |""".stripMargin
+    } else {
+      s"""`make[$tpeStr]` DSL failure: constructor for $tpeStr WAS NOT generated.
+         |After `make[$tpeStr]` the following method calls were detected in the same expression:${nonWhitelistedMethods.niceList()}
+         |
+         |These calls were treated as `.from`-like (they are not in the allowed no-op list).
+         |The DSL expects every such chain to eventually call one of `.from`/`.fromValue`/`.fromResource`/`.using`/`.todo`/`.fromSelf`/`.fromEffect` to fill in the constructor — none of those was found.
+         |
+         |If you intended to bind $tpeStr to its own auto-derived constructor, use `make[$tpeStr].fromSelf`.
+         |""".stripMargin
+    }
   }
 }

--- a/distage/distage-core/.jvm/src/test/scala/izumi/distage/compat/CatsResourcesTestJvm.scala
+++ b/distage/distage-core/.jvm/src/test/scala/izumi/distage/compat/CatsResourcesTestJvm.scala
@@ -44,7 +44,7 @@ final class CatsResourcesTestJvm extends AnyWordSpec with CatsIOPlatformDependen
     val module = new ModuleDef {
       make[DBConnection].fromResource(dbResource)
       make[MessageQueueConnection].fromResource(mqResource)
-      make[MyApp]
+      make[MyApp].fromSelf
     }
 
     val res = catsIOUnsafeRunSync {
@@ -64,7 +64,7 @@ final class CatsResourcesTestJvm extends AnyWordSpec with CatsIOPlatformDependen
     val module = new ModuleDef {
       make[DBConnection].fromResource(dbResource)
       make[MessageQueueConnection].fromResource(mqResource)
-      make[MyApp]
+      make[MyApp].fromSelf
 
       make[IORuntime].from {
         (cpuPool: ExecutionContext @Id("cpu"), blockingPool: ExecutionContext @Id("io"), scheduler: Scheduler, ioRuntimeConfig: IORuntimeConfig) =>
@@ -96,7 +96,7 @@ final class CatsResourcesTestJvm extends AnyWordSpec with CatsIOPlatformDependen
     val module = new ModuleDef {
       make[DBConnection].fromResource(dbResource)
       make[MessageQueueConnection].fromResource(mqResource)
-      make[MyApp]
+      make[MyApp].fromSelf
 
       make[IORuntime].from {
         (cpuPool: ExecutionContext @Id("cpu"), blockingPool: ExecutionContext @Id("io"), scheduler: Scheduler, ioRuntimeConfig: IORuntimeConfig) =>

--- a/distage/distage-core/.jvm/src/test/scala/izumi/distage/compat/ZIOResourcesTestJvm.scala
+++ b/distage/distage-core/.jvm/src/test/scala/izumi/distage/compat/ZIOResourcesTestJvm.scala
@@ -43,7 +43,7 @@ final class ZIOResourcesTestJvm extends AnyWordSpec with GivenWhenThen with ZIOT
       val module = new ModuleDef {
         make[DBConnection].fromResource(dbResource)
         make[MessageQueueConnection].fromResource(mqResource)
-        make[MyApp]
+        make[MyApp].fromSelf
       }
 
       unsafeRun(Injector[Task]().produceRun(module) {
@@ -148,7 +148,7 @@ final class ZIOResourcesTestJvm extends AnyWordSpec with GivenWhenThen with ZIOT
       val module = new ModuleDef {
         make[DBConnection].fromResource(dbResource)
         make[MessageQueueConnection].fromResource(mqResource)
-        make[MyApp]
+        make[MyApp].fromSelf
       }
 
       unsafeRun(Injector[Task]().produceRun(module) {

--- a/distage/distage-core/.jvm/src/test/scala/izumi/distage/gc/GcBasicTestsJvm.scala
+++ b/distage/distage-core/.jvm/src/test/scala/izumi/distage/gc/GcBasicTestsJvm.scala
@@ -20,11 +20,11 @@ class GcBasicTestsJvm extends AnyWordSpec with MkGcInjector {
       val plan = injector.planUnsafe(
         PlannerInput(
           new ModuleDef {
-            make[Circular1]
-            make[Circular2]
-            make[Circular3]
-            make[Circular4]
-            make[Trash]
+            make[Circular1].fromSelf
+            make[Circular2].fromSelf
+            make[Circular3].fromSelf
+            make[Circular4].fromSelf
+            make[Trash].fromSelf
           },
           Roots(DIKey.get[Circular2]),
           Activation.empty,
@@ -57,8 +57,8 @@ class GcBasicTestsJvm extends AnyWordSpec with MkGcInjector {
         PlannerInput(
           new ModuleDef {
             make[MkS3Client].from[Impl]
-            make[S3Component]
-            make[App]
+            make[S3Component].fromSelf
+            make[App].fromSelf
           },
           Roots(DIKey.get[App]),
           Activation.empty,
@@ -79,9 +79,9 @@ class GcBasicTestsJvm extends AnyWordSpec with MkGcInjector {
             many[IntegrationComponent].add[S3Component]
 
             make[MkS3Client].from[Impl]
-            make[S3Upload]
-            make[Ctx]
-            make[S3Component]
+            make[S3Upload].fromSelf
+            make[Ctx].fromSelf
+            make[S3Component].fromSelf
           },
           Roots(DIKey.get[Ctx]),
           Activation.empty,
@@ -102,12 +102,12 @@ class GcBasicTestsJvm extends AnyWordSpec with MkGcInjector {
       val plan = injector.planUnsafe(
         PlannerInput(
           new ModuleDef {
-            make[MkS3Client]
-            make[S3Upload]
-            make[Ctx]
-            make[S3Component]
+            make[MkS3Client].fromSelf
+            make[S3Upload].fromSelf
+            make[Ctx].fromSelf
+            make[S3Component].fromSelf
             many[IntegrationComponent].add[S3Component]
-            make[Initiator]
+            make[Initiator].fromSelf
           },
           Roots(DIKey.get[Ctx], DIKey.get[Initiator]),
           Activation.empty,
@@ -125,8 +125,8 @@ class GcBasicTestsJvm extends AnyWordSpec with MkGcInjector {
       val plan = injector.planUnsafe(
         PlannerInput(
           new ModuleDef {
-            make[Circular1]
-            make[Circular2]
+            make[Circular1].fromSelf
+            make[Circular2].fromSelf
             make[T1].using[Circular1]
             make[T2].using[Circular2]
           },
@@ -209,8 +209,8 @@ class GcBasicTestsJvm extends AnyWordSpec with MkGcInjector {
       val plan = injector.planUnsafe(
         PlannerInput(
           new ModuleDef {
-            make[Circular1]
-            make[Circular2]
+            make[Circular1].fromSelf
+            make[Circular2].fromSelf
           },
           Roots(DIKey.get[Circular2]),
           Activation.empty,
@@ -231,8 +231,8 @@ class GcBasicTestsJvm extends AnyWordSpec with MkGcInjector {
       val plan = injector.planUnsafe(
         PlannerInput(
           new ModuleDef {
-            make[Circular1]
-            make[Circular2]
+            make[Circular1].fromSelf
+            make[Circular2].fromSelf
           },
           Roots(DIKey.get[Circular2]),
           Activation.empty,
@@ -252,8 +252,8 @@ class GcBasicTestsJvm extends AnyWordSpec with MkGcInjector {
       val plan = injector.planUnsafe(
         PlannerInput(
           new ModuleDef {
-            make[Circular1]
-            make[Circular2]
+            make[Circular1].fromSelf
+            make[Circular2].fromSelf
           },
           Roots(DIKey.get[Circular2], DIKey.get[Set[AutoCloseable]]),
           Activation.empty,
@@ -273,10 +273,10 @@ class GcBasicTestsJvm extends AnyWordSpec with MkGcInjector {
       val plan = injector.planUnsafe(
         PlannerInput(
           new ModuleDef {
-            make[Circular1]
-            make[Circular2]
-            make[Circular3]
-            make[Circular4]
+            make[Circular1].fromSelf
+            make[Circular2].fromSelf
+            make[Circular3].fromSelf
+            make[Circular4].fromSelf
             many[T1]
               .ref[Circular1]
               .ref[Circular2]

--- a/distage/distage-core/.jvm/src/test/scala/izumi/distage/injector/AnimalModelTestJvm.scala
+++ b/distage/distage-core/.jvm/src/test/scala/izumi/distage/injector/AnimalModelTestJvm.scala
@@ -14,15 +14,15 @@ class AnimalModelTestJvm extends AnyWordSpec with MkInjector {
 
       val definition = PlannerInput(
         new ModuleDef {
-          make[Cluster]
+          make[Cluster].fromSelf
           make[UserRepo].from[UserRepoImpl]
           make[AccountsRepo].from[AccountsRepoImpl]
           make[UsersService].from[UserServiceImpl]
           make[AccountingService].from[AccountingServiceImpl]
-          make[UsersApiImpl]
-          make[AccountsApiImpl]
-          make[UnrequiredDep]
-          make[App]
+          make[UsersApiImpl].fromSelf
+          make[AccountsApiImpl].fromSelf
+          make[UnrequiredDep].fromSelf
+          make[App].fromSelf
         },
         Roots(DIKey.get[App]),
         Activation.empty,

--- a/distage/distage-core/.jvm/src/test/scala/izumi/distage/injector/CglibProxiesTestJvm.scala
+++ b/distage/distage-core/.jvm/src/test/scala/izumi/distage/injector/CglibProxiesTestJvm.scala
@@ -23,7 +23,7 @@ class CglibProxiesTestJvm extends AnyWordSpec with MkInjector with ScalatestGuar
       import CircularCase1.*
 
       val definition = PlannerInput.everything(new ModuleDef {
-        make[Circular2]
+        make[Circular2].fromSelf
         makeTrait[Circular1]
       })
 
@@ -82,7 +82,7 @@ class CglibProxiesTestJvm extends AnyWordSpec with MkInjector with ScalatestGuar
       import CircularCase3.*
 
       val definition = PlannerInput.everything(new ModuleDef {
-        make[SelfReference]
+        make[SelfReference].fromSelf
       })
 
       val injector = mkInjector()
@@ -117,8 +117,8 @@ class CglibProxiesTestJvm extends AnyWordSpec with MkInjector with ScalatestGuar
       import CircularCase8.*
 
       val definition = PlannerInput.everything(new ModuleDef {
-        make[Circular2]
-        make[Circular1]
+        make[Circular2].fromSelf
+        make[Circular1].fromSelf
         make[Int].from(1)
       })
 
@@ -141,9 +141,9 @@ class CglibProxiesTestJvm extends AnyWordSpec with MkInjector with ScalatestGuar
       import CircularCase9.*
 
       val definition = PlannerInput.everything(new ModuleDef {
-        make[Circular2]
-        make[Circular1]
-        make[IntHolder]
+        make[Circular2].fromSelf
+        make[Circular1].fromSelf
+        make[IntHolder].fromSelf
       })
 
       val injector = mkInjector()
@@ -166,8 +166,8 @@ class CglibProxiesTestJvm extends AnyWordSpec with MkInjector with ScalatestGuar
       import CircularCase5.*
 
       val definition = PlannerInput.everything(new ModuleDef {
-        make[GenericCircular[Dependency]]
-        make[Dependency]
+        make[GenericCircular[Dependency]].fromSelf
+        make[Dependency].fromSelf
       })
 
       val injector = mkInjector()
@@ -184,8 +184,8 @@ class CglibProxiesTestJvm extends AnyWordSpec with MkInjector with ScalatestGuar
       import CircularCase5._
 
       val definition = PlannerInput.everything(new ModuleDef {
-        make[ErasedCircular[Dependency]]
-        make[ErasedDependency[Dependency]]
+        make[ErasedCircular[Dependency]].fromSelf
+        make[ErasedDependency[Dependency]].fromSelf
       })
 
       val injector = mkInjector()
@@ -205,10 +205,10 @@ class CglibProxiesTestJvm extends AnyWordSpec with MkInjector with ScalatestGuar
       import CircularCase4.*
 
       val definition = PlannerInput.everything(new ModuleDef {
-        make[IdTypeCircular]
-        make[IdParamCircular]
-        make[Dependency[IdTypeCircular]].named("special")
-        make[Dependency[IdParamCircular]].named("special")
+        make[IdTypeCircular].fromSelf
+        make[IdParamCircular].fromSelf
+        make[Dependency[IdTypeCircular]].named("special").fromSelf
+        make[Dependency[IdParamCircular]].named("special").fromSelf
       })
 
       val injector = mkInjector()
@@ -227,7 +227,7 @@ class CglibProxiesTestJvm extends AnyWordSpec with MkInjector with ScalatestGuar
 
       val definition = PlannerInput.everything(new ModuleDef {
         make[Dependency { def dep: RefinedCircular }].from[RealDependency]
-        make[RefinedCircular]
+        make[RefinedCircular].fromSelf
       })
 
       val injector = mkInjector()
@@ -245,11 +245,11 @@ class CglibProxiesTestJvm extends AnyWordSpec with MkInjector with ScalatestGuar
 
       val definition = PlannerInput(
         new ModuleDef {
-          make[Component1]
-          make[Component2]
-          make[ComponentWithByNameFwdRef]
-          make[ComponentHolder]
-          make[Root]
+          make[Component1].fromSelf
+          make[Component2].fromSelf
+          make[ComponentWithByNameFwdRef].fromSelf
+          make[ComponentHolder].fromSelf
+          make[Root].fromSelf
         },
         Roots(DIKey.get[Root]),
         Activation.empty,
@@ -271,24 +271,24 @@ class CglibProxiesTestJvm extends AnyWordSpec with MkInjector with ScalatestGuar
 
       val definition = PlannerInput.everything(new ModuleDef {
         // cycle
-        make[DynamoDDLService]
-        make[DynamoComponent]
-        make[DynamoClient]
+        make[DynamoDDLService].fromSelf
+        make[DynamoComponent].fromSelf
+        make[DynamoClient].fromSelf
         //
 
-        make[Sonar]
-        make[ComponentsLifecycleManager]
-        make[RoleStarter]
-        make[TgHttpComponent]
-        make[HttpServerLauncher]
-        make[IRTServerBindings]
-        make[IRTClientMultiplexor]
-        make[ConfigurationRepository]
-        make[DynamoQueryExecutorService]
-        make[IRTMultiplexorWithRateLimiter]
-        make[HealthCheckService]
-        make[HealthCheckHttpRoutes]
-        make[K8ProbesHttpRoutes]
+        make[Sonar].fromSelf
+        make[ComponentsLifecycleManager].fromSelf
+        make[RoleStarter].fromSelf
+        make[TgHttpComponent].fromSelf
+        make[HttpServerLauncher].fromSelf
+        make[IRTServerBindings].fromSelf
+        make[IRTClientMultiplexor].fromSelf
+        make[ConfigurationRepository].fromSelf
+        make[DynamoQueryExecutorService].fromSelf
+        make[IRTMultiplexorWithRateLimiter].fromSelf
+        make[HealthCheckService].fromSelf
+        make[HealthCheckHttpRoutes].fromSelf
+        make[K8ProbesHttpRoutes].fromSelf
 
         many[IRTWrappedService]
         many[IRTWrappedClient]
@@ -323,8 +323,8 @@ class CglibProxiesTestJvm extends AnyWordSpec with MkInjector with ScalatestGuar
         import StableObjectInheritingTrait.*
 
         val definition = PlannerInput.everything(new ModuleDef {
-          make[Circular1]
-          make[Circular2]
+          make[Circular1].fromSelf
+          make[Circular2].fromSelf
         })
 
         val context = mkInjector().produce(definition).unsafeGet()
@@ -343,8 +343,8 @@ class CglibProxiesTestJvm extends AnyWordSpec with MkInjector with ScalatestGuar
 
         val definition = PlannerInput.everything(new ModuleDef {
           //        make[testProviderModule.type].from[testProviderModule.type](testProviderModule: testProviderModule.type)
-          make[testProviderModule.Circular1]
-          make[testProviderModule.Circular2]
+          make[testProviderModule.Circular1].fromSelf
+          make[testProviderModule.Circular2].fromSelf
         })
 
         val context = mkInjector().produce(definition).unsafeGet()
@@ -424,8 +424,8 @@ class CglibProxiesTestJvm extends AnyWordSpec with MkInjector with ScalatestGuar
       import CircularCase5._
 
       val definition = PlannerInput.everything(new ModuleDef {
-        make[ErasedCircular[Dependency]]
-        make[ErasedDependency[Dependency]]
+        make[ErasedCircular[Dependency]].fromSelf
+        make[ErasedDependency[Dependency]].fromSelf
       })
 
       val injector = mkNoCyclesInjector()
@@ -445,8 +445,8 @@ class CglibProxiesTestJvm extends AnyWordSpec with MkInjector with ScalatestGuar
       import CircularCase5._
 
       val definition = PlannerInput.everything(new ModuleDef {
-        make[ErasedCircular[Dependency]]
-        make[ErasedDependency[Dependency]]
+        make[ErasedCircular[Dependency]].fromSelf
+        make[ErasedDependency[Dependency]].fromSelf
       })
 
       val injector = mkNoProxiesInjector()

--- a/distage/distage-core/.jvm/src/test/scala/izumi/distage/injector/ZIOHasInjectionTest.scala
+++ b/distage/distage-core/.jvm/src/test/scala/izumi/distage/injector/ZIOHasInjectionTest.scala
@@ -177,9 +177,9 @@ class ZIOHasInjectionTest extends AnyWordSpec with MkInjector with ZIOTest with 
       def getDep2: URIO[Dependency2, Dependency2] = ZIO.environmentWith[Dependency2](_.get)
 
       val definition = PlannerInput.everything(new ModuleDef {
-        make[Dependency1]
-        make[Dependency2]
-        make[Dependency3]
+        make[Dependency1].fromSelf
+        make[Dependency2].fromSelf
+        make[Dependency3].fromSelf
         make[Trait3 { def acquired: Boolean }].fromZIOEnv(
           (d3: Dependency3) =>
             for {
@@ -258,8 +258,8 @@ class ZIOHasInjectionTest extends AnyWordSpec with MkInjector with ZIOTest with 
       import TraitCase6.*
 
       val definition = PlannerInput.everything(new ModuleDef {
-        make[Dep]
-        make[AnyValDep]
+        make[Dep].fromSelf
+        make[AnyValDep].fromSelf
         make[TestTrait].fromZIOEnv(
           ZIO.environmentWith[AnyValDep](
             h =>

--- a/distage/distage-core/src/main/scala/izumi/distage/DebugProperties.scala
+++ b/distage/distage-core/src/main/scala/izumi/distage/DebugProperties.scala
@@ -11,4 +11,12 @@ object DebugProperties extends properties.DebugProperties {
 
   /** Run [[izumi.distage.planning.solver.PlanVerifier]] for all planner runs, dumping errors to stderr. default: `false` */
   final val `izumi.distage.debug.verify-all` = BoolProperty("izumi.distage.debug.verify-all")
+
+  /**
+    * Promote distage-core deprecation warnings emitted from macros (such as the bare-`make[T]` deprecation)
+    * to fatal compile-time errors. default: `false`
+    *
+    * Set via JVM property `-Dizumi.distage.fatal-deprecations=true` (e.g. in `.jvmopts`).
+    */
+  final val `izumi.distage.fatal-deprecations` = BoolProperty("izumi.distage.fatal-deprecations")
 }

--- a/distage/distage-core/src/main/scala/izumi/distage/InjectorDefaultImpl.scala
+++ b/distage/distage-core/src/main/scala/izumi/distage/InjectorDefaultImpl.scala
@@ -103,7 +103,7 @@ object InjectorDefaultImpl {
     input: PlannerInput,
   ): ModuleDef = {
     new ModuleDef {
-      make[Bootloader]
+      make[Bootloader].fromSelf
       // Bootloader dependencies
       make[InjectorFactory].fromValue(parentFactory)
       make[BootstrapModule].fromValue(bsModule)

--- a/distage/distage-core/src/main/scala/izumi/distage/bootstrap/BootstrapLocator.scala
+++ b/distage/distage-core/src/main/scala/izumi/distage/bootstrap/BootstrapLocator.scala
@@ -132,7 +132,7 @@ object BootstrapLocator {
     make[MirrorProvider].fromValue(mirrorProvider)
 
     make[PlanSolver].from[PlanSolver.Impl]
-    make[GraphQueries]
+    make[GraphQueries].fromSelf
 
     make[SemigraphSolver[DIKey, Int, InstantiationOp]].from[SemigraphSolverImpl[DIKey, Int, InstantiationOp]]
 

--- a/distage/distage-core/src/main/scala/izumi/distage/planning/solver/PlanVerifier.scala
+++ b/distage/distage-core/src/main/scala/izumi/distage/planning/solver/PlanVerifier.scala
@@ -1,13 +1,15 @@
 package izumi.distage.planning.solver
 
-import izumi.distage.model.definition.ModuleBase
+import izumi.distage.model.definition.{Binding, ImplDef, ModuleBase}
 import izumi.distage.model.exceptions.PlanVerificationException
 import izumi.distage.model.plan.ExecutableOp.{InstantiationOp, MonadicOp}
+import izumi.distage.model.plan.operations.OperationOrigin
 import izumi.distage.model.plan.{ExecutableOp, Roots}
 import izumi.distage.model.planning.PlanIssue.*
 import izumi.distage.model.planning.{AxisPoint, PlanIssue}
 import izumi.distage.model.reflection.DIKey.SetElementKey
-import izumi.distage.model.reflection.{DIKey, SafeType}
+import izumi.distage.model.reflection.Provider.{ErrorMakeWithoutFromMarker, ProviderType}
+import izumi.distage.model.reflection.{DIKey, Provider, SafeType}
 import izumi.distage.planning.solver.PlanVerifier.PlanVerifierResult
 import izumi.distage.planning.{BindingTranslator, SubcontextHandler}
 import izumi.fundamentals.collections.MutableMultiMap
@@ -84,15 +86,18 @@ class PlanVerifier(
         }
       }
     }
+    val deprecationIssues: Set[PlanIssue] = PlanVerifier.findBareMakeDeprecations(bindings)
+
     traversal
       .traverse[F](bindings, roots, providedKeys, excludedActivations).left.map {
         failure =>
-          val issues = failure.issues.map(f => PlanIssue.CantVerifyLocalContext(f)).toSet[PlanIssue]
+          val issues = failure.issues.map(f => PlanIssue.CantVerifyLocalContext(f)).toSet[PlanIssue] ++ deprecationIssues
           PlanVerifierResult.Incorrect(Some(NESet.unsafeFrom(issues)), Set.empty, failure.time)
       }.map {
         result =>
-          result.maybeIssues match {
-            case issues @ Some(_) => PlanVerifierResult.Incorrect(issues, result.visitedKeys, result.time)
+          val combined: Set[PlanIssue] = result.maybeIssues.fold(Set.empty[PlanIssue])(_.toSet) ++ deprecationIssues
+          NESet.from(combined) match {
+            case Some(issues) => PlanVerifierResult.Incorrect(Some(issues), result.visitedKeys, result.time)
             case None => PlanVerifierResult.Correct(result.visitedKeys, result.time)
           }
       }.merge
@@ -272,6 +277,46 @@ object PlanVerifier {
   def apply(preps: GraphQueries): PlanVerifier = new PlanVerifier(preps)
 
   private object Default extends PlanVerifier(new GraphQueries(new BindingTranslator.Impl))
+
+  /**
+    * Locate any [[izumi.distage.model.definition.Binding]] whose impl is the marker functoid produced by
+    * a bare `make[T]` call (no follow-up `.from`-like method). Each such binding becomes a
+    * [[PlanIssue.BareMakeDeprecation]].
+    */
+  private[planning] def findBareMakeDeprecations(bindings: ModuleBase): Set[PlanIssue] = {
+    bindings.iterator.flatMap {
+      case b: Binding.ImplBinding =>
+        bareMakeMarker(b.implementation).map {
+          marker =>
+            PlanIssue.BareMakeDeprecation(
+              key = b.key,
+              op = OperationOrigin.UserBinding(b),
+              tpeStr = marker.tpeStr,
+              methods = marker.nonWhitelistedMethods,
+              message = marker.message,
+            )
+        }
+      case _ => None
+    }.toSet[PlanIssue]
+  }
+
+  @scala.annotation.tailrec
+  private def bareMakeMarker(impl: ImplDef): Option[ErrorMakeWithoutFromMarker] = impl match {
+    case ImplDef.ProviderImpl(_, function) => providerMarker(function)
+    case ImplDef.SubcontextImplDef(_, function, _, _) => providerMarker(function)
+    case ImplDef.EffectImpl(_, _, inner) => bareMakeMarker(inner)
+    case ImplDef.ResourceImpl(_, _, inner) => bareMakeMarker(inner)
+    case _: ImplDef.ReferenceImpl | _: ImplDef.InstanceImpl => None
+  }
+
+  private def providerMarker(provider: Provider): Option[ErrorMakeWithoutFromMarker] = {
+    if (provider.providerType == ProviderType.ErrorMakeWithoutFrom) {
+      provider.underlying match {
+        case m: ErrorMakeWithoutFromMarker => Some(m)
+        case _ => None
+      }
+    } else None
+  }
 
   sealed abstract class PlanVerifierResult {
     def issues: Option[NESet[PlanIssue]]

--- a/distage/distage-core/src/test/scala-3/izumi/distage/injector/Scala3AutoTraitsTest.scala
+++ b/distage/distage-core/src/test/scala-3/izumi/distage/injector/Scala3AutoTraitsTest.scala
@@ -96,7 +96,7 @@ class Scala3AutoTraitsTest extends AnyWordSpec with MkInjector {
             def makeConcreteDep1(d: Int): T @With[C2]
           }
         ]
-        make[C1]
+        make[C1].fromSelf
         make[Int].fromValue(1)
         make[Number].fromValue(5)
         make[String].fromValue("abc")

--- a/distage/distage-core/src/test/scala/izumi/distage/compat/ModuleBaseInstancesTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/compat/ModuleBaseInstancesTest.scala
@@ -12,11 +12,11 @@ final class ModuleBaseInstancesTest extends AnyWordSpec {
       import BasicCase1._
 
       val mod1 = new ModuleDef {
-        make[TestClass]
+        make[TestClass].fromSelf
       }
 
       val mod2 = new ModuleDef {
-        make[TestCaseClass2]
+        make[TestCaseClass2].fromSelf
       }
 
       val mod3_1: Module = new ModuleDef {

--- a/distage/distage-core/src/test/scala/izumi/distage/dsl/DSLTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/dsl/DSLTest.scala
@@ -27,12 +27,12 @@ class DSLTest extends AnyWordSpec with MkInjector with should.Matchers {
     "allow to define contexts" in {
       import BasicCase1.*
       val definition: ModuleBase = new ModuleDef {
-        make[TestClass]
+        make[TestClass].fromSelf
         make[TestDependency0].from[TestImpl0]
         make[TestInstanceBinding].from(TestInstanceBinding())
 
         make[TestClass]
-          .named("named.test.class")
+          .named("named.test.class").fromSelf
         makeTrait[TestDependency0]
           .named("named.test.dependency.0")
         make[TestInstanceBinding]
@@ -62,7 +62,7 @@ class DSLTest extends AnyWordSpec with MkInjector with should.Matchers {
       import BasicCase1.*
 
       object Module extends ModuleDef {
-        make[TestClass]
+        make[TestClass].fromSelf
         make[TestDependency0].from[TestImpl0]
       }
 
@@ -78,7 +78,7 @@ class DSLTest extends AnyWordSpec with MkInjector with should.Matchers {
       import BasicCase1.*
 
       object Module extends ModuleDef {
-        make[TestClass].annotateParameter[TestDependency0]("test_param")
+        make[TestClass].annotateParameter[TestDependency0]("test_param").fromSelf
         make[TestDependency0].named("test_param").from[TestImpl0]
       }
 
@@ -98,7 +98,7 @@ class DSLTest extends AnyWordSpec with MkInjector with should.Matchers {
       import BasicCase1.*
 
       object ModuleAnnotated extends ModuleDef {
-        make[TestClass].annotateParameter[TestDependency0]("test_param")
+        make[TestClass].annotateParameter[TestDependency0]("test_param").fromSelf
         make[TestDependency1].from[TestImpl1]
         make[TestDependency0].from[TestImpl0]
         make[TestDependency0].named("test_param").from[TestImpl00]
@@ -125,10 +125,10 @@ class DSLTest extends AnyWordSpec with MkInjector with should.Matchers {
       import SetCase1.*
 
       val definition = new ModuleDef {
-        make[Service2]
-        make[Service0]
-        make[Service1]
-        make[Service3]
+        make[Service2].fromSelf
+        make[Service0].fromSelf
+        make[Service1].fromSelf
+        make[Service3].fromSelf
 
         many[SetTrait]
           .add[SetImpl1]
@@ -156,11 +156,11 @@ class DSLTest extends AnyWordSpec with MkInjector with should.Matchers {
       import BasicCase1.*
 
       val mod1: ModuleBase = new ModuleDef {
-        make[TestClass]
+        make[TestClass].fromSelf
       }
 
       val mod2: ModuleBase = new ModuleDef {
-        make[TestCaseClass2]
+        make[TestCaseClass2].fromSelf
       }
 
       val mod3_1 = new ModuleDef {
@@ -201,7 +201,7 @@ class DSLTest extends AnyWordSpec with MkInjector with should.Matchers {
       import BasicCase1.*
 
       object mod1 extends ModuleDef {
-        make[TestClass]
+        make[TestClass].fromSelf
       }
       object mod2 extends ModuleDef {
         makeTrait[TestDependency0]
@@ -214,7 +214,7 @@ class DSLTest extends AnyWordSpec with MkInjector with should.Matchers {
       import BasicCase1.*
 
       class mod1 extends ModuleDef {
-        make[TestClass]
+        make[TestClass].fromSelf
       }
       class mod2 extends ModuleDef {
         makeTrait[TestDependency0]
@@ -228,7 +228,7 @@ class DSLTest extends AnyWordSpec with MkInjector with should.Matchers {
 
       val definition: ModuleBase = new ModuleDef {
         tag("tag1")
-        make[TestClass]
+        make[TestClass].fromSelf
         makeTrait[TestDependency0].tagged("sniv")
         tag("tag2")
       }
@@ -252,7 +252,7 @@ class DSLTest extends AnyWordSpec with MkInjector with should.Matchers {
         make[Service1].tagged("CA").from[Service1] // merge
         make[Service1].tagged("CB").from[Service1] // merge
 
-        make[Service2].tagged("CC")
+        make[Service2].tagged("CC").fromSelf
 
         many[SetTrait]
       }
@@ -373,7 +373,7 @@ class DSLTest extends AnyWordSpec with MkInjector with should.Matchers {
       }
 
       trait Def2 extends ModuleDef {
-        make[TestClass]
+        make[TestClass].fromSelf
         tag("tag1")
       }
 
@@ -408,10 +408,10 @@ class DSLTest extends AnyWordSpec with MkInjector with should.Matchers {
         tag(A.X, B.C)
         include(
           new ModuleDef {
-            make[X].tagged(A.Y)
-            make[Y].tagged(A.Y)
-            make[Z]
-            make[W].tagged(C.G)
+            make[X].tagged(A.Y).fromSelf
+            make[Y].tagged(A.Y).fromSelf
+            make[Z].fromSelf
+            make[W].tagged(C.G).fromSelf
           },
           TagMergePolicy.MergePreferInner,
         )
@@ -422,7 +422,7 @@ class DSLTest extends AnyWordSpec with MkInjector with should.Matchers {
         tag(A.X, B.C)
         include(
           new ModuleDef {
-            make[X].tagged(A.Y)
+            make[X].tagged(A.Y).fromSelf
           },
           TagMergePolicy.MergePreferOuter,
         )
@@ -433,7 +433,7 @@ class DSLTest extends AnyWordSpec with MkInjector with should.Matchers {
         tag(A.X)
         include(
           new ModuleDef {
-            make[X].tagged(B.C)
+            make[X].tagged(B.C).fromSelf
           },
           TagMergePolicy.UseOnlyInner,
         )
@@ -444,7 +444,7 @@ class DSLTest extends AnyWordSpec with MkInjector with should.Matchers {
         tag(A.X)
         include(
           new ModuleDef {
-            make[X].tagged(B.C)
+            make[X].tagged(B.C).fromSelf
           },
           TagMergePolicy.UseOnlyOuter,
         )
@@ -455,7 +455,7 @@ class DSLTest extends AnyWordSpec with MkInjector with should.Matchers {
         tag(A.X)
         include(
           new ModuleDef {
-            make[X].tagged(B.C)
+            make[X].tagged(B.C).fromSelf
           },
           TagMergePolicy.ReplaceWith(Set(C.G)),
         )
@@ -466,7 +466,7 @@ class DSLTest extends AnyWordSpec with MkInjector with should.Matchers {
         tag(A.X)
         include(
           new ModuleDef {
-            make[X].tagged(B.C)
+            make[X].tagged(B.C).fromSelf
           },
           TagMergePolicy.MergePreferNewWith(Set(B.D, C.G)),
         )
@@ -477,7 +477,7 @@ class DSLTest extends AnyWordSpec with MkInjector with should.Matchers {
         tag(A.X)
         include(
           new ModuleDef {
-            make[X].tagged(B.C)
+            make[X].tagged(B.C).fromSelf
           },
           TagMergePolicy.MergePreferExistingWith(Set(B.D, C.G)),
         )
@@ -500,7 +500,7 @@ class DSLTest extends AnyWordSpec with MkInjector with should.Matchers {
         make[ImplXYZ]
           .aliased[TraitX]
           .aliased[TraitY]
-          .aliased[TraitZ]
+          .aliased[TraitZ].fromSelf
       }
 
       assert(
@@ -602,11 +602,11 @@ class DSLTest extends AnyWordSpec with MkInjector with should.Matchers {
         make[ImplXYZ]
           .named("my-impl")
           .aliased[TraitX]
-          .aliased[TraitY]("Y")
+          .aliased[TraitY]("Y").fromSelf
       })
 
       val defWithoutSugar = PlannerInput.everything(new ModuleDef {
-        make[ImplXYZ].named("my-impl")
+        make[ImplXYZ].named("my-impl").fromSelf
         make[TraitX].using[ImplXYZ]("my-impl")
         make[TraitY].named("Y").using[ImplXYZ]("my-impl")
       })
@@ -615,11 +615,11 @@ class DSLTest extends AnyWordSpec with MkInjector with should.Matchers {
         make[ImplXYZ]
           .named("my-impl").tagged("tag1")
           .aliased[TraitX]
-          .aliased[TraitY]
+          .aliased[TraitY].fromSelf
       })
 
       val defWithTagsWithoutSugar = PlannerInput.everything(new ModuleDef {
-        make[ImplXYZ].named("my-impl").tagged("tag1")
+        make[ImplXYZ].named("my-impl").tagged("tag1").fromSelf
         make[TraitX].tagged("tag1").using[ImplXYZ]("my-impl")
         make[TraitY].tagged("tag1").using[ImplXYZ]("my-impl")
       })
@@ -747,9 +747,9 @@ class DSLTest extends AnyWordSpec with MkInjector with should.Matchers {
       class X
 
       val module = new ModuleDef {
-        make[X].tagged(Repo.Prod, Mode.Prod)
-        make[X].tagged(Repo.Dummy, Mode.Prod)
-        make[X].tagged(Mode.Test)
+        make[X].tagged(Repo.Prod, Mode.Prod).fromSelf
+        make[X].tagged(Repo.Dummy, Mode.Prod).fromSelf
+        make[X].tagged(Mode.Test).fromSelf
       }
       val bindings = (module ++ module).overriddenBy(module).bindings
       assert(bindings.size == 3)

--- a/distage/distage-core/src/test/scala/izumi/distage/dsl/LocatorDefTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/dsl/LocatorDefTest.scala
@@ -48,7 +48,7 @@ class LocatorDefTest extends AnyWordSpec {
       import BasicCase1._
 
       val ctx = new LocatorDef {
-        make[TestCaseClass]
+        make[TestCaseClass].fromSelf
       }
       assertThrows[LocatorDefUninstantiatedBindingException](ctx.instances)
     }

--- a/distage/distage-core/src/test/scala/izumi/distage/fixtures/BasicCases.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/fixtures/BasicCases.scala
@@ -112,7 +112,7 @@ Forest fire, climbin' higher, real life, it can wait""")
     class MyClass(val a: (scala.Predef.String {}) @Id("a"), val b: String @Id("b"))
 
     object MyClassModule extends ModuleDef {
-      make[MyClass]
+      make[MyClass].fromSelf
     }
 
     object ConfigModule extends ModuleDef {

--- a/distage/distage-core/src/test/scala/izumi/distage/gc/GcBasicTests.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/gc/GcBasicTests.scala
@@ -19,8 +19,8 @@ class GcBasicTests extends AnyWordSpec with MkGcInjector {
         injector.planUnsafe(
           PlannerInput(
             new ModuleDef {
-              make[Circular1]
-              make[Circular2]
+              make[Circular1].fromSelf
+              make[Circular2].fromSelf
             },
             Roots(DIKey.get[Circular2]),
             Activation.empty,
@@ -38,9 +38,9 @@ class GcBasicTests extends AnyWordSpec with MkGcInjector {
       val plan = injector.planUnsafe(
         PlannerInput(
           new ModuleDef {
-            make[Circular1]
-            make[Circular2]
-            make[T1]
+            make[Circular1].fromSelf
+            make[Circular2].fromSelf
+            make[T1].fromSelf
             make[Box[T1]].from(new Box(new T1))
           },
           Roots(DIKey.get[Circular1], DIKey.get[Circular2]),

--- a/distage/distage-core/src/test/scala/izumi/distage/gc/GcCases.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/gc/GcCases.scala
@@ -219,8 +219,8 @@ object GcCases {
     final case class Weak() extends Elem
 
     final val module = new ModuleDef {
-      make[Strong]
-      make[Weak]
+      make[Strong].fromSelf
+      make[Weak].fromSelf
 
       many[Elem]
         .ref[Strong]

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/AdvancedBindingsTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/AdvancedBindingsTest.scala
@@ -64,7 +64,7 @@ class AdvancedBindingsTest extends AnyWordSpec with MkInjector {
     import SetCase2.*
 
     val definition = PlannerInput.everything(new ModuleDef {
-      make[Service1]
+      make[Service1].fromSelf
 
       many[Service]
         .ref[Service1]

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/AdvancedTypesTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/AdvancedTypesTest.scala
@@ -22,7 +22,7 @@ class AdvancedTypesTest extends AnyWordSpec with MkInjector with ScalatestGuards
       make[List[Dep]].named("As").from(List(DepA()))
       make[List[Dep]].named("Bs").from(List(DepB()))
       make[List[DepA]].from(List(DepA(), DepA(), DepA()))
-      make[TestClass[DepA]]
+      make[TestClass[DepA]].fromSelf
     })
 
     val injector = mkInjector()
@@ -39,8 +39,8 @@ class AdvancedTypesTest extends AnyWordSpec with MkInjector with ScalatestGuards
     import TypesCase1.*
 
     val definition = PlannerInput.everything(new ModuleDef {
-      make[DepA]
-      make[TestClass2[TypeAliasDepA]]
+      make[DepA].fromSelf
+      make[TestClass2[TypeAliasDepA]].fromSelf
     })
 
     val injector = mkInjector()
@@ -54,7 +54,7 @@ class AdvancedTypesTest extends AnyWordSpec with MkInjector with ScalatestGuards
     import TypesCase1.*
 
     val definition = PlannerInput.everything(new ModuleDef {
-      make[DepA]
+      make[DepA].fromSelf
       makeTrait[TestTrait]
     })
 
@@ -69,7 +69,7 @@ class AdvancedTypesTest extends AnyWordSpec with MkInjector with ScalatestGuards
     import TraitCase2.*
 
     val definition = PlannerInput.everything(new ModuleDef {
-      make[Dependency1 @Id("special")]
+      make[Dependency1 @Id("special")].fromSelf
       makeTrait[Trait1]
     })
 
@@ -87,8 +87,8 @@ class AdvancedTypesTest extends AnyWordSpec with MkInjector with ScalatestGuards
     import TypesCase3.*
 
     val definition = PlannerInput.everything(new ModuleDef {
-      make[Dep]
-      make[Dep2]
+      make[Dep].fromSelf
+      make[Dep2].fromSelf
       make[Trait2 & Trait1].fromTrait[Trait6]
     })
 
@@ -105,8 +105,8 @@ class AdvancedTypesTest extends AnyWordSpec with MkInjector with ScalatestGuards
     import TypesCase3.*
 
     val definition = PlannerInput.everything(new ModuleDef {
-      make[Dep]
-      make[Dep2]
+      make[Dep].fromSelf
+      make[Dep2].fromSelf
       make[Trait1 { def dep: Dep2 }].fromTrait[Trait31[Dep2]]
       make[Trait1 { def dep: Dep }].fromTrait[Trait31[Dep]]
       make[{ def dep: Dep }].fromTrait[Trait6]
@@ -129,8 +129,8 @@ class AdvancedTypesTest extends AnyWordSpec with MkInjector with ScalatestGuards
     import TypesCase4.*
 
     class Definition[T: Tag] extends ModuleDef {
-      make[Dep]
-      make[Dep2]
+      make[Dep].fromSelf
+      make[Dep2].fromSelf
       locally {
         type X[A] = Trait1[Dep, A]
         makeTrait[X[T]]
@@ -151,7 +151,7 @@ class AdvancedTypesTest extends AnyWordSpec with MkInjector with ScalatestGuards
     import TypesCase3.*
 
     class Definition[T >: Null: Tag, G <: T { def dep: Dep }: Tag: TraitConstructor] extends ModuleDef {
-      make[Dep]
+      make[Dep].fromSelf
       make[T { def dep2: Dep }].from(() => null.asInstanceOf[T { def dep2: Dep }])
       make[T { def dep: Dep }].fromTrait[G]
     }
@@ -172,7 +172,7 @@ class AdvancedTypesTest extends AnyWordSpec with MkInjector with ScalatestGuards
     import TypesCase3.*
 
     class Definition[T: Tag, G <: T & Trait1: Tag: TraitConstructor, C <: T & Trait4: Tag: TraitConstructor] extends ModuleDef {
-      make[Dep]
+      make[Dep].fromSelf
       make[T & Trait4].fromTrait[C]
       make[T & Trait1].fromTrait[G]
     }
@@ -199,7 +199,7 @@ class AdvancedTypesTest extends AnyWordSpec with MkInjector with ScalatestGuards
     import TypesCase3.*
 
     class Definition[T <: Dep: Tag: ClassConstructor, K >: Trait5[T]: Tag] extends ModuleDef {
-      make[T]
+      make[T].fromSelf
       make[Trait3[T] & K].fromTrait[Trait5[T]]
     }
 
@@ -218,7 +218,7 @@ class AdvancedTypesTest extends AnyWordSpec with MkInjector with ScalatestGuards
 
     val definition = PlannerInput.everything(new ModuleDef {
       make[WidgetId].from(WidgetId(1))
-      make[Dep]
+      make[Dep].fromSelf
     })
 
     val injector = mkInjector()
@@ -233,7 +233,7 @@ class AdvancedTypesTest extends AnyWordSpec with MkInjector with ScalatestGuards
     import TypesCase4.*
 
     val definition = PlannerInput.everything(new ModuleDef {
-      make[Dep {}]
+      make[Dep {}].fromSelf
     })
 
     val injector = mkInjector()
@@ -246,7 +246,7 @@ class AdvancedTypesTest extends AnyWordSpec with MkInjector with ScalatestGuards
     val constantHolder = LiteralCompat.`5`
 
     val definition = PlannerInput.everything(new ModuleDef {
-      make[constantHolder.T]
+      make[constantHolder.T].fromSelf
     })
 
     val injector = mkInjector()

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/ArityTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/ArityTest.scala
@@ -11,8 +11,8 @@ class ArityTest extends AnyWordSpec with MkInjector {
     import BasicCase8._
 
     val definition = PlannerInput.everything(new ModuleDef {
-      make[Beep[Int]]
-      make[Bop[Int]]
+      make[Beep[Int]].fromSelf
+      make[Bop[Int]].fromSelf
     })
 
     val context = Injector.Standard().produce(definition).unsafeGet()
@@ -24,7 +24,7 @@ class ArityTest extends AnyWordSpec with MkInjector {
     import BasicCase8._
 
     val definition = PlannerInput.everything(new ModuleDef {
-      make[Beep[Int]]
+      make[Beep[Int]].fromSelf
       makeTrait[BopTrait[Int]]
     })
 
@@ -38,7 +38,7 @@ class ArityTest extends AnyWordSpec with MkInjector {
     import BasicCase8._
 
     val definition = PlannerInput.everything(new ModuleDef {
-      make[Beep[Int]]
+      make[Beep[Int]].fromSelf
       makeTrait[BopAbstractClass[Int]]
     })
 
@@ -53,7 +53,7 @@ class ArityTest extends AnyWordSpec with MkInjector {
     import BasicCase8._
 
     val definition = PlannerInput.everything(new ModuleDef {
-      make[Beep[Int]]
+      make[Beep[Int]].fromSelf
       makeFactory[BopFactory[Int]]
     })
 
@@ -71,7 +71,7 @@ class ArityTest extends AnyWordSpec with MkInjector {
     import BasicCase8._
 
     val definition = PlannerInput.everything(new ModuleDef {
-      make[NoArgClass]
+      make[NoArgClass].fromSelf
       makeTrait[NoArgTrait]
       makeTrait[NoArgAbstractClass]
     })

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/AutoSetTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/AutoSetTest.scala
@@ -14,10 +14,10 @@ class AutoSetTest extends AnyWordSpec with MkInjector {
     import SetCase3.*
 
     val definition = new ModuleDef {
-      make[ServiceA]
-      make[ServiceB]
-      make[ServiceC]
-      make[ServiceD]
+      make[ServiceA].fromSelf
+      make[ServiceB].fromSelf
+      make[ServiceC].fromSelf
+      make[ServiceD].fromSelf
     }
 
     val injector = Injector[Identity](bootstrapOverrides = Seq(new BootstrapModuleDef {
@@ -72,8 +72,8 @@ class AutoSetTest extends AnyWordSpec with MkInjector {
 
     def appModule = new ModuleDef {
       make[A].from[AImpl]
-      make[B]
-      make[C]
+      make[B].fromSelf
+      make[C].fromSelf
     }
 
     val services: Set[PrintService] = Injector[Identity](bootstrapOverrides = Seq(bootstrapModule))

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/AutoTraitsTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/AutoTraitsTest.scala
@@ -34,7 +34,7 @@ class AutoTraitsTest extends AnyWordSpec with MkInjector {
     import TraitCase1.*
 
     val definition = new ModuleDef {
-      make[Dependency1]
+      make[Dependency1].fromSelf
       makeTrait[TestTrait]
     }
 
@@ -51,7 +51,7 @@ class AutoTraitsTest extends AnyWordSpec with MkInjector {
     import TraitCase1.*
 
     val definition = new ModuleDef {
-      make[Dependency1]
+      make[Dependency1].fromSelf
       make[TestTrait].named("named-trait").fromTrait[TestTrait]
     }
 
@@ -71,9 +71,9 @@ class AutoTraitsTest extends AnyWordSpec with MkInjector {
       makeTrait[Trait3]
       makeTrait[Trait2]
       makeTrait[Trait1]
-      make[Dependency3]
-      make[Dependency2]
-      make[Dependency1]
+      make[Dependency3].fromSelf
+      make[Dependency2].fromSelf
+      make[Dependency1].fromSelf
     }
 
     val injector = mkNoCyclesInjector()
@@ -97,9 +97,9 @@ class AutoTraitsTest extends AnyWordSpec with MkInjector {
 
     val definition = new ModuleDef {
       make[Trait2].fromTrait[Trait3]
-      make[Dependency3]
-      make[Dependency2]
-      make[Dependency1]
+      make[Dependency3].fromSelf
+      make[Dependency2].fromSelf
+      make[Dependency1].fromSelf
     }
 
     val injector = mkNoCyclesInjector()
@@ -175,7 +175,7 @@ class AutoTraitsTest extends AnyWordSpec with MkInjector {
 
     val definition = PlannerInput.everything(new ModuleDef {
       makeTrait[TestTrait]
-      make[Dep]
+      make[Dep].fromSelf
     })
 
     val injector = mkInjector()
@@ -192,7 +192,7 @@ class AutoTraitsTest extends AnyWordSpec with MkInjector {
 
     val definition = PlannerInput.everything(new ModuleDef {
       makeTrait[TestTraitAny { def dep: Dep }]
-      make[Dep]
+      make[Dep].fromSelf
     })
 
     val injector = mkInjector()
@@ -220,8 +220,8 @@ class AutoTraitsTest extends AnyWordSpec with MkInjector {
     import TypesCase3.*
 
     val definition = PlannerInput.everything(new ModuleDef {
-      make[Dep]
-      make[Dep2]
+      make[Dep].fromSelf
+      make[Dep2].fromSelf
       makeTrait[Trait2 & (Trait2 & (Trait2 & Trait1))]
     })
 
@@ -239,8 +239,8 @@ class AutoTraitsTest extends AnyWordSpec with MkInjector {
     import TypesCase6.*
 
     val definition = PlannerInput.everything(new ModuleDef {
-      make[Dep]
-      make[Dep2]
+      make[Dep].fromSelf
+      make[Dep2].fromSelf
       makeTrait[Trait1 & Trait2]
     })
 
@@ -258,8 +258,8 @@ class AutoTraitsTest extends AnyWordSpec with MkInjector {
     import TraitCase6.*
 
     val definition = PlannerInput.everything(new ModuleDef {
-      make[Dep]
-      make[AnyValDep]
+      make[Dep].fromSelf
+      make[AnyValDep].fromSelf
       makeTrait[TestTrait]
     })
 
@@ -277,8 +277,8 @@ class AutoTraitsTest extends AnyWordSpec with MkInjector {
     import TraitCase7.*
 
     val definition = PlannerInput.everything(new ModuleDef {
-      make[Dependency1]
-      make[Dependency2]
+      make[Dependency1].fromSelf
+      make[Dependency2].fromSelf
       make[X].fromTrait[XImpl]
     })
 

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/AxisTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/AxisTest.scala
@@ -309,7 +309,7 @@ class AxisTest extends AnyWordSpec with MkInjector {
     val definition = new ModuleDef {
       make[Unit].named("x").tagged(Repo.Dummy).fromValue(())
       make[Unit].named("x").tagged(Repo.Prod).fromValue(())
-      make[X]
+      make[X].fromSelf
     }
 
     val instance = mkInjector()

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/BasicTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/BasicTest.scala
@@ -24,12 +24,12 @@ class BasicTest extends AnyWordSpec with MkInjector with ScalatestGuards {
     import BasicCase1.*
     val definition = PlannerInput(
       new ModuleDef {
-        make[TestClass]
+        make[TestClass].fromSelf
         makeTrait[TestDependency3]
         make[TestDependency0].from[TestImpl0]
         makeTrait[TestDependency1]
-        make[TestCaseClass]
-        make[LocatorDependent]
+        make[TestCaseClass].fromSelf
+        make[LocatorDependent].fromSelf
         make[TestInstanceBinding].from(TestInstanceBinding())
       },
       Activation.empty,
@@ -76,7 +76,7 @@ class BasicTest extends AnyWordSpec with MkInjector with ScalatestGuards {
     import BasicCase1.*
 
     val definition = PlannerInput.everything(new ModuleDef {
-      make[TestClass0]
+      make[TestClass0].fromSelf
       make[TestClass2].from {
         (ref: LocatorRef, test: TestClass0) =>
           assert(ref.unsafeUnstableMutableLocator().instances.nonEmpty)
@@ -184,7 +184,7 @@ class BasicTest extends AnyWordSpec with MkInjector with ScalatestGuards {
     import BasicCase2.*
     val definition = PlannerInput.everything(new ModuleDef {
       make[TestClass]
-        .named("named.test.class")
+        .named("named.test.class").fromSelf
       make[TestDependency0].from[TestImpl0Bad]
       make[TestDependency0]
         .named("named.test.dependency.0")
@@ -235,7 +235,7 @@ class BasicTest extends AnyWordSpec with MkInjector with ScalatestGuards {
   "instantiate simple class" in {
     import BasicCase1.*
     val definition = PlannerInput.everything(new ModuleDef {
-      make[TestCaseClass2]
+      make[TestCaseClass2].fromSelf
       make[TestInstanceBinding].from(new TestInstanceBinding)
     })
 
@@ -251,10 +251,10 @@ class BasicTest extends AnyWordSpec with MkInjector with ScalatestGuards {
     import SetCase1.*
 
     val definition = PlannerInput.everything(new ModuleDef {
-      make[Service2]
-      make[Service0]
-      make[Service1]
-      make[Service3]
+      make[Service2].fromSelf
+      make[Service0].fromSelf
+      make[Service1].fromSelf
+      make[Service3].fromSelf
 
       many[SetTrait]
         .add[SetImpl1]
@@ -320,7 +320,7 @@ class BasicTest extends AnyWordSpec with MkInjector with ScalatestGuards {
 
     val definition = PlannerInput.everything(new ModuleDef {
       makeTrait[Dependency].named("special")
-      make[TestClass]
+      make[TestClass].fromSelf
     })
 
     val injector = mkInjector()
@@ -375,7 +375,7 @@ class BasicTest extends AnyWordSpec with MkInjector with ScalatestGuards {
     import BasicCase5.*
     val definition = PlannerInput.everything(new ModuleDef {
       many[TestDependency]
-      make[TestImpl1]
+      make[TestImpl1].fromSelf
     })
 
     val context = mkInjector().produce(definition).unsafeGet()
@@ -537,7 +537,7 @@ class BasicTest extends AnyWordSpec with MkInjector with ScalatestGuards {
       new mutateModule.dsl {
         make[T]
           .named("xyz")
-          .aliased[T]("abc")
+          .aliased[T]("abc").fromSelf
 
         many[RegisteredComponent]
           .weak[T]("xyz")
@@ -658,8 +658,8 @@ class BasicTest extends AnyWordSpec with MkInjector with ScalatestGuards {
     import BasicCase9.*
     val definition = PlannerInput(
       new ModuleDef {
-        make[Out]
-        make[Dep1]
+        make[Out].fromSelf
+        make[Dep1].fromSelf
         make[T2].named("wrong").from[Dep2]
       },
       Activation.empty,
@@ -682,9 +682,9 @@ class BasicTest extends AnyWordSpec with MkInjector with ScalatestGuards {
     import BasicCase10.*
     import SetCase4.*
     val definition = PlannerInput.everything(new ModuleDef {
-      make[TestClass]
-      make[TestGreeter].named(Some("named.greeter"))
-      make[TestGreeter].named(None) // should bind without id
+      make[TestClass].fromSelf
+      make[TestGreeter].named(Some("named.greeter")).fromSelf
+      make[TestGreeter].named(None).fromSelf // should bind without id
       make[TestDependency].named(Some("named.test.before.from")).from[TestImpl1]
       make[TestDependency].named(None).from[TestImpl1]
       make[TestDependency].from[TestImpl2].named(Some("named.test.after.from"))

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/CircularDependenciesTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/CircularDependenciesTest.scala
@@ -69,7 +69,7 @@ class CircularDependenciesTest extends AnyWordSpec with MkInjector with Scalates
     import CircularCase3._
 
     val definition = PlannerInput.everything(new ModuleDef {
-      make[ByNameSelfReference]
+      make[ByNameSelfReference].fromSelf
     })
 
     val injector = mkNoProxiesInjector()
@@ -103,7 +103,7 @@ class CircularDependenciesTest extends AnyWordSpec with MkInjector with Scalates
     FactoryConstructor[FactorySelfReference]
 
     val definition = PlannerInput.everything(new ModuleDef {
-      make[ByNameSelfReference]
+      make[ByNameSelfReference].fromSelf
       makeFactory[FactorySelfReference]
     })
 
@@ -169,8 +169,8 @@ class CircularDependenciesTest extends AnyWordSpec with MkInjector with Scalates
     import ByNameCycle._
 
     val definition = PlannerInput.everything(new ModuleDef {
-      make[Circular2]
-      make[Circular1]
+      make[Circular2].fromSelf
+      make[Circular1].fromSelf
       make[Int].from(1)
     })
 

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/FactoriesTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/FactoriesTest.scala
@@ -181,7 +181,7 @@ class FactoriesTest extends AnyWordSpec with MkInjector with ScalatestGuards {
 
     val definition = PlannerInput.everything(new ModuleDef {
       makeFactory[AssistedAbstractFactory]
-      make[Dependency]
+      make[Dependency].fromSelf
     })
 
     val injector = mkInjector()
@@ -205,7 +205,7 @@ class FactoriesTest extends AnyWordSpec with MkInjector with ScalatestGuards {
     val definition = PlannerInput.everything(new ModuleDef {
       // FIXME: broken due to dotty bug https://github.com/lampepfl/dotty/issues/16468
       makeFactory[AssistedAbstractFactoryF[Identity]]
-      make[Identity[Dependency]]
+      make[Identity[Dependency]].fromSelf
     })
 
     val injector = mkInjector()
@@ -301,7 +301,7 @@ class FactoriesTest extends AnyWordSpec with MkInjector with ScalatestGuards {
 
     val definition = PlannerInput.everything(new ModuleDef {
       makeTrait[Dependency]
-      make[TestClass]
+      make[TestClass].fromSelf
       makeFactory[Factory]
     })
 
@@ -319,8 +319,8 @@ class FactoriesTest extends AnyWordSpec with MkInjector with ScalatestGuards {
     import FactoryCase3.*
 
     val definition = PlannerInput.everything(new ModuleDef {
-      make[Dep1]
-      make[Dep2]
+      make[Dep1].fromSelf
+      make[Dep2].fromSelf
       make[TC[Any]].fromValue(TC1)
       makeFactory[ImplicitFactory]
     })
@@ -352,7 +352,7 @@ class FactoriesTest extends AnyWordSpec with MkInjector with ScalatestGuards {
 
     val definition = PlannerInput.everything(new ModuleDef {
       makeTrait[Dependency]
-      make[TestClass]
+      make[TestClass].fromSelf
       makeFactory[AbstractClassFactory]
     })
 
@@ -504,7 +504,7 @@ class FactoriesTest extends AnyWordSpec with MkInjector with ScalatestGuards {
 
     def definition[F[+_, +_]: TagKK]: PlannerInput = PlannerInput.everything(new ModuleDef {
       makeFactory[XFactory[F]]
-      make[XContext[F]]
+      make[XContext[F]].fromSelf
     })
 
     val injector = mkNoCyclesInjector()

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/HigherKindsTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/HigherKindsTest.scala
@@ -18,7 +18,7 @@ class HigherKindsTest extends AnyWordSpec with MkInjector {
       addImplicit[Pointed[F]]
 
       make[TestTrait].from[TestServiceClass[F]]
-      make[TestServiceClass[F]]
+      make[TestServiceClass[F]].fromSelf
       makeTrait[TestServiceTrait[F]]
       make[Int].named("TestService").from(getResult)
       make[F[String]].from {
@@ -97,7 +97,7 @@ class HigherKindsTest extends AnyWordSpec with MkInjector {
     import HigherKindsCase1.*
 
     abstract class Parent[C: Tag, R[_]: TagK: Pointed] extends ModuleDef {
-      make[TestProvider[C, R]]
+      make[TestProvider[C, R]].fromSelf
     }
 
     assert(new Parent[Int, List] {}.bindings.head.key.tpe == SafeType.get[TestProvider[Int, List]])
@@ -107,7 +107,7 @@ class HigherKindsTest extends AnyWordSpec with MkInjector {
     import HigherKindsCase1.*
 
     abstract class Parent[A: Tag, C: Tag, R[_]: TagK: Pointed] extends ModuleDef {
-      make[TestProvider0[A, C, R]]
+      make[TestProvider0[A, C, R]].fromSelf
     }
 
     assert(new Parent[Int, Boolean, List] {}.bindings.head.key.tpe == SafeType.get[TestProvider0[Int, Boolean, List]])
@@ -117,7 +117,7 @@ class HigherKindsTest extends AnyWordSpec with MkInjector {
     import HigherKindsCase1.*
 
     abstract class Parent[A: Tag, F[_]: TagK, R[_]: TagK: Pointed] extends ModuleDef {
-      make[TestProvider1[A, F, R]]
+      make[TestProvider1[A, F, R]].fromSelf
     }
 
     assert(new Parent[Int, List, List] {}.bindings.head.key.tpe == SafeType.get[TestProvider1[Int, List, List]])
@@ -127,7 +127,7 @@ class HigherKindsTest extends AnyWordSpec with MkInjector {
     import HigherKindsCase1.*
 
     abstract class Parent[F[_]: TagK, R[_]: TagK: Pointed, A: Tag] extends ModuleDef {
-      make[TestProvider2[F, R, A]]
+      make[TestProvider2[F, R, A]].fromSelf
     }
 
     assert(new Parent[List, List, Int] {}.bindings.head.key.tpe == SafeType.get[TestProvider2[List, List, Int]])
@@ -137,20 +137,20 @@ class HigherKindsTest extends AnyWordSpec with MkInjector {
     import izumi.distage.fixtures.HigherKindCases.HigherKindsCase2.*
 
     class Definition[F[+_, +_]: TagKK: TestCovariantTC, G[_]: TagK, A: Tag](v: F[String, Int]) extends ModuleDef {
-      make[TestCovariantTC[F]]
-      make[TestCovariantTC[Either]]
+      make[TestCovariantTC[F]].fromSelf
+      make[TestCovariantTC[Either]].fromSelf
       final val t0 = Tag[TestCovariantTC[F]]
 
-      make[TestClassFG[F, G]]
-      make[TestClassFG[Either, G]]
-      make[TestClassFG[F, Option]]
-      make[TestClassFG[Either, Option]]
+      make[TestClassFG[F, G]].fromSelf
+      make[TestClassFG[Either, G]].fromSelf
+      make[TestClassFG[F, Option]].fromSelf
+      make[TestClassFG[Either, Option]].fromSelf
       final val t1 = Tag[TestClassFG[F, G]]
 
-      make[TestClassFA[F, A]]
-      make[TestClassFA[Either, A]]
-      make[TestClassFA[F, Int]]
-      make[TestClassFA[Either, Int]]
+      make[TestClassFA[F, A]].fromSelf
+      make[TestClassFA[Either, A]].fromSelf
+      make[TestClassFA[F, Int]].fromSelf
+      make[TestClassFA[Either, Int]].fromSelf
       final val t2 = Tag[TestClassFA[F, A]]
 
       make[F[String, Int]].from(v)

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/ImplicitInjectionTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/ImplicitInjectionTest.scala
@@ -13,10 +13,10 @@ class ImplicitInjectionTest extends AnyWordSpec with MkInjector {
     import ImplicitCase2._
 
     val definition = PlannerInput.everything(new ModuleDef {
-      make[TestDependency2]
-      make[TestDependency1]
-      make[TestDependency3]
-      make[TestClass]
+      make[TestDependency2].fromSelf
+      make[TestDependency1].fromSelf
+      make[TestDependency3].fromSelf
+      make[TestClass].fromSelf
     })
 
     val injector = mkInjector()
@@ -33,8 +33,8 @@ class ImplicitInjectionTest extends AnyWordSpec with MkInjector {
     import ImplicitCase1._
 
     val definition = PlannerInput.everything(new ModuleDef {
-      make[TestClass]
-      make[Dep]
+      make[TestClass].fromSelf
+      make[Dep].fromSelf
       make[DummyImplicit].from[MyDummyImplicit]
     })
 
@@ -54,10 +54,10 @@ class ImplicitInjectionTest extends AnyWordSpec with MkInjector {
     val definition = PlannerInput.everything(new ModuleDef {
       @nowarn implicit val testDependency3: TestDependency3 = new TestDependency3
 
-      make[TestDependency1]
-      make[TestDependency2]
-      make[TestDependency3]
-      make[TestClass]
+      make[TestDependency1].fromSelf
+      make[TestDependency2].fromSelf
+      make[TestDependency3].fromSelf
+      make[TestClass].fromSelf
     })
 
     val injector = mkInjector()

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/InnerClassesTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/InnerClassesTest.scala
@@ -11,8 +11,8 @@ class InnerClassesTest extends AnyWordSpec with MkInjector {
     import InnerClassStablePathsCase.*
 
     val definition = PlannerInput.everything(new ModuleDef {
-      make[StableObjectInheritingTrait.TestDependency]
-      make[StableObjectInheritingTrait1.TestDependency]
+      make[StableObjectInheritingTrait.TestDependency].fromSelf
+      make[StableObjectInheritingTrait1.TestDependency].fromSelf
     })
 
     val context = mkNoCyclesInjector().produce(definition).unsafeGet()
@@ -27,8 +27,8 @@ class InnerClassesTest extends AnyWordSpec with MkInjector {
     import StableObjectInheritingTrait.*
 
     val definition = PlannerInput.everything(new ModuleDef {
-      make[TestDependency]
-      make[TestClass]
+      make[TestDependency].fromSelf
+      make[TestClass].fromSelf
     })
 
     val context = mkNoCyclesInjector().produce(definition).unsafeGet()
@@ -43,8 +43,8 @@ class InnerClassesTest extends AnyWordSpec with MkInjector {
 
     val definition = PlannerInput.everything(new ModuleDef {
       make[testProviderModule.type].from[testProviderModule.type](testProviderModule: testProviderModule.type)
-      make[testProviderModule.TestDependency]
-      make[testProviderModule.TestClass[testProviderModule.type]]
+      make[testProviderModule.TestDependency].fromSelf
+      make[testProviderModule.TestClass[testProviderModule.type]].fromSelf
     })
 
     val injector = mkInjector()
@@ -62,8 +62,8 @@ class InnerClassesTest extends AnyWordSpec with MkInjector {
 
       val definition = PlannerInput.everything(new ModuleDef {
         make[testProviderModule.type].from[testProviderModule.type](testProviderModule: testProviderModule.type)
-        make[testProviderModule.TestClass[testProviderModule.type]]
-        make[testProviderModule.TestDependency]
+        make[testProviderModule.TestClass[testProviderModule.type]].fromSelf
+        make[testProviderModule.TestDependency].fromSelf
       })
 
       val injector = mkNoCyclesInjector()
@@ -104,8 +104,8 @@ class InnerClassesTest extends AnyWordSpec with MkInjector {
 
     val definition = PlannerInput.everything(new ModuleDef {
       make[testProviderModule.type].from[testProviderModule.type](testProviderModule: testProviderModule.type)
-      make[testProviderModule.TestDependency]
-      make[testProviderModule.TestClass[testProviderModule.type]]
+      make[testProviderModule.TestDependency].fromSelf
+      make[testProviderModule.TestClass[testProviderModule.type]].fromSelf
     })
 
     val injector = mkInjector()
@@ -123,8 +123,8 @@ class InnerClassesTest extends AnyWordSpec with MkInjector {
   "can handle class local path-dependent injections" in {
     val definition = PlannerInput.everything(new ModuleDef {
       make[TopLevelPathDepTest.type].from[TopLevelPathDepTest.type](TopLevelPathDepTest: TopLevelPathDepTest.type)
-      make[TopLevelPathDepTest.TestClass[TopLevelPathDepTest.type]]
-      make[TopLevelPathDepTest.TestDependency]
+      make[TopLevelPathDepTest.TestClass[TopLevelPathDepTest.type]].fromSelf
+      make[TopLevelPathDepTest.TestDependency].fromSelf
     })
 
     val injector = mkNoCyclesInjector()
@@ -153,8 +153,8 @@ class InnerClassesTest extends AnyWordSpec with MkInjector {
     import StableObjectInheritingTrait.*
 
     val definition = PlannerInput.everything(new ModuleDef {
-      make[ByNameCircular1]
-      make[ByNameCircular2]
+      make[ByNameCircular1].fromSelf
+      make[ByNameCircular2].fromSelf
     })
 
     val context = mkNoProxiesInjector().produce(definition).unsafeGet()
@@ -189,8 +189,8 @@ class InnerClassesTest extends AnyWordSpec with MkInjector {
     private val definition = PlannerInput.everything(new ModuleDef {
       make[InnerPathDepTest.this.type].from[InnerPathDepTest.this.type](InnerPathDepTest.this: InnerPathDepTest.this.type)
       make[InnerPathDepTest.type].from[InnerPathDepTest.type]
-      make[TestClass[InnerPathDepTest.this.type]]
-      make[TestDependency]
+      make[TestClass[InnerPathDepTest.this.type]].fromSelf
+      make[TestDependency].fromSelf
     })
 
     def testCase = {

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/JSRAnnotationTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/JSRAnnotationTest.scala
@@ -15,7 +15,7 @@ class JSRAnnotationTest extends AnyWordSpec with MkGcInjector with ScalatestGuar
         make[String].named("address").from("localhost")
         make[Int].named("port1").from(90)
         make[String].named("address1").from("localhost1")
-        make[ServerConfig]
+        make[ServerConfig].fromSelf
       })
 
       val context = Injector.Standard().produce(definition).unsafeGet()
@@ -31,7 +31,7 @@ class JSRAnnotationTest extends AnyWordSpec with MkGcInjector with ScalatestGuar
       val definition = PlannerInput.everything(new ModuleDef {
         make[Int].named("port1").from(90)
         make[String].named("address1").from("localhost1")
-        make[ServerConfigWithFieldAnnos]
+        make[ServerConfigWithFieldAnnos].fromSelf
       })
 
       val context = Injector.Standard().produce(definition).unsafeGet()
@@ -44,7 +44,7 @@ class JSRAnnotationTest extends AnyWordSpec with MkGcInjector with ScalatestGuar
       val definition = PlannerInput.everything(new ModuleDef {
         make[Int].named("port").from(80)
         make[String].named("address").from("localhost")
-        make[ServerConfigWithTypeAnnos]
+        make[ServerConfigWithTypeAnnos].fromSelf
       })
 
       val context = Injector.Standard().produce(definition).unsafeGet()

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/PlanOperationsTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/PlanOperationsTest.scala
@@ -23,11 +23,11 @@ class PlanOperationsTest extends AnyWordSpec with MkInjector {
 
     val definition = PlannerInput(
       new ModuleDef {
-        make[PrimaryComponent]
-        make[IntegrationComponent]
-        make[SharedComponent0]
-        make[SharedComponent1]
-        make[SharedComponent2]
+        make[PrimaryComponent].fromSelf
+        make[IntegrationComponent].fromSelf
+        make[SharedComponent0].fromSelf
+        make[SharedComponent1].fromSelf
+        make[SharedComponent2].fromSelf
       },
       primary ++ sub,
       Activation.empty,

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/PlanVerifierTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/PlanVerifierTest.scala
@@ -508,7 +508,7 @@ class PlanVerifierTest extends AnyWordSpec with MkInjector {
       many[Dep]
         .ref[ExternalDep]
 
-      make[X]
+      make[X].fromSelf
       make[Fork1].tagged(Axis.A).from[ImplA].addDependency[Set[Dep]]
       make[Fork1].tagged(Axis.B).from[ImplB]
 
@@ -583,8 +583,8 @@ class PlanVerifierTest extends AnyWordSpec with MkInjector {
       many[Fork2]
         .weak[ImplC].tagged(Axis1.A)
         .weak[ImplD].tagged(Axis1.B)
-      make[ImplC]
-      make[ImplD]
+      make[ImplC].fromSelf
+      make[ImplD].fromSelf
     }
 
     val result = PlanVerifier().verify[Identity](definition, Roots.target[Set[Fork2]], Injector.providedKeys(), Set.empty)
@@ -598,8 +598,8 @@ class PlanVerifierTest extends AnyWordSpec with MkInjector {
       many[Fork2]
         .weak[ImplC].tagged(Axis1.A)
         .weak[ImplD].tagged(Axis1.B)
-      make[ImplC].tagged(Axis1.A)
-      make[ImplD].tagged(Axis1.B)
+      make[ImplC].tagged(Axis1.A).fromSelf
+      make[ImplD].tagged(Axis1.B).fromSelf
     }
 
     val result = PlanVerifier().verify[Identity](definition, Roots.target[Set[Fork2]], Injector.providedKeys(), Set.empty)
@@ -613,7 +613,7 @@ class PlanVerifierTest extends AnyWordSpec with MkInjector {
       many[Fork2]
         .weak[ImplC].tagged(Axis1.A)
         .weak[ImplD].tagged(Axis1.B)
-      make[ImplD]
+      make[ImplD].fromSelf
     }
 
     val result = PlanVerifier().verify[Identity](definition, Roots.target[Set[Fork2]], Injector.providedKeys(), Set.empty)

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/PrivateBindingsTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/PrivateBindingsTest.scala
@@ -74,7 +74,7 @@ class PrivateBindingsTest extends AnyWordSpec with MkInjector {
       .target[TestCaseClass2](
         new ModuleDef {
           make[TestInstanceBinding].fromValue(TestInstanceBinding())
-          make[TestCaseClass2]
+          make[TestCaseClass2].fromSelf
         }
       )
       .withLocatorPrivacy(LocatorPrivacy.PublicRoots)

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/ProvidersTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/ProvidersTest.scala
@@ -28,7 +28,7 @@ class ProvidersTest extends AnyWordSpec with MkInjector {
     import ProviderCase3._
 
     val definition = PlannerInput.everything(new ModuleDef {
-      make[TestDependency].named("classdeftypeann1")
+      make[TestDependency].named("classdeftypeann1").fromSelf
       make[TestClass].from(implType _)
     })
 
@@ -46,7 +46,7 @@ class ProvidersTest extends AnyWordSpec with MkInjector {
     import ProviderCase3._
 
     val definition = PlannerInput.everything(new ModuleDef {
-      make[TestDependency].named("classdeftypeann1")
+      make[TestDependency].named("classdeftypeann1").fromSelf
       make[TestClass].from {
         (t: TestDependency @Id("classdeftypeann1")) => new TestClass(t)
       }

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/ResourceEffectBindingsTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/ResourceEffectBindingsTest.scala
@@ -363,12 +363,12 @@ class ResourceEffectBindingsTest extends AnyWordSpec with MkInjector  {
 
       val definition = PlannerInput.everything(new ModuleDef {
         makeTrait[NotInContext]
-        make[TestClass]
+        make[TestClass].fromSelf
         makeTrait[TestDependency3]
         make[TestDependency0].from[TestImpl0]
         makeTrait[TestDependency1]
-        make[TestCaseClass]
-        make[LocatorDependent]
+        make[TestCaseClass].fromSelf
+        make[LocatorDependent].fromSelf
         make[TestInstanceBinding].fromResource(new Lifecycle.Basic[Option, TestInstanceBinding] {
           override def acquire: Option[TestInstanceBinding] = None
           override def release(resource: TestInstanceBinding): Option[Unit] = None

--- a/distage/distage-core/src/test/scala/izumi/distage/injector/SubcontextTest.scala
+++ b/distage/distage-core/src/test/scala/izumi/distage/injector/SubcontextTest.scala
@@ -15,8 +15,8 @@ class SubcontextTest extends AnyWordSpec with MkInjector {
 
   "support local contexts" in {
     val module = new ModuleDef {
-      make[GlobalServiceDependency]
-      make[GlobalService]
+      make[GlobalServiceDependency].fromSelf
+      make[GlobalService].fromSelf
 
       // this will not be used/instantiated
       make[LocalService].from[LocalServiceBadImpl]
@@ -56,8 +56,8 @@ class SubcontextTest extends AnyWordSpec with MkInjector {
 
   "support incomplete dsl chains (good case, no externals)" in {
     val module = new ModuleDef {
-      make[GlobalServiceDependency]
-      make[GlobalService]
+      make[GlobalServiceDependency].fromSelf
+      make[GlobalService].fromSelf
 
       makeSubcontext[Identity, Int]
         .named("test")
@@ -103,8 +103,8 @@ class SubcontextTest extends AnyWordSpec with MkInjector {
 
   "support activations on subcontexts" in {
     val module = new ModuleDef {
-      make[GlobalServiceDependency]
-      make[GlobalService]
+      make[GlobalServiceDependency].fromSelf
+      make[GlobalService].fromSelf
       make[LocalService].from[LocalServiceGoodImpl]
       make[Arg].fromValue(Arg(1))
 
@@ -140,8 +140,8 @@ class SubcontextTest extends AnyWordSpec with MkInjector {
 
   "support activations in subcontexts" in {
     val module = new ModuleDef {
-      make[GlobalServiceDependency]
-      make[GlobalService]
+      make[GlobalServiceDependency].fromSelf
+      make[GlobalService].fromSelf
 
       makeSubcontext[Identity, Int](new ModuleDef {
         make[LocalService].from[LocalServiceGoodImpl]
@@ -166,8 +166,8 @@ class SubcontextTest extends AnyWordSpec with MkInjector {
 
   "support value types in subcontexts" in {
     val module = new ModuleDef {
-      make[GlobalServiceDependency]
-      make[GlobalService]
+      make[GlobalServiceDependency].fromSelf
+      make[GlobalService].fromSelf
 
       makeSubcontext[Identity, Int](new ModuleDef {
         make[LocalService].from[LocalServiceAnyValImpl]
@@ -187,8 +187,8 @@ class SubcontextTest extends AnyWordSpec with MkInjector {
 
   "usability: subcontext is pinned to its effect type, preventing confusion when Identity is used in `.use`" in {
     val module = new ModuleDef {
-      make[GlobalServiceDependency]
-      make[GlobalService]
+      make[GlobalServiceDependency].fromSelf
+      make[GlobalService].fromSelf
 
       makeSubcontext[Suspend2[Throwable, _], Suspend2[Throwable, Int]](new ModuleDef {
         make[LocalService].from[LocalServiceGoodImpl]

--- a/distage/distage-extension-config/.jvm/src/test/scala/izumi/distage/impl/OptionalDependencyTest.scala
+++ b/distage/distage-extension-config/.jvm/src/test/scala/izumi/distage/impl/OptionalDependencyTest.scala
@@ -158,8 +158,8 @@ class OptionalDependencyTest extends AnyWordSpec with GivenWhenThen {
 
     Then("ModuleDef syntax works")
     new ModuleDef {
-      make[Some[Int]]
-      make[None.type]
+      make[Some[Int]].fromSelf
+      make[None.type].fromSelf
       make[Int].from(0)
     }
 

--- a/distage/distage-extension-config/src/test/scala/izumi/distage/config/test/configapp/TestConfigApp.scala
+++ b/distage/distage-extension-config/src/test/scala/izumi/distage/config/test/configapp/TestConfigApp.scala
@@ -47,20 +47,20 @@ class HttpServer2(val listenOn: HostPort @Id("HttpServer2.HostPort.listenOn")) e
 
 object TestConfigApp {
   final val definition = PlannerInput.everything(new ConfigModuleDef {
-    make[HttpServer1]
-    make[HttpServer2]
+    make[HttpServer1].fromSelf
+    make[HttpServer2].fromSelf
     makeConfigNamed[HostPort]("HttpServer1.HostPort")
     makeConfigNamed[HostPort]("HttpServer2.HostPort.listenOn")
 
-    make[DataPuller1]
+    make[DataPuller1].fromSelf
     makeConfigNamed[HostPort]("DataPuller1.target")
     makeConfigNamed[HostPort]("DataPuller1.source")
 
-    make[DataPuller2]
+    make[DataPuller2].fromSelf
     makeConfigNamed[HostPort]("DataPuller2.target")
     makeConfigNamed[HostPort]("DataPuller2.source")
 
-    make[DataPuller3]
+    make[DataPuller3].fromSelf
     makeConfigNamed[HostPort]("cassandra")
     makeConfigNamed[HostPort]("datasource.google")
     makeConfigNamed[String]("scalars.s")
@@ -76,7 +76,7 @@ object TestConfigApp {
       .ref[TestAppService]("puller2")
       .ref[TestAppService]("puller3")
 
-    make[TestConfigApp]
+    make[TestConfigApp].fromSelf
   })
 
 }

--- a/distage/distage-extension-config/src/test/scala/izumi/distage/config/test/configapp/TestConfigReaders.scala
+++ b/distage/distage-extension-config/src/test/scala/izumi/distage/config/test/configapp/TestConfigReaders.scala
@@ -80,47 +80,47 @@ final class AnyValInt(val int: Int) extends AnyVal
 
 object TestConfigReaders {
   final val mapDefinition = PlannerInput.everything(new ConfigModuleDef {
-    make[Service[MapCaseClass]]
+    make[Service[MapCaseClass]].fromSelf
     makeConfig[MapCaseClass]("MapCaseClass")
   })
 
   final val listDefinition = PlannerInput.everything(new ConfigModuleDef {
-    make[Service[ListCaseClass]]
+    make[Service[ListCaseClass]].fromSelf
     makeConfig[ListCaseClass]("ListCaseClass")
   })
 
   final val optDefinition = PlannerInput.everything(new ConfigModuleDef {
-    make[Service[OptionCaseClass]]
+    make[Service[OptionCaseClass]].fromSelf
     makeConfig[OptionCaseClass]("OptionCaseClass")
   })
 
   final val backticksDefinition = PlannerInput.everything(new ConfigModuleDef {
-    make[Service[BackticksCaseClass]]
+    make[Service[BackticksCaseClass]].fromSelf
     makeConfig[BackticksCaseClass]("BackticksCaseClass")
   })
 
   final val sealedDefinition = PlannerInput.everything(new ConfigModuleDef {
-    make[Service[SealedCaseClass]]
+    make[Service[SealedCaseClass]].fromSelf
     makeConfig[SealedCaseClass]("SealedCaseClass")
   })
 
   final val tupleDefinition = PlannerInput.everything(new ConfigModuleDef {
-    make[Service[TupleCaseClass]]
+    make[Service[TupleCaseClass]].fromSelf
     makeConfig[TupleCaseClass]("TupleCaseClass")
   })
 
   final val customCodecDefinition = PlannerInput.everything(new ConfigModuleDef {
-    make[Service[CustomCaseClass]]
+    make[Service[CustomCaseClass]].fromSelf
     makeConfig[CustomCaseClass]("CustomCaseClass")
   })
 
   final val privateFieldsCodecDefinition = PlannerInput.everything(new ConfigModuleDef {
-    make[Service[PrivateCaseClass]]
+    make[Service[PrivateCaseClass]].fromSelf
     makeConfig[PrivateCaseClass]("PrivateCaseClass")
   })
 
   final val partiallyPrivateFieldsCodecDefinition = PlannerInput.everything(new ConfigModuleDef {
-    make[Service[PartiallyPrivateCaseClass]]
+    make[Service[PartiallyPrivateCaseClass]].fromSelf
     makeConfig[PartiallyPrivateCaseClass]("PartiallyPrivateCaseClass")
   })
 

--- a/distage/distage-extension-logstage/src/main/scala/izumi/logstage/distage/LogstageModule.scala
+++ b/distage/distage-extension-logstage/src/main/scala/izumi/logstage/distage/LogstageModule.scala
@@ -14,7 +14,7 @@ class LogstageModule(router: LogRouter, setupStaticLogRouter: Boolean) extends B
   make[IzLogger]
     .aliased[RoutingLogger]
     .aliased[AbstractLogger]
-    .exposed
+    .exposed.fromSelf
 
   make[LogRouter].fromValue(router)
   make[CustomContext].fromValue(CustomContext.empty)

--- a/distage/distage-extension-logstage/src/test/scala/izumi/logstage/distage/LoggerInjectionTest.scala
+++ b/distage/distage-extension-logstage/src/test/scala/izumi/logstage/distage/LoggerInjectionTest.scala
@@ -27,8 +27,8 @@ class LoggerInjectionTest extends AnyWordSpec {
       val router = ConfigurableLogRouter(IzLogger.Level.Trace, testSink)
 
       val definition = PlannerInput.everything(new ModuleDef {
-        make[ExampleService]
-        make[ExampleApp]
+        make[ExampleService].fromSelf
+        make[ExampleApp].fromSelf
       })
 
       val loggerModule = new LogstageModule(router, false)

--- a/distage/distage-extension-plugins/.jvm/src/test/scala/izumi/distage/compat/ZIOResourcesZManagedTestJvm.scala
+++ b/distage/distage-extension-plugins/.jvm/src/test/scala/izumi/distage/compat/ZIOResourcesZManagedTestJvm.scala
@@ -47,7 +47,7 @@ final class ZIOResourcesZManagedTestJvm extends AnyWordSpec with GivenWhenThen w
       val module = new ModuleDef {
         make[DBConnection].fromResource(dbResource)
         make[MessageQueueConnection].fromResource(mqResource)
-        make[MyApp]
+        make[MyApp].fromSelf
       }
 
       unsafeRun(Injector[Task]().produceRun(module) {

--- a/distage/distage-extension-plugins/.jvm/src/test/scala/izumi/distage/injector/ZIOZManagedHasInjectionTest.scala
+++ b/distage/distage-extension-plugins/.jvm/src/test/scala/izumi/distage/injector/ZIOZManagedHasInjectionTest.scala
@@ -79,9 +79,9 @@ class ZIOZManagedHasInjectionTest extends AnyWordSpec with ScalatestGuards {
       def getDep2: URIO[Dependency2, Dependency2] = ZIO.environmentWith[Dependency2](_.get)
 
       val definition = PlannerInput.everything(new ModuleDef {
-        make[Dependency1]
-        make[Dependency2]
-        make[Dependency3]
+        make[Dependency1].fromSelf
+        make[Dependency2].fromSelf
+        make[Dependency3].fromSelf
         make[Trait3 { def acquired: Boolean }].fromZIOEnv(
           (d3: Dependency3) =>
             for {

--- a/distage/distage-extension-plugins/src/test/scala/com/github/pshirshov/test/plugins/DependingPlugin.scala
+++ b/distage/distage-extension-plugins/src/test/scala/com/github/pshirshov/test/plugins/DependingPlugin.scala
@@ -9,6 +9,6 @@ class DependingPlugin extends SneakyPlugin {
 object DependingPlugin extends App {
   class NestedDoublePlugin extends SneakyPlugin
   object NestedDoublePlugin extends SneakyPlugin {
-    make[TestDepending]
+    make[TestDepending].fromSelf
   }
 }

--- a/distage/distage-extension-plugins/src/test/scala/com/github/pshirshov/test/plugins/ObjectTestPlugin.scala
+++ b/distage/distage-extension-plugins/src/test/scala/com/github/pshirshov/test/plugins/ObjectTestPlugin.scala
@@ -3,5 +3,5 @@ package com.github.pshirshov.test.plugins
 import com.github.pshirshov.test.sneaky.SneakyPlugin
 
 object ObjectTestPlugin extends SneakyPlugin {
-  make[TestDep3]
+  make[TestDep3].fromSelf
 }

--- a/distage/distage-extension-plugins/src/test/scala/com/github/pshirshov/test/plugins/StaticTestPlugin2.scala
+++ b/distage/distage-extension-plugins/src/test/scala/com/github/pshirshov/test/plugins/StaticTestPlugin2.scala
@@ -1,5 +1,5 @@
 package com.github.pshirshov.test.plugins
 
 class StaticTestPlugin2 extends izumi.distage.plugins.PluginDef {
-  make[TestService]
+  make[TestService].fromSelf
 }

--- a/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/modules/DockerSupportModule.scala
+++ b/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/modules/DockerSupportModule.scala
@@ -38,7 +38,7 @@ class DockerSupportModule[F[_]: TagK](configModule: ModuleBase) extends ModuleDe
       Lifecycle.fromAutoCloseable(clientFactory.makeClient(clientConfig, rawClientConfig))
   }
 
-  make[DockerIntegrationCheck[F]]
+  make[DockerIntegrationCheck[F]].fromSelf
 }
 
 object DockerSupportModule {

--- a/distage/distage-framework-docker/src/test/scala/izumi/distage/testkit/docker/fixtures/DockerPlugin.scala
+++ b/distage/distage-framework-docker/src/test/scala/izumi/distage/testkit/docker/fixtures/DockerPlugin.scala
@@ -96,7 +96,7 @@ object DockerPlugin extends PluginDef {
       AvailablePort.local(pgPort)
   }
 
-  make[PgSvcExample]
+  make[PgSvcExample].fromSelf
 
   include(new ConfigModuleDef {
     makeConfigNamed[Int]("postgres.port")

--- a/distage/distage-framework/.jvm/src/test/scala/izumi/distage/roles/test/RoleAppTest.scala
+++ b/distage/distage-framework/.jvm/src/test/scala/izumi/distage/roles/test/RoleAppTest.scala
@@ -243,7 +243,7 @@ class RoleAppTest extends AnyWordSpec with WithProperties {
       val initCounterIdentity = new XXX_ResourceEffectsRecorder[Identity]
 
       val definition = new ResourcesPluginBase {
-        make[IntegrationResource0[Identity]]
+        make[IntegrationResource0[Identity]].fromSelf
         make[TestResource[Identity]].using[IntegrationResource0[Identity]]
         make[TestResource[Identity] & AutoCloseable].using[IntegrationResource0[Identity]]
         many[TestResource[Identity]]

--- a/distage/distage-framework/src/test/scala/com/github/pshirshov/test3/bootstrap/BootstrapFixture3.scala
+++ b/distage/distage-framework/src/test/scala/com/github/pshirshov/test3/bootstrap/BootstrapFixture3.scala
@@ -12,7 +12,7 @@ object BootstrapFixture3 {
 
   object BootstrapPlugin extends BootstrapPluginDef() with ConfigModuleDef {
     makeConfig[BasicConfig]("basicConfig").exposed
-    make[BootstrapComponent].exposed
+    make[BootstrapComponent].exposed.fromSelf
   }
 
   final class UnsatisfiedDep

--- a/distage/distage-framework/src/test/scala/izumi/distage/roles/test/fixtures/ResourcesPlugin.scala
+++ b/distage/distage-framework/src/test/scala/izumi/distage/roles/test/fixtures/ResourcesPlugin.scala
@@ -22,11 +22,11 @@ class ConflictPlugin extends PluginDef {
 trait ResourcesPluginBase extends ModuleDef {
   make[ExecutorService].from(Executors.newCachedThreadPool())
 
-  make[IntegrationResource1[Identity]]
-  make[JustResource1[Identity]]
-  make[JustResource2[Identity]]
-  make[ProbeResource0[Identity]]
-  make[JustResource3[Identity]]
+  make[IntegrationResource1[Identity]].fromSelf
+  make[JustResource1[Identity]].fromSelf
+  make[JustResource2[Identity]].fromSelf
+  make[ProbeResource0[Identity]].fromSelf
+  make[JustResource3[Identity]].fromSelf
 
   many[TestResource[Identity]]
     .ref[IntegrationResource1[Identity]]
@@ -35,11 +35,11 @@ trait ResourcesPluginBase extends ModuleDef {
     .ref[ProbeResource0[Identity]]
     .ref[JustResource3[Identity]]
 
-  make[IntegrationResource1[IO]]
-  make[JustResource1[IO]]
-  make[JustResource2[IO]]
-  make[ProbeResource0[IO]]
-  make[JustResource3[IO]]
+  make[IntegrationResource1[IO]].fromSelf
+  make[JustResource1[IO]].fromSelf
+  make[JustResource2[IO]].fromSelf
+  make[ProbeResource0[IO]].fromSelf
+  make[JustResource3[IO]].fromSelf
 
   many[TestResource[IO]]
     .ref[IntegrationResource1[IO]]
@@ -50,9 +50,9 @@ trait ResourcesPluginBase extends ModuleDef {
 }
 
 class ResourcesPlugin extends PluginDef with ResourcesPluginBase {
-  make[XXX_ResourceEffectsRecorder[IO]]
+  make[XXX_ResourceEffectsRecorder[IO]].fromSelf
 
-  make[IntegrationResource0[IO]]
+  make[IntegrationResource0[IO]].fromSelf
   many[TestResource[IO]]
     .ref[IntegrationResource0[IO]]
 }

--- a/distage/distage-framework/src/test/scala/izumi/distage/roles/test/fixtures/TestPlugin.scala
+++ b/distage/distage-framework/src/test/scala/izumi/distage/roles/test/fixtures/TestPlugin.scala
@@ -51,8 +51,8 @@ class TestPluginBase[F[_]: TagK] extends PluginDef with RoleModuleDef {
   makeRole[FailingRole01[F]]
   makeRole[FailingRole02[F]]
 
-  make[TestRole00Resource[F]]
-  make[TestRole00ResourceIntegrationCheck[F]]
+  make[TestRole00Resource[F]].fromSelf
+  make[TestRole00ResourceIntegrationCheck[F]].fromSelf
 
   makeRole[ConfigTestRole[F]]
 

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/runner/TestkitRunnerModule.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/runner/TestkitRunnerModule.scala
@@ -29,14 +29,14 @@ class TestkitRunnerModule[F[_]: TagK: QuasiIO: QuasiAsync](
     DebugProperties.`izumi.distage.testkit.skip.docker.failures`.boolValue(default = false) ||
     IzPlatform.getenvOption("IZUMI_SKIP_DOCKER_FAILURES").contains("true")
   }
-  make[TestStatusConverter]
+  make[TestStatusConverter].fromSelf
 
-  make[TestkitLogging]
+  make[TestkitLogging].fromSelf
 
   make[TimedActionF[Identity]].from[TimedActionFImpl[Identity]]
   make[TestConfigLoader].from[TestConfigLoader.TestConfigLoaderImpl]
 
-  make[TestPlanner]
+  make[TestPlanner].fromSelf
   make[TestTreeBuilder].from[TestTreeBuilder.TestTreeBuilderImpl]
 
   make[TimedActionF[F]].from[TimedActionFImpl[F]]

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/runner/impl/TestRuntimeModule.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/runner/impl/TestRuntimeModule.scala
@@ -16,7 +16,7 @@ class TestRuntimeModule[F[_]: TagK](params: EnvExecutionParams) extends ModuleDe
     (exec: EnvExecutionParams) =>
       exec.planningOptions
   }
-  make[PlanCircularDependencyCheck]
+  make[PlanCircularDependencyCheck].fromSelf
 
   make[IzLogger].named("distage-testkit").from {
     (logger: IzLogger) => logger

--- a/distage/distage-testkit-scalatest/src/test/scala/izumi/distage/testkit/distagesuite/fixtures/Fixtures.scala
+++ b/distage/distage-testkit-scalatest/src/test/scala/izumi/distage/testkit/distagesuite/fixtures/Fixtures.scala
@@ -21,13 +21,13 @@ object MockAppIdPlugin extends MockAppPlugin[Identity]
 object MockAppZioZEnvPlugin extends MockAppPlugin[zio.ZIO[Int, Throwable, +_]]
 
 abstract class MockAppPlugin[F[_]: TagK] extends PluginDef {
-  make[MockPostgresDriver[F]]
-  make[MockUserRepository[F]]
-  make[MockPostgresCheck[F]]
-  make[MockRedis[F]]
-  make[MockCache[F]]
-  make[MockCachedUserService[F]]
-  make[UnavailableIntegrationCheck[F]]
+  make[MockPostgresDriver[F]].fromSelf
+  make[MockUserRepository[F]].fromSelf
+  make[MockPostgresCheck[F]].fromSelf
+  make[MockRedis[F]].fromSelf
+  make[MockCache[F]].fromSelf
+  make[MockCachedUserService[F]].fromSelf
+  make[UnavailableIntegrationCheck[F]].fromSelf
   make[ActiveComponent].fromValue(TestActiveComponent).tagged(Mode.Test)
   make[ActiveComponent].fromValue(ProdActiveComponent).tagged(Mode.Prod)
 }

--- a/distage/distage-testkit-scalatest/src/test/scala/izumi/distage/testkit/distagesuite/generic/tests.scala
+++ b/distage/distage-testkit-scalatest/src/test/scala/izumi/distage/testkit/distagesuite/generic/tests.scala
@@ -117,15 +117,15 @@ abstract class DistageTestExampleBase[F[_]: TagK: DefaultModule](implicit F: Qua
     ) ++ new izumi.distage.plugins.PluginDef {
       make[ZEnvironment[Int]].named("zio-initial-env").from(ZEnvironment(1))
 
-      make[SetCounter]
-      make[SetCounter].named("unmemoized")
-      make[SetCounter].named("directly-memoized")
+      make[SetCounter].fromSelf
+      make[SetCounter].named("unmemoized").fromSelf
+      make[SetCounter].named("directly-memoized").fromSelf
 
-      make[SetElement1]
-      make[SetElement2]
-      make[SetElement3]
-      make[SetElement4]
-      make[SetElement4Retainer]
+      make[SetElement1].fromSelf
+      make[SetElement2].fromSelf
+      make[SetElement3].fromSelf
+      make[SetElement4].fromSelf
+      make[SetElement4Retainer].fromSelf
 
       many[SetElement]
         .weak[SetElement1]
@@ -140,11 +140,11 @@ abstract class DistageTestExampleBase[F[_]: TagK: DefaultModule](implicit F: Qua
         .weak[SetElement3]
         .weak[SetElement4]
 
-      make[UnmemoizedSetElement1]
-      make[UnmemoizedSetElement2]
-      make[UnmemoizedSetElement3]
-      make[UnmemoizedSetElement4]
-      make[UnmemoizedSetElement4Retainer]
+      make[UnmemoizedSetElement1].fromSelf
+      make[UnmemoizedSetElement2].fromSelf
+      make[UnmemoizedSetElement3].fromSelf
+      make[UnmemoizedSetElement4].fromSelf
+      make[UnmemoizedSetElement4Retainer].fromSelf
 
       many[UnmemoizedSetElement]
         .weak[UnmemoizedSetElement1]
@@ -152,8 +152,8 @@ abstract class DistageTestExampleBase[F[_]: TagK: DefaultModule](implicit F: Qua
         .weak[UnmemoizedSetElement3]
         .weak[UnmemoizedSetElement4]
 
-      make[DirectlyMemoizedSetElement1]
-      make[DirectlyMemoizedSetElement2]
+      make[DirectlyMemoizedSetElement1].fromSelf
+      make[DirectlyMemoizedSetElement2].fromSelf
 
       many[DirectlyMemoizedSetElement]
         .weak[DirectlyMemoizedSetElement1]
@@ -350,7 +350,7 @@ abstract class ForcedRootTest[F[_]: TagK: DefaultModule] extends Spec1[F] {
   override protected def config: TestConfig = super.config.copy(
     moduleOverrides = new ModuleDef {
       make[ForcedRootResource[F]].fromResource[ForcedRootResource[F]]
-      make[ForcedRootProbe]
+      make[ForcedRootProbe].fromSelf
     },
     forcedRoots = Set(DIKey.get[ForcedRootResource[F]]),
   )

--- a/distage/distage-testkit-scalatest/src/test/scala/izumi/distage/testkit/distagesuite/tagged/DistageTestTaggedAxesExampleBase.scala
+++ b/distage/distage-testkit-scalatest/src/test/scala/izumi/distage/testkit/distagesuite/tagged/DistageTestTaggedAxesExampleBase.scala
@@ -16,9 +16,9 @@ abstract class DistageTestTaggedAxesExampleBase extends SpecZIO with AssertZIO {
       Set(Repo.Dummy) -> Set(DIKey[DummyDep]),
     ),
     pluginConfig = PluginConfig.const(new izumi.distage.plugins.PluginDef {
-      make[PrdDep]
-      make[DummyDep]
-      make[DepsCounters]
+      make[PrdDep].fromSelf
+      make[DummyDep].fromSelf
+      make[DepsCounters].fromSelf
     }),
   )
 }

--- a/doc/microsite/src/main/scala/com/example/example.scala
+++ b/doc/microsite/src/main/scala/com/example/example.scala
@@ -15,6 +15,6 @@ final class OtherService
 final class AppPlugin extends PluginDef with ConfigModuleDef {
   tag(Mode.Prod)
 
-  make[Service]
+  make[Service].fromSelf
   makeConfig[Config]("config")
 }

--- a/doc/microsite/src/main/scala/com/example/petstore/PetStorePlugin.scala
+++ b/doc/microsite/src/main/scala/com/example/petstore/PetStorePlugin.scala
@@ -3,9 +3,9 @@ package com.example.petstore
 import izumi.distage.plugins.PluginDef
 
 object PetStorePlugin extends PluginDef {
-  make[PetRepository]
-  make[PetStoreService]
-  make[PetStoreController]
+  make[PetRepository].fromSelf
+  make[PetStoreService].fromSelf
+  make[PetStoreController].fromSelf
 }
 
 class PetRepository

--- a/doc/microsite/src/main/tut/distage/advanced-features.md
+++ b/doc/microsite/src/main/tut/distage/advanced-features.md
@@ -30,9 +30,9 @@ class C() {
 }
 
 def module = new ModuleDef {
-  make[A]
-  make[B]
-  make[C]
+  make[A].fromSelf
+  make[B].fromSelf
+  make[C].fromSelf
 }
 
 // create an object graph from description in `module`
@@ -67,9 +67,9 @@ class C() {
 }
 
 def module = new ModuleDef {
-  make[A]
-  make[B]
-  make[C]
+  make[A].fromSelf
+  make[B].fromSelf
+  make[C].fromSelf
 }
 ```
 
@@ -95,9 +95,9 @@ class B(val a: A)
 class C(val c: C)
 
 def module = new ModuleDef {
-  make[A]
-  make[B]
-  make[C]
+  make[A].fromSelf
+  make[B].fromSelf
+  make[C].fromSelf
 }
 
 val objects = Injector().produce(module, Roots(DIKey[A], DIKey[C])).unsafeGet()
@@ -141,9 +141,9 @@ class C(self: => C) {
 }
 
 def module = new ModuleDef {
-  make[A]
-  make[B]
-  make[C]
+  make[A].fromSelf
+  make[B].fromSelf
+  make[C].fromSelf
 }
 
 // disable proxies and execute the module
@@ -186,8 +186,8 @@ final case class Weak() extends Elem {
 }
 
 def module = new ModuleDef {
-  make[Strong]
-  make[Weak]
+  make[Strong].fromSelf
+  make[Weak].fromSelf
 
   many[Elem]
     .ref[Strong]
@@ -230,8 +230,8 @@ final class Weak extends Elem {
 }
 
 def module = new ModuleDef {
-  make[Strong]
-  make[Weak]
+  make[Strong].fromSelf
+  make[Weak].fromSelf
 
   many[Elem]
     .ref[Strong]
@@ -281,8 +281,8 @@ def bootstrapModule: BootstrapModule = new AutoSetModule {
 
 def appModule = new ModuleDef {
   make[A].from[AImpl]
-  make[B]
-  make[C]
+  make[B].fromSelf
+  make[C].fromSelf
 }
 
 val services: Set[PrintService] = Injector[Identity](bootstrapOverrides = Seq(bootstrapModule))
@@ -342,9 +342,9 @@ class B
 class C
 
 def module = new ModuleDef {
-  make[A]
-  make[B]
-  make[C]
+  make[A].fromSelf
+  make[B].fromSelf
+  make[C].fromSelf
 }
 
 val objects = Injector().produce(module, Roots(DIKey[A], DIKey[B], DIKey[C])).unsafeGet()
@@ -391,7 +391,7 @@ class Printer(a: A, b: B, c: C) {
     println(s"I've got A=$a, B=$b, C=$c, all here!")
 }
 
-childInjector.produceRun(new ModuleDef { make[Printer] }) {
+childInjector.produceRun(new ModuleDef { make[Printer].fromSelf }) {
   (_: Printer).printEm()
 }
 ```
@@ -409,7 +409,7 @@ import distage.{Roots, ModuleDef, PlannerInput, Injector, Activation}
 class InjectionInfo(val plannerInput: PlannerInput)
 
 def module = new ModuleDef {
-  make[InjectionInfo]
+  make[InjectionInfo].fromSelf
 }
 
 val input = PlannerInput(module, Roots.target[InjectionInfo], Activation.empty)
@@ -437,7 +437,7 @@ class Path {
 val path = new Path
 
 def module = new ModuleDef {
-  make[path.A]
+  make[path.A].fromSelf
 }
 
 Injector()
@@ -452,7 +452,7 @@ not the full type information available to the compiler, therefore the following
 
 ```scala mdoc:to-string
 def pathModule(p: Path) = new ModuleDef {
-  make[p.A]
+  make[p.A].fromSelf
 }
 
 val path1 = new Path
@@ -493,7 +493,7 @@ object Path {
 }
 
 def pathModule[A: Tag: ClassConstructor](p: Path.Aux[A]) = new ModuleDef {
-  make[A]
+  make[A].fromSelf
 }
 
 val path1 = new Path
@@ -529,8 +529,8 @@ class B
 class C
 
 def module = new ModuleDef {
-  make[A]
-  make[B].confined
+  make[A].fromSelf
+  make[B].confined.fromSelf
 }
 val input = PlannerInput.everything(module).withLocatorPrivacy(LocatorPrivacy.PublicByDefault)
 val mainLocator = Injector().produce(Injector().planUnsafe(input)).unsafeGet()
@@ -538,7 +538,7 @@ val mainLocator = Injector().produce(Injector().planUnsafe(input)).unsafeGet()
 val inheritedInjector = Injector.inherit(mainLocator)
 
 def module2 = new ModuleDef {
-  make[C]
+  make[C].fromSelf
 }
 val input2 = PlannerInput.everything(module2)
 val inheritedLocator = inheritedInjector.produce(inheritedInjector.planUnsafe(input2)).unsafeGet()
@@ -562,8 +562,8 @@ class B
 class C
 
 def module = new ModuleDef {
-  make[A]
-  make[B].exposed
+  make[A].fromSelf
+  make[B].exposed.fromSelf
 }
 val input = PlannerInput.everything(module).withLocatorPrivacy(LocatorPrivacy.PrivateByDefault)
 
@@ -572,7 +572,7 @@ val mainLocator = Injector().produce(Injector().planUnsafe(input)).unsafeGet()
 val inheritedInjector = Injector.inherit(mainLocator)
 
 def module2 = new ModuleDef {
-  make[C]
+  make[C].fromSelf
 }
 val input2 = PlannerInput.everything(module2)
 val inheritedLocator = inheritedInjector.produce(inheritedInjector.planUnsafe(input2)).unsafeGet()
@@ -598,8 +598,8 @@ class B
 class C
 
 def module = new ModuleDef {
-  make[A]
-  make[B]
+  make[A].fromSelf
+  make[B].fromSelf
 }
 val input = PlannerInput.target[A](module).withLocatorPrivacy(LocatorPrivacy.PublicRoots)
 
@@ -608,7 +608,7 @@ val mainLocator = Injector().produce(Injector().planUnsafe(input)).unsafeGet()
 val inheritedInjector = Injector.inherit(mainLocator)
 
 def module2 = new ModuleDef {
-  make[C]
+  make[C].fromSelf
 }
 val input2 = PlannerInput.everything(module2)
 val inheritedLocator = inheritedInjector.produce(inheritedInjector.planUnsafe(input2)).unsafeGet()

--- a/doc/microsite/src/main/tut/distage/basics.md
+++ b/doc/microsite/src/main/tut/distage/basics.md
@@ -146,7 +146,7 @@ import distage.ModuleDef
 def HelloByeModule = new ModuleDef {
   make[Greeter].from[PrintGreeter]
   make[Byer].from[PrintByer]
-  make[HelloByeApp] // `.from` is not required for concrete classes
+  make[HelloByeApp].fromSelf // `.from` is not required for concrete classes
 }
 ```
 
@@ -218,7 +218,7 @@ new ModuleDef {
 ```
 
 
-You can use `make[_].annotateParameter` method instead of an annotation, to attach a name component to an existing constructor:
+You can use `make[_].annotateParameter.fromSelf` method instead of an annotation, to attach a name component to an existing constructor:
 
 ```scala mdoc:silent
 def negateAnyByer(otherByer: Byer): Byer = {
@@ -498,7 +498,7 @@ class MyApp(
 def module = new ModuleDef {
   make[DBConnection].fromResource(dbResource)
   make[MessageQueueConnection].fromResource(mqResource)
-  make[MyApp]
+  make[MyApp].fromSelf
 }
 ```
 
@@ -991,7 +991,7 @@ def makeXManaged: ZManaged[Dependency, Throwable, X] = makeX.toManaged
 def makeXLayer: ZLayer[Dependency, Throwable, X] = ZLayer.fromZIO(makeX)
 
 def module1 = new ModuleDef {
-  make[Dependency]
+  make[Dependency].fromSelf
 
   make[X].fromZIOEnv(makeX)
   // or
@@ -1013,7 +1013,7 @@ def zioArgEnvCtor(
 }
 
 def module2 = new ModuleDef {
-  make[Dependency]
+  make[Dependency].fromSelf
 
   make[X].fromZLayerEnv(zioArgEnvCtor _)
 }
@@ -1370,10 +1370,10 @@ class PetStoreBusinessLogic[F[+_, +_]: Error2](
 }
 
 def module1[F[+_, +_]: TagKK] = new ModuleDef {
-  make[PetStoreAPIHandler[F]]
+  make[PetStoreAPIHandler[F]].fromSelf
 
-  make[PetStoreRepository[F]]
-  make[PetStoreBusinessLogic[F]]
+  make[PetStoreRepository[F]].fromSelf
+  make[PetStoreBusinessLogic[F]].fromSelf
 }
 
 class PetStoreAPIHandler[F[+_, +_]: IO2](
@@ -1412,12 +1412,12 @@ class HACK_OVERRIDE_PetStoreBusinessLogic[F[+_, +_]: Error2](
 }
 
 def module2[F[+_, +_]: TagKK] = new ModuleDef {
-  make[HACK_OVERRIDE_PetStoreAPIHandler[F]]
+  make[HACK_OVERRIDE_PetStoreAPIHandler[F]].fromSelf
 
   makeSubcontext[F[Throwable, _], PetStoreBusinessLogic[F]]
     .withSubmodule(new ModuleDef {
-      make[PetStoreRepository[F]]
-      make[HACK_OVERRIDE_PetStoreBusinessLogic[F]]
+      make[PetStoreRepository[F]].fromSelf
+      make[HACK_OVERRIDE_PetStoreBusinessLogic[F]].fromSelf
     })
     .localDependency[RequestId]
 }
@@ -1566,7 +1566,7 @@ object Pets {
 }
 
 def module[F[+_, +_]: TagKK] = new ModuleDef {
-  make[PetStoreAPIHandler[F]]
+  make[PetStoreAPIHandler[F]].fromSelf
 
   make[IzLogger].from(HACK_OVERRIDE_IzLogger())
   include(LogIO2Module[F]())
@@ -1574,7 +1574,7 @@ def module[F[+_, +_]: TagKK] = new ModuleDef {
   makeSubcontext[F[Throwable, _], PetStoreBusinessLogic[F]]
     .withSubmodule(new ModuleDef {
       make[PetStoreRepository[F]].fromResource[PetStoreRepository.Impl[F]]
-      make[PetStoreBusinessLogic[F]]
+      make[PetStoreBusinessLogic[F]].fromSelf
     })
     .localDependency[RequestId]
 }
@@ -1651,7 +1651,7 @@ class TaglessProgram[F[_]: Monad: Validation: Interaction] {
 }
 
 def ProgramModule[F[_]: TagK]: Module = new ModuleDef {
-  make[TaglessProgram[F]]
+  make[TaglessProgram[F]].fromSelf
 }
 ```
 

--- a/doc/microsite/src/main/tut/distage/debugging.md
+++ b/doc/microsite/src/main/tut/distage/debugging.md
@@ -13,7 +13,7 @@ class A(b: B)
 class B
 
 def badModule = new ModuleDef {
-  make[A]
+  make[A].fromSelf
   make[B].fromEffect(zio.ZIO.attempt { ??? })
 }
 ```
@@ -26,7 +26,7 @@ Injector[cats.effect.IO]().assert(badModule, Roots.target[A])
 
 ```scala mdoc:to-string
 def goodModule = new ModuleDef {
-  make[A]
+  make[A].fromSelf
   make[B].fromEffect(cats.effect.IO(new B))
 }
 ```

--- a/doc/microsite/src/main/tut/distage/distage-framework-docker.md
+++ b/doc/microsite/src/main/tut/distage/distage-framework-docker.md
@@ -333,7 +333,7 @@ class PostgresExampleAppIntegrationTest extends Spec1[IO] with AssertCIO {
       include(TransactorFromConfigModule)
       include(PostgresUsingDockerModule)
       include(DistageFrameworkModules)
-      make[PostgresExampleApp]
+      make[PostgresExampleApp].fromSelf
     },
     memoizationRoots = Set(
       DIKey[PostgresServerConfig]
@@ -364,7 +364,7 @@ def postgresDockerIntegrationExample = {
     include(PostgresUsingDockerModule)
     include(DistageFrameworkModules)
 
-    make[PostgresExampleApp]
+    make[PostgresExampleApp].fromSelf
   }
 
   Injector[IO]().produceRun(applicationModules) {

--- a/doc/microsite/src/main/tut/distage/distage-framework.md
+++ b/doc/microsite/src/main/tut/distage/distage-framework.md
@@ -324,7 +324,7 @@ final class ConfigPrinter(
 }
 
 val module = new ConfigModuleDef {
-  make[ConfigPrinter]
+  make[ConfigPrinter].fromSelf
 
   // declare paths to parse
   makeConfig[Conf]("conf")
@@ -423,9 +423,9 @@ import distage.plugins.{PluginConfig, PluginLoader}
 import izumi.distage.plugins.PluginDef
 
 object PetStorePlugin extends PluginDef {
-  make[PetRepository]
-  make[PetStoreService]
-  make[PetStoreController]
+  make[PetRepository].fromSelf
+  make[PetStoreService].fromSelf
+  make[PetStoreController].fromSelf
 }
 ```
 

--- a/doc/microsite/src/main/tut/distage/reference.md
+++ b/doc/microsite/src/main/tut/distage/reference.md
@@ -4,7 +4,7 @@
 
 ```
 Singleton bindings:
-  - `make[X]` = create X using its constructor
+  - `make[X].fromSelf` = create X using its constructor
   - `makeTrait[X]` = create an abstract class or a trait `X` using [[izumi.distage.constructors.TraitConstructor]] ([[https://izumi.7mind.io/distage/basics.html#auto-traits Auto-Traits feature]])
   - `makeFactory[X]` = create a "factory-like" abstract class or a trait `X` using [[izumi.distage.constructors.FactoryConstructor]] ([[https://izumi.7mind.io/distage/basics.html#auto-factories Auto-Factories feature]])
   - `make[X].from[XImpl]` = bind X to its subtype XImpl using XImpl's constructor
@@ -14,7 +14,7 @@ Singleton bindings:
   - `make[X].from { y: Y => new X(y) }` = bind X to an instance of X constructed by a given [[izumi.distage.model.providers.Functoid Functoid]] requesting an Y parameter
   - `make[X].from { y: Y @Id("special") => new X(y) }` = bind X to an instance of X constructed by a given [[izumi.distage.model.providers.Functoid Functoid]], requesting a named "special" Y parameter
   - `make[X].from { y: Y => new X(y) }`.annotateParameter[Y]("special") = bind X to an instance of X constructed by a given [[izumi.distage.model.providers.Functoid Functoid]], requesting a named "special" Y parameter
-  - `make[X].named("special")` = bind a named instance of X. It can then be summoned using [[Id]] annotation.
+  - `make[X].named("special").fromSelf` = bind a named instance of X. It can then be summoned using [[Id]] annotation.
   - `make[X].using[X]("special")` = bind X to refer to another already bound named instance at key `[X].named("special")`
   - `make[X].fromEffect(X.create[F]: F[X])` = create X using a purely-functional effect `X.create` in `F` monad
   - `make[X].fromResource(X.resource[F]: Lifecycle[F, X])` = create X using a `Lifecycle` value specifying its creation and destruction lifecycle
@@ -35,7 +35,7 @@ Mutators:
   - `modify[X].by(_.flatAp { (c: C, d: D) => (x: X) => c.method(x, d) })` = add a modifier, applying the provided lambda to a `Functoid` retrieving `X` - in this case by summoning additional `C` & `D` dependencies and applying `C.method` to `X`
 
 Tags:
-  - `make[X].tagged("t1", "t2)` = attach tags to X's binding.
+  - `make[X].fromSelf.tagged("t1", "t2)` = attach tags to X's binding.
   - `many[X].add[X1].tagged("x1tag")` = Tag a specific element of X. The tags of sets and their elements are separate.
   - `many[X].tagged("xsettag")` = Tag the binding of empty Set of X with a tag. The tags of sets and their elements are separate.
 

--- a/fundamentals/fundamentals-functoid/src/main/scala/izumi/distage/model/reflection/Provider.scala
+++ b/fundamentals/fundamentals-functoid/src/main/scala/izumi/distage/model/reflection/Provider.scala
@@ -29,6 +29,7 @@ trait Provider {
       case ProviderType.Constructor => (ret, diKeys)
       case ProviderType.Function => (underlying, diKeys)
       case ProviderType.Singleton => (underlying, diKeys)
+      case ProviderType.ErrorMakeWithoutFrom => (underlying, diKeys)
     }
   }
 
@@ -43,6 +44,7 @@ trait Provider {
     case ProviderType.Singleton => s"κ:$underlying"
     case ProviderType.Constructor => s"π:$providerType"
     case ProviderType.Function => s"ƒ:$underlying"
+    case ProviderType.ErrorMakeWithoutFrom => s"err:$underlying"
   }
 
   protected def verifyArgs(refs: Seq[GenericTypedRef[?]]): Seq[Any] = {
@@ -86,7 +88,23 @@ object Provider {
 
     /** Function captured by the Functoid macro, or any provider transformed by the `unsafeMap` and `unsafeZip` helper methods */
     case object Function extends ProviderType
+
+    /**
+      * Marker for a provider produced by a bare `make[T]` (without a follow-up `.from`-like call).
+      *
+      * Such a binding is deprecated: the user should write `make[T].fromSelf` (or `make[T].from[T]`) instead.
+      * `PlanVerifier` reports any binding carrying this provider type as a verification failure.
+      */
+    case object ErrorMakeWithoutFrom extends ProviderType
   }
+
+  /**
+    * Marker payload stored as the `underlying` of a `ProviderType.ErrorMakeWithoutFrom` provider.
+    *
+    * Carries enough information to render a useful deprecation message when `PlanVerifier` (or a runtime
+    * provisioner step) encounters such a binding.
+    */
+  final case class ErrorMakeWithoutFromMarker(tpeStr: String, nonWhitelistedMethods: List[String], message: String)
 
   final case class ProviderImpl[+A](
     parameters: Seq[LinkedParameter],


### PR DESCRIPTION
Supporting `make[T]` syntax without a follow-up `from` is rife with issues (see https://github.com/scala/scala3/issues/21622) Ports of distage to [Python](https://github.com/7mind/izumi-chibi-py) and [TypeScript](https://github.com/7mind/izumi-chibi-ts) do not support solitary `make` and that seems to work out just fine.

Commit is generated and needs cleanup/review before merge.