### PR TITLE
distage-framework-docker: add template traits for bundled containers

### DIFF
--- a/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/ContainerDef.scala
+++ b/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/ContainerDef.scala
@@ -5,9 +5,48 @@ import izumi.distage.docker.impl.ContainerResource
 import izumi.distage.model.definition.Lifecycle
 import izumi.distage.model.providers.Functoid
 
-trait ContainerDef {
-  // `ContainerDef`s must be top-level objects, otherwise `.Container` and `.Config` won't be referencable in ModuleDef
-  self: Singleton =>
+/**
+  * Base trait for Docker container definitions.
+  *
+  * Must be extended by an `object` so that [[Tag]] becomes a unique path-dependent type
+  * usable in `ModuleDef` bindings.
+  *
+  * For simple containers, extend `ContainerDef` directly:
+  *
+  * {{{
+  * object MyRedis extends ContainerDef {
+  *   val primaryPort: DockerPort = DockerPort.TCP(6379)
+  *
+  *   override def config: Config = Config(
+  *     image = "redis:7",
+  *     ports = Seq(primaryPort),
+  *   )
+  * }
+  *
+  * // in ModuleDef:
+  * make[MyRedis.Container].fromResource(MyRedis.make[F])
+  * }}}
+  *
+  * For common services, extend one of the bundled template classes
+  * (e.g. [[bundled.PostgresDockerTemplateDef]], [[bundled.CassandraDockerTemplateDef]])
+  * which provide sensible defaults and customization points:
+  *
+  * {{{
+  * object MyPostgres extends PostgresDockerTemplateDef {
+  *   override def version: String = "15"
+  *   override def postgresPassword: String = "secret"
+  * }
+  * }}}
+  *
+  * To kill all containers spawned by distage, use the following command:
+  *
+  * {{{
+  *   docker rm -f $(docker ps -q -a -f 'label=distage.type')
+  * }}}
+  *
+  * @see [[bundled]]
+  */
+trait ContainerDef { self: Singleton =>
 
   type Tag
 

--- a/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/ContainerDefTemplate.scala
+++ b/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/ContainerDefTemplate.scala
@@ -1,0 +1,8 @@
+package izumi.distage.docker
+
+trait ContainerDefTemplate extends ContainerDef {
+  self: Singleton =>
+
+  def image: String
+  def version: String
+}

--- a/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/bundled/CassandraDocker.scala
+++ b/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/bundled/CassandraDocker.scala
@@ -1,25 +1,42 @@
 package izumi.distage.docker.bundled
 
-import izumi.distage.docker.ContainerDef
+import izumi.distage.docker.ContainerDefTemplate
 import izumi.distage.docker.model.Docker.DockerPort
 import izumi.distage.model.definition.ModuleDef
 import izumi.reflect.TagK
 
 /**
-  * Example Cassandra docker.
-  * You're encouraged to use this definition as a template and modify it to your needs.
+  * Template for creating customized Cassandra docker containers.
+  *
+  * {{{
+  * object MyCassandra extends CassandraDockerTemplateDef {
+  *   override def version: String = "4.1"
+  * }
+  *
+  * // in ModuleDef:
+  * make[MyCassandra.Container].fromResource(MyCassandra.make[F])
+  * }}}
+  *
+  * @see [[CassandraDocker]] for a ready-to-use default instance
   */
-object CassandraDocker extends ContainerDef {
+trait CassandraDockerTemplateDef extends ContainerDefTemplate {
+  self: Singleton =>
+
+  override def image: String = "docker/library/cassandra"
+  override def version: String = "5.0"
+
   val primaryPort: DockerPort = DockerPort.TCP(9042)
 
   override def config: Config = {
     Config(
       registry = Some("public.ecr.aws"),
-      image = "docker/library/cassandra:4.0",
+      image = s"$image:$version",
       ports = Seq(primaryPort),
     )
   }
 }
+
+object CassandraDocker extends CassandraDockerTemplateDef
 
 class CassandraDockerModule[F[_]: TagK] extends ModuleDef {
   make[CassandraDocker.Container].fromResource {

--- a/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/bundled/DynamoDocker.scala
+++ b/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/bundled/DynamoDocker.scala
@@ -1,24 +1,40 @@
 package izumi.distage.docker.bundled
 
 import distage.{ModuleDef, TagK}
-import izumi.distage.docker.ContainerDef
+import izumi.distage.docker.ContainerDefTemplate
 import izumi.distage.docker.model.Docker.DockerPort
 
 /**
-  * Example AWS DynamoDB Local docker.
-  * You're encouraged to use this definition as a template and modify it to your needs.
+  * Template for creating customized AWS DynamoDB Local docker containers.
+  *
+  * {{{
+  * object MyDynamo extends DynamoDockerTemplateDef {
+  *   override def version: String = "2.4.0"
+  * }
+  *
+  * // in ModuleDef:
+  * make[MyDynamo.Container].fromResource(MyDynamo.make[F])
+  * }}}
+  *
+  * @see [[DynamoDocker]] for a ready-to-use default instance
   */
-object DynamoDocker extends ContainerDef {
+trait DynamoDockerTemplateDef extends ContainerDefTemplate {
+  self: Singleton =>
+
+  override def image: String = "amazon/dynamodb-local"
+  override def version: String = "3.3.0"
+
   val primaryPort: DockerPort = DockerPort.TCP(8000)
 
   override def config: Config = {
     Config(
-      registry = Some("public.ecr.aws"),
-      image = "aws-dynamodb-local/aws-dynamodb-local:2.3.0",
+      image = s"$image:$version",
       ports = Seq(primaryPort),
     )
   }
 }
+
+object DynamoDocker extends DynamoDockerTemplateDef
 
 class DynamoDockerModule[F[_]: TagK] extends ModuleDef {
   make[DynamoDocker.Container].fromResource {

--- a/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/bundled/ElasticMQDocker.scala
+++ b/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/bundled/ElasticMQDocker.scala
@@ -1,26 +1,43 @@
 package izumi.distage.docker.bundled
 
-import izumi.distage.docker.ContainerDef
+import izumi.distage.docker.ContainerDefTemplate
 import izumi.distage.docker.model.Docker.DockerPort
 import izumi.distage.docker.healthcheck.ContainerHealthCheck
 import izumi.distage.model.definition.ModuleDef
 import izumi.reflect.TagK
 
 /**
-  * Example Elastic MQ docker.
-  * You're encouraged to use this definition as a template and modify it to your needs.
+  * Template for creating customized ElasticMQ docker containers.
+  *
+  * {{{
+  * object MyElasticMQ extends ElasticMQDockerTemplateDef {
+  *   override def version: String = "1.4.0"
+  * }
+  *
+  * // in ModuleDef:
+  * make[MyElasticMQ.Container].fromResource(MyElasticMQ.make[F])
+  * }}}
+  *
+  * @see [[ElasticMQDocker]] for a ready-to-use default instance
   */
-object ElasticMQDocker extends ContainerDef {
+trait ElasticMQDockerTemplateDef extends ContainerDefTemplate {
+  self: Singleton =>
+
+  override def image: String = "softwaremill/elasticmq-native"
+  override def version: String = "1.6.14"
+
   val primaryPort: DockerPort = DockerPort.TCP(9324)
 
   override def config: Config = {
     Config(
-      image = "softwaremill/elasticmq:1.3.14",
+      image = s"$image:$version",
       ports = Seq(primaryPort),
       healthCheck = ContainerHealthCheck.httpGetCheck(primaryPort),
     )
   }
 }
+
+object ElasticMQDocker extends ElasticMQDockerTemplateDef
 
 class ElasticMQDockerModule[F[_]: TagK] extends ModuleDef {
   make[ElasticMQDocker.Container].fromResource {

--- a/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/bundled/KafkaDocker.scala
+++ b/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/bundled/KafkaDocker.scala
@@ -1,33 +1,59 @@
 package izumi.distage.docker.bundled
 
 import distage.{ModuleDef, TagK}
-import izumi.distage.docker.ContainerDef
+import izumi.distage.docker.{ContainerDef, ContainerDefTemplate}
 import izumi.distage.docker.model.Docker.{ContainerEnvironment, DockerPort}
 
 /**
-  * Example Kafka Docker.
-  * Depends on [[KafkaZookeeperNetwork.Network]] provided by [[ZookeeperDocker]]
-  * You're encouraged to use this definition as a template and modify it to your needs.
+  * Template for creating customized Kafka (Zookeeper-based) docker containers.
+  * Depends on [[KafkaZookeeperNetwork.Network]] provided by [[ZookeeperDocker]].
+  *
+  * {{{
+  * object MyKafka extends KafkaDockerTemplateDef {
+  *   override def version: String = "3.9.0"
+  * }
+  *
+  * // in ModuleDef:
+  * make[MyKafka.Container].fromResource {
+  *   MyKafka.make[F]
+  *     .connectToNetwork(KafkaZookeeperNetwork)
+  *     .dependOnContainerPorts(ZookeeperDocker)(2181 -> "KAFKA_ZOOKEEPER_CONNECT")
+  * }
+  * }}}
+  *
+  * @see [[KafkaDocker]] for a ready-to-use default instance
   */
-object KafkaDocker extends ContainerDef {
+trait KafkaDockerTemplateDef extends ContainerDefTemplate {
+  self: Singleton =>
+
+  override def image: String = "apache/kafka"
+  override def version: String = "3.9.0"
+
   val primaryPort: DockerPort = DockerPort.DynamicTCP("dynamic_kafka_port")
 
   override def config: Config = {
     Config(
-      image = "wurstmeister/kafka:2.12-2.4.1",
+      image = s"$image:$version",
       ports = Seq(primaryPort),
       env = ContainerEnvironment.from {
         ports =>
           val port = ports.getOrElse(primaryPort, "0000")
           Map(
-            "KAFKA_ADVERTISED_HOST_NAME" -> "127.0.0.1",
-            "KAFKA_ADVERTISED_PORT" -> port,
-            "KAFKA_PORT" -> port,
+            // apache/kafka image: env vars map to server.properties keys (KAFKA_<KEY> → <key.lower>)
+            "KAFKA_NODE_ID" -> "1",
+            "KAFKA_BROKER_ID" -> "1",
+            "KAFKA_LISTENERS" -> s"PLAINTEXT://:$port",
+            "KAFKA_ADVERTISED_LISTENERS" -> s"PLAINTEXT://127.0.0.1:$port",
+            "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP" -> "PLAINTEXT:PLAINTEXT",
+            "KAFKA_INTER_BROKER_LISTENER_NAME" -> "PLAINTEXT",
+            "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR" -> "1",
           )
       },
     )
   }
 }
+
+object KafkaDocker extends KafkaDockerTemplateDef
 
 object KafkaTwofaceDocker extends ContainerDef {
   val insidePort: DockerPort = DockerPort.DynamicTCP("dynamic_kafka_port_inside")
@@ -53,38 +79,56 @@ object KafkaTwofaceDocker extends ContainerDef {
   }
 }
 
-object KafkaKRaftDocker extends ContainerDef {
+/**
+  * Template for creating customized Kafka KRaft (no Zookeeper) docker containers.
+  *
+  * {{{
+  * object MyKafkaKRaft extends KafkaKRaftDockerTemplateDef {
+  *   override def version: String = "4.1.0"
+  * }
+  *
+  * // in ModuleDef:
+  * make[MyKafkaKRaft.Container].fromResource(MyKafkaKRaft.make[F])
+  * }}}
+  *
+  * @see [[KafkaKRaftDocker]] for a ready-to-use default instance
+  */
+trait KafkaKRaftDockerTemplateDef extends ContainerDefTemplate {
+  self: Singleton =>
+
+  override def image: String = "apache/kafka"
+  override def version: String = "4.2.0"
+
   val primaryPort: DockerPort = DockerPort.DynamicTCP("dynamic_kafka_port")
 
   override def config: Config = {
     Config(
-      // arm64 image is missing on public aws ecr
-      // registry = Some("public.ecr.aws"),
-      image = "soldevelo/kafka:3.7.1",
+      image = s"$image:$version",
       ports = Seq(primaryPort),
       env = ContainerEnvironment.from {
         ports =>
           val port = ports.getOrElse(primaryPort, "0000")
           Map(
-            "KAFKA_CFG_PORT" -> port,
-            "KAFKA_CFG_ADVERTISED_PORT" -> port,
-            "KAFKA_CFG_LISTENERS" -> s"PLAINTEXT://:$port,CONTROLLER://:9093",
-            "KAFKA_CFG_ADVERTISED_LISTENERS" -> s"PLAINTEXT://127.0.0.1:$port",
-            "ALLOW_PLAINTEXT_LISTENER" -> "yes",
-            "KAFKA_ENABLE_KRAFT" -> "yes",
-            "KAFKA_BROKER_ID" -> "1",
-            "KAFKA_CFG_NODE_ID" -> "1",
-            "KAFKA_CFG_ADVERTISED_HOST_NAME" -> "127.0.0.1",
-            "KAFKA_CFG_PROCESS_ROLES" -> "broker,controller",
-            "KAFKA_CFG_CONTROLLER_LISTENER_NAMES" -> "CONTROLLER",
-            "KAFKA_CFG_CONTROLLER_QUORUM_VOTERS" -> "1@127.0.0.1:9093",
-            "KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP" -> "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT",
-            "KAFKA_CFG_DELETE_TOPIC_ENABLE" -> "true",
+            // apache/kafka image: env vars map to server.properties keys (KAFKA_<KEY> → <key.lower>)
+            "CLUSTER_ID" -> "5L6g3nShT-eMCtK--X86sw",
+            "KAFKA_NODE_ID" -> "1",
+            "KAFKA_PROCESS_ROLES" -> "broker,controller",
+            "KAFKA_LISTENERS" -> s"PLAINTEXT://:$port,CONTROLLER://:9093",
+            "KAFKA_ADVERTISED_LISTENERS" -> s"PLAINTEXT://127.0.0.1:$port",
+            "KAFKA_CONTROLLER_LISTENER_NAMES" -> "CONTROLLER",
+            "KAFKA_CONTROLLER_QUORUM_VOTERS" -> "1@localhost:9093",
+            "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP" -> "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT",
+            "KAFKA_INTER_BROKER_LISTENER_NAME" -> "PLAINTEXT",
+            "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR" -> "1",
+            "KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR" -> "1",
+            "KAFKA_TRANSACTION_STATE_LOG_MIN_ISR" -> "1",
           )
       },
     )
   }
 }
+
+object KafkaKRaftDocker extends KafkaKRaftDockerTemplateDef
 
 class KafkaDockerModule[F[_]: TagK] extends ModuleDef {
   make[KafkaDocker.Container].fromResource {

--- a/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/bundled/PostgresDocker.scala
+++ b/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/bundled/PostgresDocker.scala
@@ -1,28 +1,56 @@
 package izumi.distage.docker.bundled
 
-import izumi.distage.docker.ContainerDef
+import izumi.distage.docker.{ContainerDefTemplate}
 import izumi.distage.docker.model.Docker.DockerPort
 import izumi.distage.docker.healthcheck.ContainerHealthCheck
 import izumi.distage.model.definition.ModuleDef
 import izumi.reflect.TagK
 
 /**
-  * Example postgres docker. It's sufficient for most usages.
-  * You're encouraged to use this definition as a template and modify it to your needs.
+  * Template for creating customized PostgreSQL docker containers.
+  *
+  * {{{
+  * object MyPostgres extends PostgresDockerTemplateDef {
+  *   override def version: String = "15"
+  *   override def postgresUser: String = "myuser"
+  *   override def postgresPassword: String = "secret"
+  *   override def postgresDb: String = "mydb"
+  * }
+  *
+  * // in ModuleDef:
+  * make[MyPostgres.Container].fromResource(MyPostgres.make[F])
+  * }}}
+  *
+  * @see [[PostgresDocker]] for a ready-to-use default instance
   */
-object PostgresDocker extends ContainerDef {
+trait PostgresDockerTemplateDef extends ContainerDefTemplate {
+  self: Singleton =>
+
+  override def image: String = "docker/library/postgres"
+  override def version: String = "17"
+
+  def postgresUser: String = "postgres"
+  def postgresPassword: String = "postgres"
+  def postgresDb: String = "postgres"
+
   val primaryPort: DockerPort = DockerPort.TCP(5432)
 
   override def config: Config = {
     Config(
       registry = Some("public.ecr.aws"),
-      image = "docker/library/postgres:16",
+      image = s"$image:$version",
       ports = Seq(primaryPort),
-      env = Map("POSTGRES_PASSWORD" -> "postgres"),
-      healthCheck = ContainerHealthCheck.postgreSqlProtocolCheck(primaryPort, "postgres", "postgres"),
+      env = Map(
+        "POSTGRES_USER" -> postgresUser,
+        "POSTGRES_PASSWORD" -> postgresPassword,
+        "POSTGRES_DB" -> postgresDb,
+      ),
+      healthCheck = ContainerHealthCheck.postgreSqlProtocolCheck(primaryPort, postgresUser, postgresPassword),
     )
   }
 }
+
+object PostgresDocker extends PostgresDockerTemplateDef
 
 class PostgresDockerModule[F[_]: TagK] extends ModuleDef {
   make[PostgresDocker.Container].fromResource {

--- a/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/bundled/ZookkeeperDocker.scala
+++ b/distage/distage-framework-docker/src/main/scala/izumi/distage/docker/bundled/ZookkeeperDocker.scala
@@ -1,25 +1,41 @@
 package izumi.distage.docker.bundled
 
 import distage.{ModuleDef, TagK}
-import izumi.distage.docker.ContainerDef
+import izumi.distage.docker.ContainerDefTemplate
 import izumi.distage.docker.model.Docker.DockerPort
 
 /**
-  * Example zookeeper docker.
-  *  In addition to Zookeeper docker, sets up on [[KafkaZookeeperNetwork.Network]] for [[KafkaDocker]]
-  * You're encouraged to use this definition as a template and modify it to your needs.
+  * Template for creating customized Zookeeper docker containers.
+  *
+  * {{{
+  * object MyZookeeper extends ZookeeperDockerTemplateDef {
+  *   override def version: String = "3.9"
+  * }
+  *
+  * // in ModuleDef:
+  * make[MyZookeeper.Container].fromResource(MyZookeeper.make[F])
+  * }}}
+  *
+  * @see [[ZookeeperDocker]] for a ready-to-use default instance
   */
-object ZookeeperDocker extends ContainerDef {
+trait ZookeeperDockerTemplateDef extends ContainerDefTemplate {
+  self: Singleton =>
+
+  override def image: String = "docker/library/zookeeper"
+  override def version: String = "3.9"
+
   val primaryPort: DockerPort = DockerPort.TCP(2181)
 
   override def config: Config = {
     Config(
       registry = Some("public.ecr.aws"),
-      image = "docker/library/zookeeper:3.5",
+      image = s"$image:$version",
       ports = Seq(primaryPort),
     )
   }
 }
+
+object ZookeeperDocker extends ZookeeperDockerTemplateDef
 
 class ZookeeperDockerModule[F[_]: TagK] extends ModuleDef {
   make[KafkaZookeeperNetwork.Network].fromResource {

--- a/distage/distage-framework-docker/src/test/scala/izumi/distage/testkit/docker/DockerContainerTemplateTest.scala
+++ b/distage/distage-framework-docker/src/test/scala/izumi/distage/testkit/docker/DockerContainerTemplateTest.scala
@@ -1,0 +1,121 @@
+package izumi.distage.testkit.docker
+
+import distage.SafeType
+import izumi.distage.docker.bundled.*
+import izumi.distage.docker.impl.ContainerResource
+import izumi.distage.docker.model.Docker.DockerPort
+import izumi.fundamentals.platform.functional.Identity
+import org.scalatest.wordspec.AnyWordSpec
+
+object CustomPostgres extends PostgresDockerTemplateDef {
+  override def version: String = "15"
+  override def postgresUser: String = "myuser"
+  override def postgresPassword: String = "mypass"
+  override def postgresDb: String = "mydb"
+}
+
+object CustomCassandra extends CassandraDockerTemplateDef {
+  override def version: String = "4.1"
+}
+
+object CustomDynamo extends DynamoDockerTemplateDef {
+  override def version: String = "2.4.0"
+}
+
+object CustomElasticMQ extends ElasticMQDockerTemplateDef {
+  override def version: String = "1.4.0"
+}
+
+object CustomZookeeper extends ZookeeperDockerTemplateDef {
+  override def version: String = "3.9"
+}
+
+object CustomKafka extends KafkaDockerTemplateDef {
+  override def version: String = "2.13-2.8.1"
+}
+
+object CustomKafkaKRaft extends KafkaKRaftDockerTemplateDef {
+  override def version: String = "3.8.0"
+}
+
+final class DockerContainerTemplateTest extends AnyWordSpec {
+
+  "Container templates" should {
+
+    "produce customized PostgreSQL config" in {
+      val cfg = CustomPostgres.config
+      assert(cfg.image == "docker/library/postgres:15")
+      assert(cfg.env.env(Map.empty)("POSTGRES_USER") == "myuser")
+      assert(cfg.env.env(Map.empty)("POSTGRES_PASSWORD") == "mypass")
+      assert(cfg.env.env(Map.empty)("POSTGRES_DB") == "mydb")
+      assert(cfg.ports == Seq(DockerPort.TCP(5432)))
+    }
+
+    "produce customized Cassandra config" in {
+      val cfg = CustomCassandra.config
+      assert(cfg.image == "docker/library/cassandra:4.1")
+      assert(cfg.ports == Seq(DockerPort.TCP(9042)))
+    }
+
+    "produce customized DynamoDB config" in {
+      val cfg = CustomDynamo.config
+      assert(cfg.image == "amazon/dynamodb-local:2.4.0")
+      assert(cfg.ports == Seq(DockerPort.TCP(8000)))
+    }
+
+    "produce customized ElasticMQ config" in {
+      val cfg = CustomElasticMQ.config
+      assert(cfg.image == "softwaremill/elasticmq-native:1.4.0")
+      assert(cfg.ports == Seq(DockerPort.TCP(9324)))
+    }
+
+    "produce customized Zookeeper config" in {
+      val cfg = CustomZookeeper.config
+      assert(cfg.image == "docker/library/zookeeper:3.9")
+      assert(cfg.ports == Seq(DockerPort.TCP(2181)))
+    }
+
+    "produce customized Kafka config" in {
+      val cfg = CustomKafka.config
+      assert(cfg.image == "apache/kafka:2.13-2.8.1")
+      assert(CustomKafka.image == "apache/kafka")
+    }
+
+    "produce customized KafkaKRaft config" in {
+      val cfg = CustomKafkaKRaft.config
+      assert(cfg.image == "apache/kafka:3.8.0")
+      assert(CustomKafkaKRaft.image == "apache/kafka")
+    }
+
+    "have unique Tag types per template instance" in {
+      val pgType = SafeType.get[CustomPostgres.Tag]
+      val defaultPgType = SafeType.get[PostgresDocker.Tag]
+      assert(pgType != defaultPgType, "Custom and default Postgres should have different Tag types")
+
+      val csType = SafeType.get[CustomCassandra.Tag]
+      val defaultCsType = SafeType.get[CassandraDocker.Tag]
+      assert(csType != defaultCsType, "Custom and default Cassandra should have different Tag types")
+    }
+
+    "produce correct return type from make[F]" in {
+      assert(CustomPostgres.make[Identity].get.ret == SafeType.get[ContainerResource[Identity, CustomPostgres.Tag]])
+      assert(CustomCassandra.make[Identity].get.ret == SafeType.get[ContainerResource[Identity, CustomCassandra.Tag]])
+      assert(CustomDynamo.make[Identity].get.ret == SafeType.get[ContainerResource[Identity, CustomDynamo.Tag]])
+      assert(CustomElasticMQ.make[Identity].get.ret == SafeType.get[ContainerResource[Identity, CustomElasticMQ.Tag]])
+      assert(CustomZookeeper.make[Identity].get.ret == SafeType.get[ContainerResource[Identity, CustomZookeeper.Tag]])
+      assert(CustomKafka.make[Identity].get.ret == SafeType.get[ContainerResource[Identity, CustomKafka.Tag]])
+      assert(CustomKafkaKRaft.make[Identity].get.ret == SafeType.get[ContainerResource[Identity, CustomKafkaKRaft.Tag]])
+    }
+
+    "preserve default configs when not overriding" in {
+      assert(PostgresDocker.config.image == "docker/library/postgres:17")
+      assert(PostgresDocker.postgresDb == "postgres")
+      assert(CassandraDocker.config.image == "docker/library/cassandra:5.0")
+      assert(DynamoDocker.config.image == "amazon/dynamodb-local:3.3.0")
+      assert(ElasticMQDocker.config.image == "softwaremill/elasticmq-native:1.6.14")
+      assert(ZookeeperDocker.config.image == "docker/library/zookeeper:3.9")
+      assert(KafkaDocker.config.image == "apache/kafka:3.9.0")
+      assert(KafkaKRaftDocker.config.image == "apache/kafka:4.2.0")
+    }
+  }
+}

--- a/distage/distage-framework-docker/src/test/scala/izumi/distage/testkit/docker/DockerTemplateIntegrationTest.scala
+++ b/distage/distage-framework-docker/src/test/scala/izumi/distage/testkit/docker/DockerTemplateIntegrationTest.scala
@@ -1,0 +1,187 @@
+package izumi.distage.testkit.docker
+
+import com.github.dockerjava.api.async.ResultCallback
+import com.github.dockerjava.api.model.Frame
+import distage.ModuleDef
+import izumi.distage.docker.ContainerNetworkDef
+import izumi.distage.docker.DockerContainer
+import izumi.distage.docker.bundled.*
+import izumi.distage.docker.impl.{ContainerResource, DockerClientWrapper}
+import izumi.distage.docker.model.Docker.DockerReusePolicy
+import izumi.distage.docker.modules.DockerSupportModule
+import izumi.distage.testkit.model.TestConfig
+import izumi.distage.testkit.scalatest.Spec2
+import izumi.functional.bio.WeakTemporal2
+import zio.{IO, Task, ZIO}
+
+import java.io.Closeable
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import scala.concurrent.duration.*
+
+object DockerTemplateIntegrationTest {
+
+  def fetchLogs(client: DockerClientWrapper[Task], container: DockerContainer[?]): Task[String] = ZIO.attempt {
+    val sb = new StringBuilder
+    val latch = new CountDownLatch(1)
+    val callback = new ResultCallback[Frame] {
+      override def onStart(closeable: Closeable): Unit = ()
+      override def onNext(frame: Frame): Unit = sb.append(new String(frame.getPayload))
+      override def onError(t: Throwable): Unit = { sb.append(s"[log error: ${t.getMessage}]"); latch.countDown() }
+      override def onComplete(): Unit = latch.countDown()
+      override def close(): Unit = ()
+    }
+    client.rawClient
+      .logContainerCmd(container.id.name)
+      .withStdOut(true)
+      .withStdErr(true)
+      .withTail(200)
+      .exec(callback)
+    latch.await(10, TimeUnit.SECONDS)
+    sb.toString
+  }
+
+
+  object TestPostgres extends PostgresDockerTemplateDef {
+    override def version: String = "16"
+    override def postgresUser: String = "testuser"
+    override def postgresPassword: String = "testpass"
+    override def postgresDb: String = "testdb"
+
+    override def config: Config = super.config.copy(reuse = DockerReusePolicy.ReuseDisabled)
+  }
+
+  object TestDynamo extends DynamoDockerTemplateDef {
+    override def config: Config = super.config.copy(reuse = DockerReusePolicy.ReuseDisabled)
+  }
+
+  object TestElasticMQ extends ElasticMQDockerTemplateDef {
+    override def config: Config = super.config.copy(reuse = DockerReusePolicy.ReuseDisabled)
+  }
+
+  object TestKafkaKRaft extends KafkaKRaftDockerTemplateDef {
+    override def config: Config = super.config.copy(reuse = DockerReusePolicy.ReuseDisabled)
+  }
+
+  object TestZookeeper extends ZookeeperDockerTemplateDef {
+    override def config: Config = super.config.copy(reuse = DockerReusePolicy.ReuseDisabled)
+  }
+
+  object TestKafka extends KafkaDockerTemplateDef {
+    override def config: Config = super.config.copy(reuse = DockerReusePolicy.ReuseDisabled)
+  }
+
+  val testModule: ModuleDef = new ModuleDef {
+    include(DockerSupportModule[Task])
+
+    make[ContainerResource[Task, TestPostgres.Tag]].from(TestPostgres.make[Task])
+    make[ContainerResource[Task, TestDynamo.Tag]].from(TestDynamo.make[Task])
+    make[ContainerResource[Task, TestElasticMQ.Tag]].from(TestElasticMQ.make[Task])
+    make[ContainerResource[Task, TestKafkaKRaft.Tag]].from(TestKafkaKRaft.make[Task])
+
+    make[ContainerNetworkDef.ContainerNetwork[KafkaZookeeperNetwork.Tag]].fromResource {
+      KafkaZookeeperNetwork.make[Task]
+    }
+    make[TestZookeeper.Container].fromResource {
+      TestZookeeper.make[Task].connectToNetwork(KafkaZookeeperNetwork)
+    }
+    make[TestKafka.Container].fromResource {
+      TestKafka.make[Task]
+        .connectToNetwork(KafkaZookeeperNetwork)
+        .dependOnContainerPorts(TestZookeeper)(2181 -> "KAFKA_ZOOKEEPER_CONNECT")
+    }
+  }
+}
+
+final class DockerTemplateIntegrationTest extends Spec2[IO] {
+  import DockerTemplateIntegrationTest.*
+
+  override protected def config: TestConfig = super.config.copy(
+    moduleOverrides = testModule
+  )
+
+  "Template-based containers" should {
+
+    "launch and destroy PostgreSQL from template" in {
+      (pgResource: ContainerResource[Task, TestPostgres.Tag], client: DockerClientWrapper[Task]) =>
+        pgResource.use {
+          container =>
+            // .use block only runs after the health check (postgreSqlProtocolCheck) succeeds;
+            // additionally assert that PG logged "database system is ready to accept connections"
+            val pollLogs: Task[Option[String]] = fetchLogs(client, container).flatMap {
+              logs =>
+                val lower = logs.toLowerCase
+                if (lower.contains("fatal") || lower.contains("panic") || lower.contains("exception in thread")) {
+                  ZIO.fail(new AssertionError(s"Postgres container logs contain fatal error:\n$logs"))
+                } else if (logs.contains("database system is ready to accept connections")) {
+                  ZIO.succeed(Some(logs))
+                } else {
+                  ZIO.succeed(None)
+                }
+            }
+            for {
+              _ <- ZIO.attempt(assert(container.availablePorts.firstOption(TestPostgres.primaryPort).nonEmpty))
+              _ <- pollLogs.repeatUntil(
+                new AssertionError("Postgres never logged 'database system is ready to accept connections'"),
+                sleep = 3.seconds,
+                maxAttempts = 20,
+              )
+            } yield ()
+        }
+    }
+
+    "launch and destroy DynamoDB from template" in {
+      (dynamoResource: ContainerResource[Task, TestDynamo.Tag]) =>
+        dynamoResource.use {
+          container =>
+            ZIO.attempt {
+              assert(container.availablePorts.firstOption(TestDynamo.primaryPort).nonEmpty)
+            }
+        }
+    }
+
+    "launch and destroy ElasticMQ from template" in {
+      (mqResource: ContainerResource[Task, TestElasticMQ.Tag]) =>
+        mqResource.use {
+          container =>
+            ZIO.attempt {
+              assert(container.availablePorts.firstOption(TestElasticMQ.primaryPort).nonEmpty)
+            }
+        }
+    }
+
+    "launch and destroy Kafka (KRaft) from template" in {
+      (kafkaResource: ContainerResource[Task, TestKafkaKRaft.Tag], client: DockerClientWrapper[Task]) =>
+        kafkaResource.use {
+          container =>
+            val pollLogs: Task[Option[String]] = fetchLogs(client, container).flatMap {
+              logs =>
+                val lower = logs.toLowerCase
+                if (lower.contains("fatal") || lower.contains("exception in thread")) {
+                  // fail fast on divergence
+                  ZIO.fail(new AssertionError(s"Kafka container logs contain fatal error:\n$logs"))
+                } else if (logs.contains("Kafka Server started")) {
+                  ZIO.succeed(Some(logs))
+                } else {
+                  ZIO.succeed(None)
+                }
+            }
+            for {
+              _ <- ZIO.attempt(assert(container.availablePorts.firstOption(TestKafkaKRaft.primaryPort).nonEmpty))
+              logs <- pollLogs.repeatUntil(
+                new AssertionError("Kafka never logged 'Kafka Server started' within the attempt budget"),
+                sleep = 3.seconds,
+                maxAttempts = 20,
+              )
+              _ = println(s"===== Kafka KRaft container logs =====\n$logs\n===== end logs =====")
+            } yield ()
+        }
+    }
+
+    "launch and destroy Kafka (Zookeeper-based) from template" in {
+      (kafka: TestKafka.Container) =>
+        ZIO.attempt {
+          assert(kafka.availablePorts.firstOption(TestKafka.primaryPort).nonEmpty)
+        }
+    }
+  }
+}


### PR DESCRIPTION
Generated commit, needs self-review

<hr/>

Introduce *Template abstract classes for all bundled container defs (Postgres, Cassandra, DynamoDB, ElasticMQ, Zookeeper, Kafka, KafkaKRaft) so users can customize containers by extending a template and overriding defs, instead of copy-pasting the entire object definition.

Existing objects now extend their respective templates with defaults.