### PR TITLE
distage-testkit: Fix wrong test count and test timings in JUnit XML report

### DIFF
--- a/distage/distage-core-api/src/main/scala/izumi/distage/model/providers/Functoid.scala
+++ b/distage/distage-core-api/src/main/scala/izumi/distage/model/providers/Functoid.scala
@@ -58,7 +58,7 @@ import izumi.distage.reflection.macros.FunctoidMacroMethods
   *
   * @note `javax.inject.Named` annotation is also supported
   *
-  * @see [[izumi.distage.reflection.macros.FunctoidMacro]]]
+  * @see [[izumi.distage.reflection.macros.FunctoidMacro]]
   * @see Functoid is based on the Magnet Pattern: [[http://spray.io/blog/2012-12-13-the-magnet-pattern/]]
   * @see Essentially Functoid is a function-like entity with additional properties, so it's funny name is reasonable enough: [[https://en.wiktionary.org/wiki/-oid#English]]
   */

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/model/IndividualTestResult.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/model/IndividualTestResult.scala
@@ -4,11 +4,32 @@ import izumi.distage.model.provisioning.PlanInterpreter.FailedProvision
 import izumi.distage.testkit.runner.impl.services.Timing
 import izumi.functional.bio.Exit
 
+import java.time.OffsetDateTime
 import scala.concurrent.duration.FiniteDuration
 
 sealed trait IndividualTestResult {
   def totalTime: FiniteDuration
   def test: FullMeta
+
+  /** The earliest observed phase begin time across this result's phases.
+    *
+    * Used by reporters to populate the wall-clock timestamp on the
+    * test-start side of the corresponding event stream (e.g. `TestStarting`).
+    */
+  def beginInstant: OffsetDateTime
+
+  /** The latest observed phase end time across this result's phases.
+    *
+    * Used by reporters to populate the wall-clock timestamp on the
+    * test-completion side of the event stream (e.g. `TestSucceeded`, `TestFailed`).
+    */
+  def endInstant: OffsetDateTime
+
+  /** Name of the thread that started the first phase of this result. */
+  def beginThreadName: String
+
+  /** Name of the thread that started the last phase of this result. */
+  def endThreadName: String
 }
 
 object IndividualTestResult {
@@ -16,16 +37,28 @@ object IndividualTestResult {
 
   case class InstantiationFailure(test: FullMeta, planningTiming: Timing, failedInstantiationTiming: Timing, failure: FailedProvision) extends IndividualTestFailure {
     override def totalTime: FiniteDuration = planningTiming.duration + failedInstantiationTiming.duration
+    override def beginInstant: OffsetDateTime = planningTiming.begin
+    override def endInstant: OffsetDateTime = failedInstantiationTiming.end
+    override def beginThreadName: String = planningTiming.threadName
+    override def endThreadName: String = failedInstantiationTiming.threadName
   }
 
   case class ExecutionFailure(test: FullMeta, planningTiming: Timing, instantiationTiming: Timing, failedExecTiming: Timing, failure: Throwable, trace: Exit.Trace[Throwable])
     extends IndividualTestFailure {
     override def totalTime: FiniteDuration = planningTiming.duration + instantiationTiming.duration + failedExecTiming.duration
+    override def beginInstant: OffsetDateTime = planningTiming.begin
+    override def endInstant: OffsetDateTime = failedExecTiming.end
+    override def beginThreadName: String = planningTiming.threadName
+    override def endThreadName: String = failedExecTiming.threadName
   }
 
   sealed trait IndividualTestSuccess extends IndividualTestResult
 
   case class TestSuccess(test: FullMeta, planningTiming: Timing, instantiationTiming: Timing, executionTiming: Timing) extends IndividualTestSuccess {
     override def totalTime: FiniteDuration = planningTiming.duration + instantiationTiming.duration + executionTiming.duration
+    override def beginInstant: OffsetDateTime = planningTiming.begin
+    override def endInstant: OffsetDateTime = executionTiming.end
+    override def beginThreadName: String = planningTiming.threadName
+    override def endThreadName: String = executionTiming.threadName
   }
 }

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/model/IndividualTestResult.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/model/IndividualTestResult.scala
@@ -24,12 +24,6 @@ sealed trait IndividualTestResult {
     * test-completion side of the event stream (e.g. `TestSucceeded`, `TestFailed`).
     */
   def endInstant: OffsetDateTime
-
-  /** Name of the thread that started the first phase of this result. */
-  def beginThreadName: String
-
-  /** Name of the thread that started the last phase of this result. */
-  def endThreadName: String
 }
 
 object IndividualTestResult {
@@ -39,8 +33,6 @@ object IndividualTestResult {
     override def totalTime: FiniteDuration = planningTiming.duration + failedInstantiationTiming.duration
     override def beginInstant: OffsetDateTime = planningTiming.begin
     override def endInstant: OffsetDateTime = failedInstantiationTiming.end
-    override def beginThreadName: String = planningTiming.threadName
-    override def endThreadName: String = failedInstantiationTiming.threadName
   }
 
   case class ExecutionFailure(test: FullMeta, planningTiming: Timing, instantiationTiming: Timing, failedExecTiming: Timing, failure: Throwable, trace: Exit.Trace[Throwable])
@@ -48,8 +40,6 @@ object IndividualTestResult {
     override def totalTime: FiniteDuration = planningTiming.duration + instantiationTiming.duration + failedExecTiming.duration
     override def beginInstant: OffsetDateTime = planningTiming.begin
     override def endInstant: OffsetDateTime = failedExecTiming.end
-    override def beginThreadName: String = planningTiming.threadName
-    override def endThreadName: String = failedExecTiming.threadName
   }
 
   sealed trait IndividualTestSuccess extends IndividualTestResult
@@ -58,7 +48,5 @@ object IndividualTestResult {
     override def totalTime: FiniteDuration = planningTiming.duration + instantiationTiming.duration + executionTiming.duration
     override def beginInstant: OffsetDateTime = planningTiming.begin
     override def endInstant: OffsetDateTime = executionTiming.end
-    override def beginThreadName: String = planningTiming.threadName
-    override def endThreadName: String = executionTiming.threadName
   }
 }

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/model/IndividualTestResult.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/model/IndividualTestResult.scala
@@ -4,49 +4,26 @@ import izumi.distage.model.provisioning.PlanInterpreter.FailedProvision
 import izumi.distage.testkit.runner.impl.services.Timing
 import izumi.functional.bio.Exit
 
-import java.time.OffsetDateTime
-import scala.concurrent.duration.FiniteDuration
-
 sealed trait IndividualTestResult {
-  def totalTime: FiniteDuration
   def test: FullMeta
-
-  /** The earliest observed phase begin time across this result's phases.
-    *
-    * Used by reporters to populate the wall-clock timestamp on the
-    * test-start side of the corresponding event stream (e.g. `TestStarting`).
-    */
-  def beginInstant: OffsetDateTime
-
-  /** The latest observed phase end time across this result's phases.
-    *
-    * Used by reporters to populate the wall-clock timestamp on the
-    * test-completion side of the event stream (e.g. `TestSucceeded`, `TestFailed`).
-    */
-  def endInstant: OffsetDateTime
+  def testTiming: Timing
 }
 
 object IndividualTestResult {
   sealed trait IndividualTestFailure extends IndividualTestResult
 
   case class InstantiationFailure(test: FullMeta, planningTiming: Timing, failedInstantiationTiming: Timing, failure: FailedProvision) extends IndividualTestFailure {
-    override def totalTime: FiniteDuration = planningTiming.duration + failedInstantiationTiming.duration
-    override def beginInstant: OffsetDateTime = planningTiming.begin
-    override def endInstant: OffsetDateTime = failedInstantiationTiming.end
+    override def testTiming: Timing = planningTiming ++ failedInstantiationTiming
   }
 
   case class ExecutionFailure(test: FullMeta, planningTiming: Timing, instantiationTiming: Timing, failedExecTiming: Timing, failure: Throwable, trace: Exit.Trace[Throwable])
     extends IndividualTestFailure {
-    override def totalTime: FiniteDuration = planningTiming.duration + instantiationTiming.duration + failedExecTiming.duration
-    override def beginInstant: OffsetDateTime = planningTiming.begin
-    override def endInstant: OffsetDateTime = failedExecTiming.end
+    override def testTiming: Timing = planningTiming ++ instantiationTiming ++ failedExecTiming
   }
 
   sealed trait IndividualTestSuccess extends IndividualTestResult
 
   case class TestSuccess(test: FullMeta, planningTiming: Timing, instantiationTiming: Timing, executionTiming: Timing) extends IndividualTestSuccess {
-    override def totalTime: FiniteDuration = planningTiming.duration + instantiationTiming.duration + executionTiming.duration
-    override def beginInstant: OffsetDateTime = planningTiming.begin
-    override def endInstant: OffsetDateTime = executionTiming.end
+    override def testTiming: Timing = planningTiming ++ instantiationTiming ++ executionTiming
   }
 }

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/runner/impl/services/TimedActionF.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/runner/impl/services/TimedActionF.scala
@@ -37,6 +37,11 @@ object Timed {
 /** A measured time interval: wall-clock `begin` moment and total `duration`. */
 final case class Timing(begin: OffsetDateTime, duration: FiniteDuration) {
   def end: OffsetDateTime = begin.plusNanos(duration.toNanos)
+  def ++(other: Timing): Timing = {
+    val combinedBegin = if (begin.isBefore(other.begin)) begin else other.begin
+    val combinedEnd = if (end.isAfter(other.end)) end else other.end
+    Timing.fromDiff(combinedBegin, combinedEnd)
+  }
 }
 object Timing {
   def fromDiff(before: OffsetDateTime, after: OffsetDateTime): Timing = {

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/runner/impl/services/TimedActionF.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/runner/impl/services/TimedActionF.scala
@@ -12,7 +12,7 @@ import scala.concurrent.duration.FiniteDuration
 
 final case class Timed[A](out: A, timing: Timing)
 object Timed {
-  def fromDiff[A](out: A, before: TimingStart, after: OffsetDateTime): Timed[A] = {
+  def fromDiff[A](out: A, before: OffsetDateTime, after: OffsetDateTime): Timed[A] = {
     Timed(out, Timing.fromDiff(before, after))
   }
 
@@ -34,33 +34,13 @@ object Timed {
   }
 }
 
-/** Captures a wall-clock moment together with the thread that observed it.
-  *
-  * The thread name is recorded for downstream reporters (notably the ScalaTest event
-  * stream) that need to attribute work to a specific JVM thread. Both fields are sampled
-  * within the same `F.maybeSuspend` so they describe the same observation.
-  */
-final case class TimingStart(at: OffsetDateTime, threadName: String)
-
-/** A measured time interval: begin moment, total duration, and the thread that
-  * began the measurement.
-  *
-  * `threadName` is captured at `begin`. For phases that may shift threads (e.g. async
-  * test execution under cats-effect/ZIO), this records the thread that the phase
-  * started on — which is the right attribution for the ScalaTest event corresponding
-  * to that phase's start. Phase-end timing on a different thread can be recovered via
-  * a follow-up [[TimingStart]] capture if needed.
-  */
-final case class Timing(begin: OffsetDateTime, duration: FiniteDuration, threadName: String) {
+/** A measured time interval: wall-clock `begin` moment and total `duration`. */
+final case class Timing(begin: OffsetDateTime, duration: FiniteDuration) {
   def end: OffsetDateTime = begin.plusNanos(duration.toNanos)
 }
 object Timing {
-  def fromDiff(before: TimingStart, after: OffsetDateTime): Timing = {
-    Timing(
-      begin = before.at,
-      duration = FiniteDuration(ChronoUnit.NANOS.between(before.at, after), TimeUnit.NANOSECONDS),
-      threadName = before.threadName,
-    )
+  def fromDiff(before: OffsetDateTime, after: OffsetDateTime): Timing = {
+    Timing(begin = before, duration = FiniteDuration(ChronoUnit.NANOS.between(before, after), TimeUnit.NANOSECONDS))
   }
 }
 
@@ -72,11 +52,9 @@ trait TimedActionF[F[_]] {
 
 object TimedActionF {
   class TimedActionFImpl[F[_]]()(implicit F: QuasiIO[F]) extends TimedActionF[F] {
-    private def sampleStart: TimingStart = TimingStart(Clock1.Standard.nowOffset(), Thread.currentThread.getName)
-
     override def timedLifecycle[A](action: => Lifecycle[F, A]): Lifecycle[F, Timed[A]] = {
       for {
-        before <- Lifecycle.liftF(F.maybeSuspend(sampleStart))
+        before <- Lifecycle.liftF(F.maybeSuspend(Clock1.Standard.nowOffset()))
         value <- action
         after <- Lifecycle.liftF(F.maybeSuspend(Clock1.Standard.nowOffset()))
       } yield {
@@ -86,7 +64,7 @@ object TimedActionF {
 
     override def timed[A](action: => F[A]): F[Timed[A]] = {
       for {
-        before <- F.maybeSuspend(sampleStart)
+        before <- F.maybeSuspend(Clock1.Standard.nowOffset())
         value <- action
         after <- F.maybeSuspend(Clock1.Standard.nowOffset())
       } yield {
@@ -96,7 +74,7 @@ object TimedActionF {
 
     override def timedWith[A](action: (() => F[Timing]) => F[A]): F[Timed[A]] = {
       for {
-        before <- F.maybeSuspend(sampleStart)
+        before <- F.maybeSuspend(Clock1.Standard.nowOffset())
         value <- action(
           () =>
             F.maybeSuspend {

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/runner/impl/services/TimedActionF.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/runner/impl/services/TimedActionF.scala
@@ -34,9 +34,9 @@ object Timed {
   }
 }
 
-/** A measured time interval: wall-clock `begin` moment and total `duration`. */
 final case class Timing(begin: OffsetDateTime, duration: FiniteDuration) {
-  def end: OffsetDateTime = begin.plusNanos(duration.toNanos)
+  lazy val end: OffsetDateTime = begin.plusNanos(duration.toNanos)
+
   def ++(other: Timing): Timing = {
     val combinedBegin = if (begin.isBefore(other.begin)) begin else other.begin
     val combinedEnd = if (end.isAfter(other.end)) end else other.end

--- a/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/runner/impl/services/TimedActionF.scala
+++ b/distage/distage-testkit-core/src/main/scala/izumi/distage/testkit/runner/impl/services/TimedActionF.scala
@@ -12,7 +12,7 @@ import scala.concurrent.duration.FiniteDuration
 
 final case class Timed[A](out: A, timing: Timing)
 object Timed {
-  def fromDiff[A](out: A, before: OffsetDateTime, after: OffsetDateTime): Timed[A] = {
+  def fromDiff[A](out: A, before: TimingStart, after: OffsetDateTime): Timed[A] = {
     Timed(out, Timing.fromDiff(before, after))
   }
 
@@ -34,10 +34,33 @@ object Timed {
   }
 }
 
-final case class Timing(begin: OffsetDateTime, duration: FiniteDuration)
+/** Captures a wall-clock moment together with the thread that observed it.
+  *
+  * The thread name is recorded for downstream reporters (notably the ScalaTest event
+  * stream) that need to attribute work to a specific JVM thread. Both fields are sampled
+  * within the same `F.maybeSuspend` so they describe the same observation.
+  */
+final case class TimingStart(at: OffsetDateTime, threadName: String)
+
+/** A measured time interval: begin moment, total duration, and the thread that
+  * began the measurement.
+  *
+  * `threadName` is captured at `begin`. For phases that may shift threads (e.g. async
+  * test execution under cats-effect/ZIO), this records the thread that the phase
+  * started on — which is the right attribution for the ScalaTest event corresponding
+  * to that phase's start. Phase-end timing on a different thread can be recovered via
+  * a follow-up [[TimingStart]] capture if needed.
+  */
+final case class Timing(begin: OffsetDateTime, duration: FiniteDuration, threadName: String) {
+  def end: OffsetDateTime = begin.plusNanos(duration.toNanos)
+}
 object Timing {
-  def fromDiff(before: OffsetDateTime, after: OffsetDateTime): Timing = {
-    Timing(begin = before, duration = FiniteDuration(ChronoUnit.NANOS.between(before, after), TimeUnit.NANOSECONDS))
+  def fromDiff(before: TimingStart, after: OffsetDateTime): Timing = {
+    Timing(
+      begin = before.at,
+      duration = FiniteDuration(ChronoUnit.NANOS.between(before.at, after), TimeUnit.NANOSECONDS),
+      threadName = before.threadName,
+    )
   }
 }
 
@@ -49,9 +72,11 @@ trait TimedActionF[F[_]] {
 
 object TimedActionF {
   class TimedActionFImpl[F[_]]()(implicit F: QuasiIO[F]) extends TimedActionF[F] {
+    private def sampleStart: TimingStart = TimingStart(Clock1.Standard.nowOffset(), Thread.currentThread.getName)
+
     override def timedLifecycle[A](action: => Lifecycle[F, A]): Lifecycle[F, Timed[A]] = {
       for {
-        before <- Lifecycle.liftF(F.maybeSuspend(Clock1.Standard.nowOffset()))
+        before <- Lifecycle.liftF(F.maybeSuspend(sampleStart))
         value <- action
         after <- Lifecycle.liftF(F.maybeSuspend(Clock1.Standard.nowOffset()))
       } yield {
@@ -61,7 +86,7 @@ object TimedActionF {
 
     override def timed[A](action: => F[A]): F[Timed[A]] = {
       for {
-        before <- F.maybeSuspend(Clock1.Standard.nowOffset())
+        before <- F.maybeSuspend(sampleStart)
         value <- action
         after <- F.maybeSuspend(Clock1.Standard.nowOffset())
       } yield {
@@ -71,7 +96,7 @@ object TimedActionF {
 
     override def timedWith[A](action: (() => F[Timing]) => F[A]): F[Timed[A]] = {
       for {
-        before <- F.maybeSuspend(Clock1.Standard.nowOffset())
+        before <- F.maybeSuspend(sampleStart)
         value <- action(
           () =>
             F.maybeSuspend {

--- a/distage/distage-testkit-scalatest/.jvm/src/test/scala/org/scalatest/tools/distagetest/JUnitXmlRegressionTest.scala
+++ b/distage/distage-testkit-scalatest/.jvm/src/test/scala/org/scalatest/tools/distagetest/JUnitXmlRegressionTest.scala
@@ -153,11 +153,11 @@ final class JUnitXmlRegressionTest extends AnyWordSpec {
         name =>
           val time = testcases.getOrElse(
             name,
-            fail(s"expected <testcase name=\"$name\"> in JUnit XML, found: ${testcases.keys.mkString(", ")}"),
+            fail(s"""expected <testcase name="$name"> in JUnit XML, found: ${testcases.keys.mkString(", ")}"""),
           )
           assert(
             time >= minExpectedPerTestSeconds,
-            s"<testcase name=\"$name\" time=\"$time\"/> is below the minimum $minExpectedPerTestSeconds s — testkit must populate Event timestamps " +
+            s"""<testcase name="$name" time="$time"/> is below the minimum $minExpectedPerTestSeconds s — testkit must populate Event timestamps """ +
             "explicitly from its own Timing measurements; relying on the case-class `(new Date).getTime` default collapses " +
             "per-test times to ~0 under the per-suite event linearizer.",
           )

--- a/distage/distage-testkit-scalatest/.jvm/src/test/scala/org/scalatest/tools/distagetest/JUnitXmlRegressionTest.scala
+++ b/distage/distage-testkit-scalatest/.jvm/src/test/scala/org/scalatest/tools/distagetest/JUnitXmlRegressionTest.scala
@@ -54,7 +54,7 @@ import scala.xml.XML
   *
   * The anonymous inner suite uses a private
   * [[DistageTestsRegistry]] (via the
-  * [[org.scalatest.distage.DistageScalatestTestSuiteRunner#__internal_distageTestRegistry]]
+  * [[org.scalatest.distage.DistageScalatestTestSuiteRunner#_distageTestsRegistry]]
   * injection point) so it is fully isolated from the process-wide
   * [[izumi.distage.testkit.services.scalatest.dstest.DistageTestsRegistrySingleton]]. SBT/ScalaTest only auto-discovers
   * top-level public suites, so the anonymous inner suite is invisible
@@ -90,7 +90,7 @@ final class JUnitXmlRegressionTest extends AnyWordSpec {
       val perTestSleep = testSleepMillis
 
       val suiteUnderTest: SpecIdentity = new SpecIdentity { spec =>
-        override protected def __internal_distageTestRegistry: DistageTestsRegistry = privateRegistry
+        override protected def _distageTestsRegistry: DistageTestsRegistry = privateRegistry
 
         scopeName.should {
           leafNames.foreach {

--- a/distage/distage-testkit-scalatest/.jvm/src/test/scala/org/scalatest/tools/distagetest/JUnitXmlRegressionTest.scala
+++ b/distage/distage-testkit-scalatest/.jvm/src/test/scala/org/scalatest/tools/distagetest/JUnitXmlRegressionTest.scala
@@ -89,18 +89,18 @@ final class JUnitXmlRegressionTest extends AnyWordSpec {
       val scopeName = parallelScope
       val perTestSleep = testSleepMillis
 
-      val suiteUnderTest: SpecIdentity = new SpecIdentity {
+      val suiteUnderTest: SpecIdentity = new SpecIdentity { spec =>
         override protected def __internal_distageTestRegistry: DistageTestsRegistry = privateRegistry
 
-        scopeName should {
+        scopeName.should {
           leafNames.foreach {
             name =>
-              name in {
+              spec.convertToWordSpecStringWrapperDS(name) in {
                 Thread.sleep(perTestSleep)
                 ()
               }
           }
-        }
+        }(using spec.subjectRegistrationFunction1)
       }
 
       val tracker = new Tracker(new Ordinal(0))

--- a/distage/distage-testkit-scalatest/.jvm/src/test/scala/org/scalatest/tools/distagetest/JUnitXmlRegressionTest.scala
+++ b/distage/distage-testkit-scalatest/.jvm/src/test/scala/org/scalatest/tools/distagetest/JUnitXmlRegressionTest.scala
@@ -5,13 +5,11 @@ package org.scalatest.tools.distagetest
 
 import izumi.distage.testkit.scalatest.SpecIdentity
 import izumi.distage.testkit.services.scalatest.dstest.DistageTestsRegistry
-import org.scalatest.{Args, Tracker}
+import izumi.fundamentals.platform.files.IzFiles
 import org.scalatest.events.{Ordinal, SuiteCompleted, SuiteStarting}
-import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.tools.JUnitXmlReporter
 import org.scalatest.wordspec.AnyWordSpec
-
-import izumi.fundamentals.platform.files.IzFiles
+import org.scalatest.{Args, Tracker}
 
 import java.nio.file.{Files, Path}
 import scala.xml.XML

--- a/distage/distage-testkit-scalatest/src/main/scala/izumi/distage/testkit/services/scalatest/dstest/DistageTestsRegistrySingleton.scala
+++ b/distage/distage-testkit-scalatest/src/main/scala/izumi/distage/testkit/services/scalatest/dstest/DistageTestsRegistrySingleton.scala
@@ -2,6 +2,7 @@ package izumi.distage.testkit.services.scalatest.dstest
 
 import izumi.distage.testkit.DebugProperties
 import izumi.distage.testkit.model.{DistageTest, SuiteId}
+import izumi.distage.testkit.services.scalatest.dstest.DistageTestsRegistry.{InstantiatedSuiteHandle, RunningSuiteHandle}
 import izumi.fundamentals.platform.console.TrivialLogger
 import izumi.fundamentals.platform.language.Quirks.Discarder
 import izumi.fundamentals.platform.language.types.HigherKindedAny.AnyF
@@ -15,27 +16,20 @@ import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.mutable
 import scala.util.chaining.scalaUtilChainingOps
 
-object DistageTestsRegistrySingleton {
-  final case class InstantiatedSuiteHandle[+F[_]](
-    suite: DistageScalatestTestSuiteRunner[F @uncheckedVariance],
-    status: StatefulStatus,
-  )
-  final case class RunningSuiteHandle(
-    tracker: Tracker,
-    reporter: Reporter,
-  )
+object DistageTestsRegistrySingleton extends DistageTestsRegistry
 
+class DistageTestsRegistry {
   private val instantiatedSuiteHandles = new mutable.HashMap[String, InstantiatedSuiteHandle[AnyF]]()
   private val runningSuiteHandles = new mutable.HashMap[String, Either[mutable.ArrayBuffer[RunningSuiteHandle => Unit], RunningSuiteHandle]]()
   private val firstRunnerStarted = new AtomicBoolean(false)
   private val runnerFinished = new AtomicBoolean(false)
 
   def collectAllTestkitTests[F[_]](instance: DistageScalatestTestSuiteRunner[F], isSbt: Boolean): Option[List[DistageTest[AnyF]]] = {
-    if (DistageTestsRegistrySingleton.permittedToRun()) {
-      val debugLogger: TrivialLogger = TrivialLogger.make[DistageTestsRegistrySingleton.type](DebugProperties.`izumi.distage.testkit.debug`.name)
+    if (permittedToRun()) {
+      val debugLogger: TrivialLogger = TrivialLogger.make[DistageTestsRegistry](DebugProperties.`izumi.distage.testkit.debug`.name)
       debugLogger.log(s"Launching tests from $instance")
 
-      val instantiatedClassNames = DistageTestsRegistrySingleton.currentInstantiatedSuites().map(_.suite.getClass.getName)
+      val instantiatedClassNames = currentInstantiatedSuites().map(_.suite.getClass.getName)
       val discoveredClassNames: Set[String] = Runner.discoveredSuites.getOrElse {
         if (isSbt) {
           throw new RuntimeException(
@@ -58,7 +52,7 @@ object DistageTestsRegistrySingleton {
           }
       }
 
-      val allSuites = DistageTestsRegistrySingleton.currentInstantiatedSuites().map(_.suite)
+      val allSuites = currentInstantiatedSuites().map(_.suite)
 
       debugLogger.log(s"Instantiated new suites ${allSuites.map(_.getClass.getName).toSet -- instantiatedClassNames}")
 
@@ -160,4 +154,15 @@ object DistageTestsRegistrySingleton {
     }
   }
 
+}
+
+object DistageTestsRegistry {
+  final case class InstantiatedSuiteHandle[+F[_]](
+    suite: DistageScalatestTestSuiteRunner[F @uncheckedVariance],
+    status: StatefulStatus,
+  )
+  final case class RunningSuiteHandle(
+    tracker: Tracker,
+    reporter: Reporter,
+  )
 }

--- a/distage/distage-testkit-scalatest/src/main/scala/izumi/distage/testkit/services/scalatest/dstest/ScalatestLinearizedTestReporter.scala
+++ b/distage/distage-testkit-scalatest/src/main/scala/izumi/distage/testkit/services/scalatest/dstest/ScalatestLinearizedTestReporter.scala
@@ -2,16 +2,40 @@ package izumi.distage.testkit.services.scalatest.dstest
 
 import izumi.distage.testkit.model.*
 import izumi.distage.testkit.runner.api.TestReporter
-import izumi.distage.testkit.services.scalatest.dstest.SafeIntellijTestReporter.{Delayed, DelayedEarly, DelayedLate}
+import izumi.distage.testkit.services.scalatest.dstest.ScalatestLinearizedTestReporter.{Delayed, DelayedEarly, DelayedLate}
 
 import scala.collection.mutable
 
-/**
-  * This TestReporter orders test events in a way that's digestible by Intellij.
+/** Serialises ScalaTest test events on a per-suite, per-test basis so that downstream
+  * reporters see a strict `TestStarting → terminator → TestStarting → terminator …`
+  * sequence within each suite.
   *
-  * It exists ONLY for Intellij compat
+  * This is required by several downstream ScalaTest reporters that pair-walk events
+  * within a suite and either throw `RuntimeException("unexpected …")` or otherwise
+  * corrupt their output when concurrent intra-suite test events interleave (distage
+  * testkit runs tests with `parallelTests = Parallelism.Unlimited` by default —
+  * see `TestConfig.scala:79-82`). The exception is silently swallowed by
+  * `org.scalatest.CatchReporter:34-44`, so the failure mode is "per-suite output
+  * file silently absent" rather than a crash — observed as JUnit XML test undercount.
+  *
+  * Reporters that REQUIRE this serialisation (pair-walkers):
+  *   - `org.scalatest.tools.JUnitXmlReporter.processTest:284-345` (throws on stray test events)
+  *   - `org.scalatest.tools.XmlReporter:129-172, 467-469` (same pattern)
+  *   - `org.scalatest.tools.DashboardReporter.SuiteRecord.toXml:720-738`
+  *     and `TestRecord.addEvent:764-779` (throws on terminator without preceding start)
+  *
+  * Reporters that BENEFIT (better-grouped output) but do not strictly require it:
+  *   - `org.scalatest.tools.HtmlReporter:1027-1083` — counter-style aggregation, tolerates
+  *     interleaving but renders nicer with linearised events
+  *   - Intellij's reporter (the original motivation for this class)
+  *
+  * Reporters that are unaffected (per-event sinks):
+  *   - All `StringReporter`-family sinks (`PrintReporter`, `FileReporter`,
+  *     `StandardOutReporter`, `StandardErrReporter`)
+  *   - `MemoryReporter`, `FilterReporter`, `SbtDispatchReporter`,
+  *     `SocketReporter`, `XmlSocketReporter`
   */
-class SafeIntellijTestReporter(
+class ScalatestLinearizedTestReporter(
   underlying: TestReporter
 ) extends TestReporter {
   private val delayedReports = new mutable.LinkedHashMap[FullMeta, mutable.Queue[Delayed]]()
@@ -122,7 +146,7 @@ class SafeIntellijTestReporter(
 
 }
 
-object SafeIntellijTestReporter {
+object ScalatestLinearizedTestReporter {
   sealed trait Delayed {
     def id: ScopeId
     def status: TestStatus

--- a/distage/distage-testkit-scalatest/src/main/scala/org/scalatest/distage/DistageScalatestReporter.scala
+++ b/distage/distage-testkit-scalatest/src/main/scala/org/scalatest/distage/DistageScalatestReporter.scala
@@ -67,26 +67,6 @@ class DistageScalatestReporter(
 
     def epochMs(odt: OffsetDateTime): Long = odt.toInstant.toEpochMilli
 
-    def reportStarting(timing: Timing): Unit = {
-      suiteHandler.doReportEvent(suiteId1)(
-        ordinal =>
-          TestStarting(
-            ordinal = ordinal,
-            suiteName = suiteName1,
-            suiteId = suiteId1.suiteId,
-            suiteClassName = Some(suiteClassName1),
-            testName = testName,
-            testText = testName,
-            formatter = Some(MotionToSuppress),
-            location = location,
-            rerunner = rerunner,
-            payload = noPayload,
-            threadName = Thread.currentThread.getName,
-            timeStamp = epochMs(timing.begin),
-          )
-      )
-    }
-
     def reportFailure(timing: Timing, throwable: Throwable, trace: Exit.Trace[Any]): Unit = {
       suiteHandler.doReportEvent(suiteId1)(
         ordinal =>
@@ -140,6 +120,43 @@ class DistageScalatestReporter(
       )
     }
 
+    def reportInfo(message: String, timing: Timing): Unit = {
+      suiteHandler.doReportEvent(suiteId1)(
+        ordinal =>
+          InfoProvided(
+            ordinal = ordinal,
+            message = s"Test: ${test.test.id} \n$message",
+            nameInfo = Some(NameInfo(suiteName1, suiteId1.suiteId, Some(suiteClassName1), Some(testName))),
+            throwable = None,
+            formatter = infoFormatter,
+            location = location,
+            payload = noPayload,
+            threadName = Thread.currentThread.getName,
+            timeStamp = epochMs(timing.begin),
+          )
+      )
+    }
+
+    def reportStarting(timing: Timing): Unit = {
+      suiteHandler.doReportEvent(suiteId1)(
+        ordinal =>
+          TestStarting(
+            ordinal = ordinal,
+            suiteName = suiteName1,
+            suiteId = suiteId1.suiteId,
+            suiteClassName = Some(suiteClassName1),
+            testName = testName,
+            testText = testName,
+            formatter = Some(MotionToSuppress),
+            location = location,
+            rerunner = rerunner,
+            payload = noPayload,
+            threadName = Thread.currentThread.getName,
+            timeStamp = epochMs(timing.begin),
+          )
+      )
+    }
+
     def reportSucceeded(timing: Timing): Unit = {
       suiteHandler.doReportEvent(suiteId1)(
         ordinal =>
@@ -158,23 +175,6 @@ class DistageScalatestReporter(
             payload = noPayload,
             threadName = Thread.currentThread.getName,
             timeStamp = epochMs(timing.end),
-          )
-      )
-    }
-
-    def reportInfo(message: String, timing: Timing): Unit = {
-      suiteHandler.doReportEvent(suiteId1)(
-        ordinal =>
-          InfoProvided(
-            ordinal = ordinal,
-            message = s"Test: ${test.test.id} \n$message",
-            nameInfo = Some(NameInfo(suiteName1, suiteId1.suiteId, Some(suiteClassName1), Some(testName))),
-            throwable = None,
-            formatter = infoFormatter,
-            location = location,
-            payload = noPayload,
-            threadName = Thread.currentThread.getName,
-            timeStamp = epochMs(timing.begin),
           )
       )
     }

--- a/distage/distage-testkit-scalatest/src/main/scala/org/scalatest/distage/DistageScalatestReporter.scala
+++ b/distage/distage-testkit-scalatest/src/main/scala/org/scalatest/distage/DistageScalatestReporter.scala
@@ -50,10 +50,14 @@ class DistageScalatestReporter(
     val suiteClassName1 = test.suite.suiteClassName
     val testName = test.test.id.name
 
-    // Every Event field below is populated from testkit data. Nothing is left to ScalaTest's
-    // case-class defaults (current-thread, current-time): ScalaTest's XML pair-walking reporters
-    // (JUnitXmlReporter, XmlReporter, DashboardReporter) use `event.timeStamp` arithmetic for test
-    // durations and would otherwise see linearised-emission timestamps, not real measured times.
+    // `timeStamp` is populated from testkit's own Timing measurements rather than left to ScalaTest's
+    // `(new Date).getTime` case-class default. ScalaTest's XML pair-walking reporters (JUnitXmlReporter,
+    // XmlReporter, DashboardReporter) derive per-testcase duration from `terminator.timeStamp -
+    // testStarting.timeStamp`, so without an explicit measured stamp those durations collapse to the
+    // event-emission delta — which under the per-suite event linearizer is effectively zero. `threadName`
+    // is captured at the actual event-emission site below; that's "the thread that flushed this event",
+    // matching the ScalaTest default semantics, since the testkit cannot meaningfully attribute async
+    // test work to a single JVM thread.
     val location = Some(LineInFile(test.test.pos.line, test.test.pos.file, None))
     val rerunner = Some(suiteClassName1)
     val terminatorFormatter = Some(getIndentedTextForTest(s"- $testName", 0, includeIcon = false))
@@ -64,7 +68,7 @@ class DistageScalatestReporter(
 
     def epochMs(odt: OffsetDateTime): Long = odt.toInstant.toEpochMilli
 
-    def reportStarting(stamp: OffsetDateTime, thread: String): Unit = {
+    def reportStarting(stamp: OffsetDateTime): Unit = {
       suiteHandler.doReportEvent(suiteId1)(
         ordinal =>
           TestStarting(
@@ -78,13 +82,13 @@ class DistageScalatestReporter(
             location = location,
             rerunner = rerunner,
             payload = noPayload,
-            threadName = thread,
+            threadName = Thread.currentThread.getName,
             timeStamp = epochMs(stamp),
           )
       )
     }
 
-    def reportFailure(duration: FiniteDuration, throwable: Throwable, trace: Exit.Trace[Any], stamp: OffsetDateTime, thread: String): Unit = {
+    def reportFailure(duration: FiniteDuration, throwable: Throwable, trace: Exit.Trace[Any], stamp: OffsetDateTime): Unit = {
       suiteHandler.doReportEvent(suiteId1)(
         ordinal =>
           TestFailed(
@@ -105,13 +109,13 @@ class DistageScalatestReporter(
             location = location,
             rerunner = rerunner,
             payload = noPayload,
-            threadName = thread,
+            threadName = Thread.currentThread.getName,
             timeStamp = epochMs(stamp),
           )
       )
     }
 
-    def reportCancellation(duration: FiniteDuration, clue: String, trace: Exit.Trace[Any], stamp: OffsetDateTime, thread: String): Unit = {
+    def reportCancellation(duration: FiniteDuration, clue: String, trace: Exit.Trace[Any], stamp: OffsetDateTime): Unit = {
       suiteHandler.doReportEvent(suiteId1)(
         ordinal =>
           TestCanceled(
@@ -131,13 +135,13 @@ class DistageScalatestReporter(
             location = location,
             rerunner = rerunner,
             payload = noPayload,
-            threadName = thread,
+            threadName = Thread.currentThread.getName,
             timeStamp = epochMs(stamp),
           )
       )
     }
 
-    def reportSucceeded(duration: FiniteDuration, stamp: OffsetDateTime, thread: String): Unit = {
+    def reportSucceeded(duration: FiniteDuration, stamp: OffsetDateTime): Unit = {
       suiteHandler.doReportEvent(suiteId1)(
         ordinal =>
           TestSucceeded(
@@ -153,13 +157,13 @@ class DistageScalatestReporter(
             location = location,
             rerunner = rerunner,
             payload = noPayload,
-            threadName = thread,
+            threadName = Thread.currentThread.getName,
             timeStamp = epochMs(stamp),
           )
       )
     }
 
-    def reportInfo(message: String, stamp: OffsetDateTime, thread: String): Unit = {
+    def reportInfo(message: String, stamp: OffsetDateTime): Unit = {
       suiteHandler.doReportEvent(suiteId1)(
         ordinal =>
           InfoProvided(
@@ -170,7 +174,7 @@ class DistageScalatestReporter(
             formatter = infoFormatter,
             location = location,
             payload = noPayload,
-            threadName = thread,
+            threadName = Thread.currentThread.getName,
             timeStamp = epochMs(stamp),
           )
       )
@@ -181,37 +185,36 @@ class DistageScalatestReporter(
     testStatus match {
       case s: TestStatus.FailedInitialPlanning =>
         // Single-phase status: the planning attempt is the whole timeline.
-        reportStarting(s.timing.begin, s.timing.threadName)
-        reportFailure(s.timing.duration, s.throwableCause, Exit.Trace.ThrowableTrace(s.throwableCause), timingEnd(s.timing), s.timing.threadName)
+        reportStarting(s.timing.begin)
+        reportFailure(s.timing.duration, s.throwableCause, Exit.Trace.ThrowableTrace(s.throwableCause), timingEnd(s.timing))
       case s: TestStatus.FailedRuntimePlanning =>
         val throwable = s.failure.failure.toThrowable
-        reportStarting(s.failure.timing.begin, s.failure.timing.threadName)
-        reportFailure(s.failure.timing.duration, throwable, Exit.Trace.ThrowableTrace(throwable), timingEnd(s.failure.timing), s.failure.timing.threadName)
+        reportStarting(s.failure.timing.begin)
+        reportFailure(s.failure.timing.duration, throwable, Exit.Trace.ThrowableTrace(throwable), timingEnd(s.failure.timing))
       case s: TestStatus.EarlyIgnoredByPrecondition =>
         val t = s.cause.instantiationTiming
-        reportStarting(t.begin, t.threadName)
+        reportStarting(t.begin)
         reportCancellation(
           t.duration,
           s"ignored early: ${s.checks.toList.niceList()}",
           // the Throwable is necessary for Intellij to include explanation other than just 'Test Canceled'
           Exit.Trace.ThrowableTrace(new IntegrationCheckException(s.checks, captureStackTrace = false)),
           timingEnd(t),
-          t.threadName,
         )
       case s: TestStatus.EarlyCancelled =>
         val t = s.cause.instantiationTiming
-        reportStarting(t.begin, t.threadName)
-        reportCancellation(t.duration, s"cancelled early: ${s.throwableCause.getMessage}", Exit.Trace.ThrowableTrace(s.throwableCause), timingEnd(t), t.threadName)
+        reportStarting(t.begin)
+        reportCancellation(t.duration, s"cancelled early: ${s.throwableCause.getMessage}", Exit.Trace.ThrowableTrace(s.throwableCause), timingEnd(t))
       case s: TestStatus.EarlyFailed =>
         val t = s.cause.instantiationTiming
-        reportStarting(t.begin, t.threadName)
-        reportFailure(t.duration, s.throwableCause, Exit.Trace.ThrowableTrace(s.throwableCause), timingEnd(t), t.threadName)
+        reportStarting(t.begin)
+        reportFailure(t.duration, s.throwableCause, Exit.Trace.ThrowableTrace(s.throwableCause), timingEnd(t))
       case s: TestStatus.Instantiating =>
         if (s.logPlan) {
-          reportInfo(s"Final test plan info: ${s.plan}", s.successfulPlanningTime.begin, s.successfulPlanningTime.threadName)
+          reportInfo(s"Final test plan info: ${s.plan}", s.successfulPlanningTime.begin)
         }
         // TestStarting marks the point the test logically begins — earliest known phase moment.
-        reportStarting(s.successfulPlanningTime.begin, s.successfulPlanningTime.threadName)
+        reportStarting(s.successfulPlanningTime.begin)
       case _: TestStatus.Running =>
         ()
 
@@ -221,18 +224,17 @@ class DistageScalatestReporter(
           s"ignored: ${s.checks.toList.niceList()}",
           Exit.Trace.ThrowableTrace(new IntegrationCheckException(s.checks, captureStackTrace = false)),
           s.cause.endInstant,
-          s.cause.endThreadName,
         )
 
       case s: TestStatus.FailedPlanning =>
-        reportFailure(s.timing.duration, s.failure, Exit.Trace.ThrowableTrace(s.failure), timingEnd(s.timing), s.timing.threadName)
+        reportFailure(s.timing.duration, s.failure, Exit.Trace.ThrowableTrace(s.failure), timingEnd(s.timing))
 
       case s: TestStatus.Cancelled =>
-        reportCancellation(s.cause.totalTime, s"cancelled: ${s.throwableCause.getMessage}", s.trace, s.cause.endInstant, s.cause.endThreadName)
+        reportCancellation(s.cause.totalTime, s"cancelled: ${s.throwableCause.getMessage}", s.trace, s.cause.endInstant)
       case s: TestStatus.Failed =>
-        reportFailure(s.cause.totalTime, s.throwableCause, s.trace, s.cause.endInstant, s.cause.endThreadName)
+        reportFailure(s.cause.totalTime, s.throwableCause, s.trace, s.cause.endInstant)
       case s: TestStatus.Succeed =>
-        reportSucceeded(s.result.totalTime, s.result.endInstant, s.result.endThreadName)
+        reportSucceeded(s.result.totalTime, s.result.endInstant)
     }
   }
 

--- a/distage/distage-testkit-scalatest/src/main/scala/org/scalatest/distage/DistageScalatestReporter.scala
+++ b/distage/distage-testkit-scalatest/src/main/scala/org/scalatest/distage/DistageScalatestReporter.scala
@@ -12,7 +12,6 @@ import org.scalatest.events.*
 
 import java.time.OffsetDateTime
 import scala.annotation.unused
-import scala.concurrent.duration.FiniteDuration
 
 class DistageScalatestReporter(
   suiteHandler: SuiteHandlerById
@@ -68,7 +67,7 @@ class DistageScalatestReporter(
 
     def epochMs(odt: OffsetDateTime): Long = odt.toInstant.toEpochMilli
 
-    def reportStarting(stamp: OffsetDateTime): Unit = {
+    def reportStarting(timing: Timing): Unit = {
       suiteHandler.doReportEvent(suiteId1)(
         ordinal =>
           TestStarting(
@@ -83,12 +82,12 @@ class DistageScalatestReporter(
             rerunner = rerunner,
             payload = noPayload,
             threadName = Thread.currentThread.getName,
-            timeStamp = epochMs(stamp),
+            timeStamp = epochMs(timing.begin),
           )
       )
     }
 
-    def reportFailure(duration: FiniteDuration, throwable: Throwable, trace: Exit.Trace[Any], stamp: OffsetDateTime): Unit = {
+    def reportFailure(timing: Timing, throwable: Throwable, trace: Exit.Trace[Any]): Unit = {
       suiteHandler.doReportEvent(suiteId1)(
         ordinal =>
           TestFailed(
@@ -104,18 +103,18 @@ class DistageScalatestReporter(
             // use .toThrowable to obtain a zio.FiberFailure instead of .unsafeAttachTraceOrReturnNewThrowable because scalatest
             // does not display suppressed exceptions (which is how zio attaches trace)
             throwable = Some(trace.toThrowable),
-            duration = Some(duration.toMillis),
+            duration = Some(timing.duration.toMillis),
             formatter = terminatorFormatter,
             location = location,
             rerunner = rerunner,
             payload = noPayload,
             threadName = Thread.currentThread.getName,
-            timeStamp = epochMs(stamp),
+            timeStamp = epochMs(timing.end),
           )
       )
     }
 
-    def reportCancellation(duration: FiniteDuration, clue: String, trace: Exit.Trace[Any], stamp: OffsetDateTime): Unit = {
+    def reportCancellation(timing: Timing, clue: String, trace: Exit.Trace[Any]): Unit = {
       suiteHandler.doReportEvent(suiteId1)(
         ordinal =>
           TestCanceled(
@@ -130,18 +129,18 @@ class DistageScalatestReporter(
             // use .toThrowable instead of .unsafeAttachTraceOrReturnNewThrowable because scalatest
             // does not display suppressed exceptions (which is how zio attaches trace)
             throwable = Some(trace.toThrowable),
-            duration = Some(duration.toMillis),
+            duration = Some(timing.duration.toMillis),
             formatter = terminatorFormatter,
             location = location,
             rerunner = rerunner,
             payload = noPayload,
             threadName = Thread.currentThread.getName,
-            timeStamp = epochMs(stamp),
+            timeStamp = epochMs(timing.end),
           )
       )
     }
 
-    def reportSucceeded(duration: FiniteDuration, stamp: OffsetDateTime): Unit = {
+    def reportSucceeded(timing: Timing): Unit = {
       suiteHandler.doReportEvent(suiteId1)(
         ordinal =>
           TestSucceeded(
@@ -152,18 +151,18 @@ class DistageScalatestReporter(
             testName = testName,
             testText = testName,
             recordedEvents = emptyRecordedEvents,
-            duration = Some(duration.toMillis),
+            duration = Some(timing.duration.toMillis),
             formatter = terminatorFormatter,
             location = location,
             rerunner = rerunner,
             payload = noPayload,
             threadName = Thread.currentThread.getName,
-            timeStamp = epochMs(stamp),
+            timeStamp = epochMs(timing.end),
           )
       )
     }
 
-    def reportInfo(message: String, stamp: OffsetDateTime): Unit = {
+    def reportInfo(message: String, timing: Timing): Unit = {
       suiteHandler.doReportEvent(suiteId1)(
         ordinal =>
           InfoProvided(
@@ -175,66 +174,60 @@ class DistageScalatestReporter(
             location = location,
             payload = noPayload,
             threadName = Thread.currentThread.getName,
-            timeStamp = epochMs(stamp),
+            timeStamp = epochMs(timing.begin),
           )
       )
     }
 
-    def timingEnd(t: Timing): OffsetDateTime = t.end
-
     testStatus match {
       case s: TestStatus.FailedInitialPlanning =>
-        // Single-phase status: the planning attempt is the whole timeline.
-        reportStarting(s.timing.begin)
-        reportFailure(s.timing.duration, s.throwableCause, Exit.Trace.ThrowableTrace(s.throwableCause), timingEnd(s.timing))
+        reportStarting(s.timing)
+        reportFailure(s.timing, s.throwableCause, Exit.Trace.ThrowableTrace(s.throwableCause))
       case s: TestStatus.FailedRuntimePlanning =>
         val throwable = s.failure.failure.toThrowable
-        reportStarting(s.failure.timing.begin)
-        reportFailure(s.failure.timing.duration, throwable, Exit.Trace.ThrowableTrace(throwable), timingEnd(s.failure.timing))
+        reportStarting(s.failure.timing)
+        reportFailure(s.failure.timing, throwable, Exit.Trace.ThrowableTrace(throwable))
       case s: TestStatus.EarlyIgnoredByPrecondition =>
         val t = s.cause.instantiationTiming
-        reportStarting(t.begin)
+        reportStarting(t)
         reportCancellation(
-          t.duration,
+          t,
           s"ignored early: ${s.checks.toList.niceList()}",
           // the Throwable is necessary for Intellij to include explanation other than just 'Test Canceled'
           Exit.Trace.ThrowableTrace(new IntegrationCheckException(s.checks, captureStackTrace = false)),
-          timingEnd(t),
         )
       case s: TestStatus.EarlyCancelled =>
         val t = s.cause.instantiationTiming
-        reportStarting(t.begin)
-        reportCancellation(t.duration, s"cancelled early: ${s.throwableCause.getMessage}", Exit.Trace.ThrowableTrace(s.throwableCause), timingEnd(t))
+        reportStarting(t)
+        reportCancellation(t, s"cancelled early: ${s.throwableCause.getMessage}", Exit.Trace.ThrowableTrace(s.throwableCause))
       case s: TestStatus.EarlyFailed =>
         val t = s.cause.instantiationTiming
-        reportStarting(t.begin)
-        reportFailure(t.duration, s.throwableCause, Exit.Trace.ThrowableTrace(s.throwableCause), timingEnd(t))
+        reportStarting(t)
+        reportFailure(t, s.throwableCause, Exit.Trace.ThrowableTrace(s.throwableCause))
       case s: TestStatus.Instantiating =>
         if (s.logPlan) {
-          reportInfo(s"Final test plan info: ${s.plan}", s.successfulPlanningTime.begin)
+          reportInfo(s"Final test plan info: ${s.plan}", s.successfulPlanningTime)
         }
-        // TestStarting marks the point the test logically begins — earliest known phase moment.
-        reportStarting(s.successfulPlanningTime.begin)
+        reportStarting(s.successfulPlanningTime)
       case _: TestStatus.Running =>
         ()
 
       case s: TestStatus.IgnoredByPrecondition =>
         reportCancellation(
-          s.cause.totalTime,
+          s.cause.testTiming,
           s"ignored: ${s.checks.toList.niceList()}",
           Exit.Trace.ThrowableTrace(new IntegrationCheckException(s.checks, captureStackTrace = false)),
-          s.cause.endInstant,
         )
 
       case s: TestStatus.FailedPlanning =>
-        reportFailure(s.timing.duration, s.failure, Exit.Trace.ThrowableTrace(s.failure), timingEnd(s.timing))
+        reportFailure(s.timing, s.failure, Exit.Trace.ThrowableTrace(s.failure))
 
       case s: TestStatus.Cancelled =>
-        reportCancellation(s.cause.totalTime, s"cancelled: ${s.throwableCause.getMessage}", s.trace, s.cause.endInstant)
+        reportCancellation(s.cause.testTiming, s"cancelled: ${s.throwableCause.getMessage}", s.trace)
       case s: TestStatus.Failed =>
-        reportFailure(s.cause.totalTime, s.throwableCause, s.trace, s.cause.endInstant)
+        reportFailure(s.cause.testTiming, s.throwableCause, s.trace)
       case s: TestStatus.Succeed =>
-        reportSucceeded(s.result.totalTime, s.result.endInstant)
+        reportSucceeded(s.result.testTiming)
     }
   }
 

--- a/distage/distage-testkit-scalatest/src/main/scala/org/scalatest/distage/DistageScalatestReporter.scala
+++ b/distage/distage-testkit-scalatest/src/main/scala/org/scalatest/distage/DistageScalatestReporter.scala
@@ -113,7 +113,7 @@ class DistageScalatestReporter(
           throwable = None,
           payload = None,
           threadName = Thread.currentThread.getName,
-          timeStamp = timing.begin.toInstant.toEpochMilli,
+          timeStamp = timing.end.toInstant.toEpochMilli,
         )
       )
     }
@@ -132,7 +132,7 @@ class DistageScalatestReporter(
           rerunner = Some(suiteClassName1),
           payload = None,
           threadName = Thread.currentThread.getName,
-          timeStamp = timing.begin.toInstant.toEpochMilli,
+          timeStamp = timing.end.toInstant.toEpochMilli,
         )
       )
     }

--- a/distage/distage-testkit-scalatest/src/main/scala/org/scalatest/distage/DistageScalatestReporter.scala
+++ b/distage/distage-testkit-scalatest/src/main/scala/org/scalatest/distage/DistageScalatestReporter.scala
@@ -10,7 +10,6 @@ import izumi.fundamentals.platform.strings.IzString.*
 import org.scalatest.Suite.{getIndentedTextForInfo, getIndentedTextForTest}
 import org.scalatest.events.*
 
-import java.time.OffsetDateTime
 import scala.annotation.unused
 
 class DistageScalatestReporter(
@@ -49,133 +48,113 @@ class DistageScalatestReporter(
     val suiteClassName1 = test.suite.suiteClassName
     val testName = test.test.id.name
 
-    // `timeStamp` is populated from testkit's own Timing measurements rather than left to ScalaTest's
-    // `(new Date).getTime` case-class default. ScalaTest's XML pair-walking reporters (JUnitXmlReporter,
-    // XmlReporter, DashboardReporter) derive per-testcase duration from `terminator.timeStamp -
-    // testStarting.timeStamp`, so without an explicit measured stamp those durations collapse to the
-    // event-emission delta — which under the per-suite event linearizer is effectively zero. `threadName`
-    // is captured at the actual event-emission site below; that's "the thread that flushed this event",
-    // matching the ScalaTest default semantics, since the testkit cannot meaningfully attribute async
-    // test work to a single JVM thread.
-    val location = Some(LineInFile(test.test.pos.line, test.test.pos.file, None))
-    val rerunner = Some(suiteClassName1)
-    val terminatorFormatter = Some(getIndentedTextForTest(s"- $testName", 0, includeIcon = false))
-    val infoFormatter = Some(getIndentedTextForInfo(s"- $testName", 1, includeIcon = false, infoIsInsideATest = true))
-    val emptyRecordedEvents: Vector[RecordableEvent] = Vector.empty
-    val emptyAnalysis: Vector[String] = Vector.empty
-    val noPayload: Option[Any] = None
-
-    def epochMs(odt: OffsetDateTime): Long = odt.toInstant.toEpochMilli
+    val formatter = Some(getIndentedTextForTest(s"- $testName", 0, includeIcon = false))
 
     def reportFailure(timing: Timing, throwable: Throwable, trace: Exit.Trace[Any]): Unit = {
       suiteHandler.doReportEvent(suiteId1)(
-        ordinal =>
-          TestFailed(
-            ordinal = ordinal,
-            message = Option(throwable.getMessage).getOrElse("null"),
-            suiteName = suiteName1,
-            suiteId = suiteId1.suiteId,
-            suiteClassName = Some(suiteClassName1),
-            testName = testName,
-            testText = testName,
-            recordedEvents = emptyRecordedEvents,
-            analysis = emptyAnalysis,
-            // use .toThrowable to obtain a zio.FiberFailure instead of .unsafeAttachTraceOrReturnNewThrowable because scalatest
-            // does not display suppressed exceptions (which is how zio attaches trace)
-            throwable = Some(trace.toThrowable),
-            duration = Some(timing.duration.toMillis),
-            formatter = terminatorFormatter,
-            location = location,
-            rerunner = rerunner,
-            payload = noPayload,
-            threadName = Thread.currentThread.getName,
-            timeStamp = epochMs(timing.end),
-          )
+        TestFailed(
+          _,
+          Option(throwable.getMessage).getOrElse("null"),
+          suiteName1,
+          suiteId1.suiteId,
+          Some(suiteClassName1),
+          testName,
+          testName,
+          recordedEvents = Vector.empty,
+          analysis = Vector.empty,
+          // use .toThrowable to obtain a zio.FiberFailure instead of .unsafeAttachTraceOrReturnNewThrowable because scalatest
+          // does not display suppressed exceptions (which is how zio attaches trace)
+          throwable = Some(trace.toThrowable),
+          duration = Some(timing.duration.toMillis),
+          location = Some(LineInFile(test.test.pos.line, test.test.pos.file, None)),
+          formatter = formatter,
+          rerunner = Some(suiteClassName1),
+          payload = None,
+          threadName = Thread.currentThread.getName,
+          timeStamp = timing.end.toInstant.toEpochMilli,
+        )
       )
     }
 
     def reportCancellation(timing: Timing, clue: String, trace: Exit.Trace[Any]): Unit = {
       suiteHandler.doReportEvent(suiteId1)(
-        ordinal =>
-          TestCanceled(
-            ordinal = ordinal,
-            message = clue,
-            suiteName = suiteName1,
-            suiteId = suiteId1.suiteId,
-            suiteClassName = Some(suiteClassName1),
-            testName = testName,
-            testText = testName,
-            recordedEvents = emptyRecordedEvents,
-            // use .toThrowable instead of .unsafeAttachTraceOrReturnNewThrowable because scalatest
-            // does not display suppressed exceptions (which is how zio attaches trace)
-            throwable = Some(trace.toThrowable),
-            duration = Some(timing.duration.toMillis),
-            formatter = terminatorFormatter,
-            location = location,
-            rerunner = rerunner,
-            payload = noPayload,
-            threadName = Thread.currentThread.getName,
-            timeStamp = epochMs(timing.end),
-          )
+        TestCanceled(
+          _,
+          clue,
+          suiteName1,
+          suiteId1.suiteId,
+          Some(suiteClassName1),
+          testName,
+          testName,
+          recordedEvents = Vector.empty,
+          duration = Some(timing.duration.toMillis),
+          location = Some(LineInFile(test.test.pos.line, test.test.pos.file, None)),
+          formatter = formatter,
+          // use .toThrowable instead of .unsafeAttachTraceOrReturnNewThrowable because scalatest
+          // does not display suppressed exceptions (which is how zio attaches trace)
+          throwable = Some(trace.toThrowable),
+          rerunner = Some(suiteClassName1),
+          payload = None,
+          threadName = Thread.currentThread.getName,
+          timeStamp = timing.end.toInstant.toEpochMilli,
+        )
       )
     }
 
     def reportInfo(message: String, timing: Timing): Unit = {
+      val formatter = Some(getIndentedTextForInfo(s"- $testName", 1, includeIcon = false, infoIsInsideATest = true))
       suiteHandler.doReportEvent(suiteId1)(
-        ordinal =>
-          InfoProvided(
-            ordinal = ordinal,
-            message = s"Test: ${test.test.id} \n$message",
-            nameInfo = Some(NameInfo(suiteName1, suiteId1.suiteId, Some(suiteClassName1), Some(testName))),
-            throwable = None,
-            formatter = infoFormatter,
-            location = location,
-            payload = noPayload,
-            threadName = Thread.currentThread.getName,
-            timeStamp = epochMs(timing.begin),
-          )
+        InfoProvided(
+          _,
+          s"Test: ${test.test.id} \n$message",
+          Some(NameInfo(suiteName1, suiteId1.suiteId, Some(suiteClassName1), Some(testName))),
+          location = Some(LineInFile(test.test.pos.line, test.test.pos.file, None)),
+          formatter = formatter,
+          throwable = None,
+          payload = None,
+          threadName = Thread.currentThread.getName,
+          timeStamp = timing.begin.toInstant.toEpochMilli,
+        )
       )
     }
 
     def reportStarting(timing: Timing): Unit = {
       suiteHandler.doReportEvent(suiteId1)(
-        ordinal =>
-          TestStarting(
-            ordinal = ordinal,
-            suiteName = suiteName1,
-            suiteId = suiteId1.suiteId,
-            suiteClassName = Some(suiteClassName1),
-            testName = testName,
-            testText = testName,
-            formatter = Some(MotionToSuppress),
-            location = location,
-            rerunner = rerunner,
-            payload = noPayload,
-            threadName = Thread.currentThread.getName,
-            timeStamp = epochMs(timing.begin),
-          )
+        TestStarting(
+          _,
+          suiteName1,
+          suiteId1.suiteId,
+          Some(suiteClassName1),
+          testName,
+          testName,
+          location = Some(LineInFile(test.test.pos.line, test.test.pos.file, None)),
+          formatter = Some(MotionToSuppress),
+          rerunner = Some(suiteClassName1),
+          payload = None,
+          threadName = Thread.currentThread.getName,
+          timeStamp = timing.begin.toInstant.toEpochMilli,
+        )
       )
     }
 
     def reportSucceeded(timing: Timing): Unit = {
       suiteHandler.doReportEvent(suiteId1)(
-        ordinal =>
-          TestSucceeded(
-            ordinal = ordinal,
-            suiteName = suiteName1,
-            suiteId = suiteId1.suiteId,
-            suiteClassName = Some(suiteClassName1),
-            testName = testName,
-            testText = testName,
-            recordedEvents = emptyRecordedEvents,
-            duration = Some(timing.duration.toMillis),
-            formatter = terminatorFormatter,
-            location = location,
-            rerunner = rerunner,
-            payload = noPayload,
-            threadName = Thread.currentThread.getName,
-            timeStamp = epochMs(timing.end),
-          )
+        TestSucceeded(
+          _,
+          suiteName1,
+          suiteId1.suiteId,
+          Some(suiteClassName1),
+          testName,
+          testName,
+          recordedEvents = Vector.empty,
+          duration = Some(timing.duration.toMillis),
+          location = Some(LineInFile(test.test.pos.line, test.test.pos.file, None)),
+          formatter = formatter,
+          rerunner = Some(suiteClassName1),
+          payload = None,
+          threadName = Thread.currentThread.getName,
+          timeStamp = timing.end.toInstant.toEpochMilli,
+        )
       )
     }
 

--- a/distage/distage-testkit-scalatest/src/main/scala/org/scalatest/distage/DistageScalatestReporter.scala
+++ b/distage/distage-testkit-scalatest/src/main/scala/org/scalatest/distage/DistageScalatestReporter.scala
@@ -163,26 +163,23 @@ class DistageScalatestReporter(
         reportStarting(s.timing)
         reportFailure(s.timing, s.throwableCause, Exit.Trace.ThrowableTrace(s.throwableCause))
       case s: TestStatus.FailedRuntimePlanning =>
-        val throwable = s.failure.failure.toThrowable
         reportStarting(s.failure.timing)
+        val throwable = s.failure.failure.toThrowable
         reportFailure(s.failure.timing, throwable, Exit.Trace.ThrowableTrace(throwable))
       case s: TestStatus.EarlyIgnoredByPrecondition =>
-        val t = s.cause.instantiationTiming
-        reportStarting(t)
+        reportStarting(s.cause.instantiationTiming)
         reportCancellation(
-          t,
+          s.cause.instantiationTiming,
           s"ignored early: ${s.checks.toList.niceList()}",
           // the Throwable is necessary for Intellij to include explanation other than just 'Test Canceled'
           Exit.Trace.ThrowableTrace(new IntegrationCheckException(s.checks, captureStackTrace = false)),
         )
       case s: TestStatus.EarlyCancelled =>
-        val t = s.cause.instantiationTiming
-        reportStarting(t)
-        reportCancellation(t, s"cancelled early: ${s.throwableCause.getMessage}", Exit.Trace.ThrowableTrace(s.throwableCause))
+        reportStarting(s.cause.instantiationTiming)
+        reportCancellation(s.cause.instantiationTiming, s"cancelled early: ${s.throwableCause.getMessage}", Exit.Trace.ThrowableTrace(s.throwableCause))
       case s: TestStatus.EarlyFailed =>
-        val t = s.cause.instantiationTiming
-        reportStarting(t)
-        reportFailure(t, s.throwableCause, Exit.Trace.ThrowableTrace(s.throwableCause))
+        reportStarting(s.cause.instantiationTiming)
+        reportFailure(s.cause.instantiationTiming, s.throwableCause, Exit.Trace.ThrowableTrace(s.throwableCause))
       case s: TestStatus.Instantiating =>
         if (s.logPlan) {
           reportInfo(s"Final test plan info: ${s.plan}", s.successfulPlanningTime)

--- a/distage/distage-testkit-scalatest/src/main/scala/org/scalatest/distage/DistageScalatestReporter.scala
+++ b/distage/distage-testkit-scalatest/src/main/scala/org/scalatest/distage/DistageScalatestReporter.scala
@@ -3,12 +3,14 @@ package org.scalatest.distage
 import izumi.distage.model.exceptions.runtime.IntegrationCheckException
 import izumi.distage.testkit.model.*
 import izumi.distage.testkit.runner.api.TestReporter
+import izumi.distage.testkit.runner.impl.services.Timing
 import izumi.distage.testkit.services.scalatest.dstest.SuiteHandlerById
 import izumi.functional.bio.Exit
 import izumi.fundamentals.platform.strings.IzString.*
 import org.scalatest.Suite.{getIndentedTextForInfo, getIndentedTextForTest}
 import org.scalatest.events.*
 
+import java.time.OffsetDateTime
 import scala.annotation.unused
 import scala.concurrent.duration.FiniteDuration
 
@@ -25,16 +27,8 @@ class DistageScalatestReporter(
   override def endLevel(scope: ScopeId, depth: Int, suites: List[SuiteMeta]): Unit = {}
 
   override def beginSuite(scope: ScopeId, depth: Int, suiteMeta: SuiteMeta): Unit = {
-    // Don't report SuiteStarting & SuiteCompleted events because Scalatest sends these events on its own
-//    suiteHandler.doReportEvent(id.suiteId)(
-//      SuiteStarting(
-//        _,
-//        id.suiteName,
-//        id.suiteId.suiteId,
-//        Some(id.suiteClassName),
-//        formatter = Some(IndentedText(id.suiteName + ":", id.suiteName, 0)),
-//      )
-//    )
+    // SuiteStarting & SuiteCompleted are emitted by ScalaTest's Framework around `suite.run(args)` —
+    // see Framework.scala:309 (start) and :336 (complete) — so we deliberately do not duplicate them here.
   }
 
   override def endSuite(scope: ScopeId, depth: Int, suiteMeta: SuiteMeta): Unit = {
@@ -43,17 +37,7 @@ class DistageScalatestReporter(
       mutStatus =>
         mutStatus.setCompleted()
     }
-    // Don't report SuiteStarting & SuiteCompleted events because Scalatest sends these events on its own
-//    suiteHandler.doReportEvent(id.suiteId)(
-//      SuiteCompleted(
-//        _,
-//        id.suiteName,
-//        id.suiteId.suiteId,
-//        Some(id.suiteClassName),
-//        formatter = Some(IndentedText(id.suiteName + ":", id.suiteName, 0)),
-//        duration = None,
-//      )
-//    )
+    // See beginSuite — ScalaTest emits SuiteCompleted itself.
   }
 
   override def testSetupStatus(scopeId: ScopeId, depth: Int, meta: FullMeta, testStatus: TestStatus.Setup): Unit = {
@@ -66,106 +50,168 @@ class DistageScalatestReporter(
     val suiteClassName1 = test.suite.suiteClassName
     val testName = test.test.id.name
 
-    val formatter = Some(getIndentedTextForTest(s"- $testName", 0, includeIcon = false))
+    // Every Event field below is populated from testkit data. Nothing is left to ScalaTest's
+    // case-class defaults (current-thread, current-time): ScalaTest's XML pair-walking reporters
+    // (JUnitXmlReporter, XmlReporter, DashboardReporter) use `event.timeStamp` arithmetic for test
+    // durations and would otherwise see linearised-emission timestamps, not real measured times.
+    val location = Some(LineInFile(test.test.pos.line, test.test.pos.file, None))
+    val rerunner = Some(suiteClassName1)
+    val terminatorFormatter = Some(getIndentedTextForTest(s"- $testName", 0, includeIcon = false))
+    val infoFormatter = Some(getIndentedTextForInfo(s"- $testName", 1, includeIcon = false, infoIsInsideATest = true))
+    val emptyRecordedEvents: Vector[RecordableEvent] = Vector.empty
+    val emptyAnalysis: Vector[String] = Vector.empty
+    val noPayload: Option[Any] = None
 
-    def reportFailure(duration: FiniteDuration, throwable: Throwable, trace: Exit.Trace[Any]): Unit = {
+    def epochMs(odt: OffsetDateTime): Long = odt.toInstant.toEpochMilli
+
+    def reportStarting(stamp: OffsetDateTime, thread: String): Unit = {
       suiteHandler.doReportEvent(suiteId1)(
-        TestFailed(
-          _,
-          Option(throwable.getMessage).getOrElse("null"),
-          suiteName1,
-          suiteId1.suiteId,
-          Some(suiteClassName1),
-          testName,
-          testName,
-          recordedEvents = Vector.empty,
-          analysis = Vector.empty,
-          // use .toThrowable to obtain a zio.FiberFailure instead of .unsafeAttachTraceOrReturnNewThrowable because scalatest
-          // does not display suppressed exceptions (which is how zio attaches trace)
-          throwable = Some(trace.toThrowable),
-          duration = Some(duration.toMillis),
-          location = Some(LineInFile(test.test.pos.line, test.test.pos.file, None)),
-          formatter = formatter,
-        )
+        ordinal =>
+          TestStarting(
+            ordinal = ordinal,
+            suiteName = suiteName1,
+            suiteId = suiteId1.suiteId,
+            suiteClassName = Some(suiteClassName1),
+            testName = testName,
+            testText = testName,
+            formatter = Some(MotionToSuppress),
+            location = location,
+            rerunner = rerunner,
+            payload = noPayload,
+            threadName = thread,
+            timeStamp = epochMs(stamp),
+          )
       )
     }
 
-    def reportCancellation(duration: FiniteDuration, clue: String, trace: Exit.Trace[Any]): Unit = {
+    def reportFailure(duration: FiniteDuration, throwable: Throwable, trace: Exit.Trace[Any], stamp: OffsetDateTime, thread: String): Unit = {
       suiteHandler.doReportEvent(suiteId1)(
-        TestCanceled(
-          _,
-          clue,
-          suiteName1,
-          suiteId1.suiteId,
-          Some(suiteClassName1),
-          testName,
-          testName,
-          recordedEvents = Vector.empty,
-          duration = Some(duration.toMillis),
-          location = Some(LineInFile(test.test.pos.line, test.test.pos.file, None)),
-          formatter = formatter,
-          // use .toThrowable instead of .unsafeAttachTraceOrReturnNewThrowable because scalatest
-          // does not display suppressed exceptions (which is how zio attaches trace)
-          throwable = Some(trace.toThrowable),
-        )
+        ordinal =>
+          TestFailed(
+            ordinal = ordinal,
+            message = Option(throwable.getMessage).getOrElse("null"),
+            suiteName = suiteName1,
+            suiteId = suiteId1.suiteId,
+            suiteClassName = Some(suiteClassName1),
+            testName = testName,
+            testText = testName,
+            recordedEvents = emptyRecordedEvents,
+            analysis = emptyAnalysis,
+            // use .toThrowable to obtain a zio.FiberFailure instead of .unsafeAttachTraceOrReturnNewThrowable because scalatest
+            // does not display suppressed exceptions (which is how zio attaches trace)
+            throwable = Some(trace.toThrowable),
+            duration = Some(duration.toMillis),
+            formatter = terminatorFormatter,
+            location = location,
+            rerunner = rerunner,
+            payload = noPayload,
+            threadName = thread,
+            timeStamp = epochMs(stamp),
+          )
       )
     }
 
-    def reportInfo(message: String): Unit = {
-      val formatter = Some(getIndentedTextForInfo(s"- $testName", 1, includeIcon = false, infoIsInsideATest = true))
+    def reportCancellation(duration: FiniteDuration, clue: String, trace: Exit.Trace[Any], stamp: OffsetDateTime, thread: String): Unit = {
       suiteHandler.doReportEvent(suiteId1)(
-        InfoProvided(
-          _,
-          s"Test: ${test.test.id} \n$message",
-          Some(NameInfo(suiteName1, suiteId1.suiteId, Some(suiteClassName1), Some(testName))),
-          location = Some(LineInFile(test.test.pos.line, test.test.pos.file, None)),
-          formatter = formatter,
-        )
+        ordinal =>
+          TestCanceled(
+            ordinal = ordinal,
+            message = clue,
+            suiteName = suiteName1,
+            suiteId = suiteId1.suiteId,
+            suiteClassName = Some(suiteClassName1),
+            testName = testName,
+            testText = testName,
+            recordedEvents = emptyRecordedEvents,
+            // use .toThrowable instead of .unsafeAttachTraceOrReturnNewThrowable because scalatest
+            // does not display suppressed exceptions (which is how zio attaches trace)
+            throwable = Some(trace.toThrowable),
+            duration = Some(duration.toMillis),
+            formatter = terminatorFormatter,
+            location = location,
+            rerunner = rerunner,
+            payload = noPayload,
+            threadName = thread,
+            timeStamp = epochMs(stamp),
+          )
       )
     }
 
-    def reportStarting(): Unit = {
+    def reportSucceeded(duration: FiniteDuration, stamp: OffsetDateTime, thread: String): Unit = {
       suiteHandler.doReportEvent(suiteId1)(
-        TestStarting(
-          _,
-          suiteName1,
-          suiteId1.suiteId,
-          Some(suiteClassName1),
-          testName,
-          testName,
-          location = Some(LineInFile(test.test.pos.line, test.test.pos.file, None)),
-          formatter = Some(MotionToSuppress),
-        )
+        ordinal =>
+          TestSucceeded(
+            ordinal = ordinal,
+            suiteName = suiteName1,
+            suiteId = suiteId1.suiteId,
+            suiteClassName = Some(suiteClassName1),
+            testName = testName,
+            testText = testName,
+            recordedEvents = emptyRecordedEvents,
+            duration = Some(duration.toMillis),
+            formatter = terminatorFormatter,
+            location = location,
+            rerunner = rerunner,
+            payload = noPayload,
+            threadName = thread,
+            timeStamp = epochMs(stamp),
+          )
       )
     }
+
+    def reportInfo(message: String, stamp: OffsetDateTime, thread: String): Unit = {
+      suiteHandler.doReportEvent(suiteId1)(
+        ordinal =>
+          InfoProvided(
+            ordinal = ordinal,
+            message = s"Test: ${test.test.id} \n$message",
+            nameInfo = Some(NameInfo(suiteName1, suiteId1.suiteId, Some(suiteClassName1), Some(testName))),
+            throwable = None,
+            formatter = infoFormatter,
+            location = location,
+            payload = noPayload,
+            threadName = thread,
+            timeStamp = epochMs(stamp),
+          )
+      )
+    }
+
+    def timingEnd(t: Timing): OffsetDateTime = t.end
 
     testStatus match {
       case s: TestStatus.FailedInitialPlanning =>
-        reportStarting()
-        reportFailure(s.timing.duration, s.throwableCause, Exit.Trace.ThrowableTrace(s.throwableCause))
+        // Single-phase status: the planning attempt is the whole timeline.
+        reportStarting(s.timing.begin, s.timing.threadName)
+        reportFailure(s.timing.duration, s.throwableCause, Exit.Trace.ThrowableTrace(s.throwableCause), timingEnd(s.timing), s.timing.threadName)
       case s: TestStatus.FailedRuntimePlanning =>
-        reportStarting()
         val throwable = s.failure.failure.toThrowable
-        reportFailure(s.failure.timing.duration, throwable, Exit.Trace.ThrowableTrace(throwable))
+        reportStarting(s.failure.timing.begin, s.failure.timing.threadName)
+        reportFailure(s.failure.timing.duration, throwable, Exit.Trace.ThrowableTrace(throwable), timingEnd(s.failure.timing), s.failure.timing.threadName)
       case s: TestStatus.EarlyIgnoredByPrecondition =>
-        reportStarting()
+        val t = s.cause.instantiationTiming
+        reportStarting(t.begin, t.threadName)
         reportCancellation(
-          s.cause.instantiationTiming.duration,
+          t.duration,
           s"ignored early: ${s.checks.toList.niceList()}",
           // the Throwable is necessary for Intellij to include explanation other than just 'Test Canceled'
           Exit.Trace.ThrowableTrace(new IntegrationCheckException(s.checks, captureStackTrace = false)),
+          timingEnd(t),
+          t.threadName,
         )
       case s: TestStatus.EarlyCancelled =>
-        reportStarting()
-        reportCancellation(s.cause.instantiationTiming.duration, s"cancelled early: ${s.throwableCause.getMessage}", Exit.Trace.ThrowableTrace(s.throwableCause))
+        val t = s.cause.instantiationTiming
+        reportStarting(t.begin, t.threadName)
+        reportCancellation(t.duration, s"cancelled early: ${s.throwableCause.getMessage}", Exit.Trace.ThrowableTrace(s.throwableCause), timingEnd(t), t.threadName)
       case s: TestStatus.EarlyFailed =>
-        reportStarting()
-        reportFailure(s.cause.instantiationTiming.duration, s.throwableCause, Exit.Trace.ThrowableTrace(s.throwableCause))
+        val t = s.cause.instantiationTiming
+        reportStarting(t.begin, t.threadName)
+        reportFailure(t.duration, s.throwableCause, Exit.Trace.ThrowableTrace(s.throwableCause), timingEnd(t), t.threadName)
       case s: TestStatus.Instantiating =>
         if (s.logPlan) {
-          reportInfo(s"Final test plan info: ${s.plan}")
+          reportInfo(s"Final test plan info: ${s.plan}", s.successfulPlanningTime.begin, s.successfulPlanningTime.threadName)
         }
-        reportStarting()
+        // TestStarting marks the point the test logically begins — earliest known phase moment.
+        reportStarting(s.successfulPlanningTime.begin, s.successfulPlanningTime.threadName)
       case _: TestStatus.Running =>
         ()
 
@@ -174,31 +220,19 @@ class DistageScalatestReporter(
           s.cause.totalTime,
           s"ignored: ${s.checks.toList.niceList()}",
           Exit.Trace.ThrowableTrace(new IntegrationCheckException(s.checks, captureStackTrace = false)),
+          s.cause.endInstant,
+          s.cause.endThreadName,
         )
 
       case s: TestStatus.FailedPlanning =>
-        reportFailure(s.timing.duration, s.failure, Exit.Trace.ThrowableTrace(s.failure))
+        reportFailure(s.timing.duration, s.failure, Exit.Trace.ThrowableTrace(s.failure), timingEnd(s.timing), s.timing.threadName)
 
       case s: TestStatus.Cancelled =>
-        reportCancellation(s.cause.totalTime, s"cancelled: ${s.throwableCause.getMessage}", s.trace)
+        reportCancellation(s.cause.totalTime, s"cancelled: ${s.throwableCause.getMessage}", s.trace, s.cause.endInstant, s.cause.endThreadName)
       case s: TestStatus.Failed =>
-        reportFailure(s.cause.totalTime, s.throwableCause, s.trace)
+        reportFailure(s.cause.totalTime, s.throwableCause, s.trace, s.cause.endInstant, s.cause.endThreadName)
       case s: TestStatus.Succeed =>
-        suiteHandler.doReportEvent(suiteId1)(
-          TestSucceeded(
-            _,
-            suiteName1,
-            suiteId1.suiteId,
-            Some(suiteClassName1),
-            testName,
-            testName,
-            recordedEvents = Vector.empty,
-            duration = Some(s.result.totalTime.toMillis),
-            location = Some(LineInFile(test.test.pos.line, test.test.pos.file, None)),
-            formatter = formatter,
-          )
-        )
-
+        reportSucceeded(s.result.totalTime, s.result.endInstant, s.result.endThreadName)
     }
   }
 

--- a/distage/distage-testkit-scalatest/src/main/scala/org/scalatest/distage/DistageScalatestTestSuiteRunner.scala
+++ b/distage/distage-testkit-scalatest/src/main/scala/org/scalatest/distage/DistageScalatestTestSuiteRunner.scala
@@ -6,7 +6,7 @@ import izumi.distage.testkit.model.DistageTest
 import izumi.distage.testkit.runner.api.TestReporter
 import izumi.distage.testkit.services.scalatest.dstest.DistageTestsRegistrySingleton.RunningSuiteHandle
 import izumi.distage.testkit.services.scalatest.dstest.TestRunnerRuntime.AsyncGlobalSuitesControlHandle
-import izumi.distage.testkit.services.scalatest.dstest.{DistageTestsRegistrySingleton, SafeIntellijTestReporter, TestRunnerRuntime}
+import izumi.distage.testkit.services.scalatest.dstest.{DistageTestsRegistrySingleton, ScalatestLinearizedTestReporter, TestRunnerRuntime}
 import izumi.distage.testkit.spec.AbstractDistageSpec
 import izumi.fundamentals.platform.IzPlatform
 import izumi.fundamentals.platform.console.TrivialLogger
@@ -82,7 +82,7 @@ abstract class DistageScalatestTestSuiteRunner[F[_]](
 
       testsToRun match {
         case Some(tests) =>
-          _doPrepareRunTests(tests, testName, args, status, globalMode, isSbt)
+          _doPrepareRunTests(tests, testName, args, status, globalMode)
         case None =>
         // In global memoization mode: Not the first runner - status will be completed by the actual runner
         // In per-instance mode: This shouldn't happen
@@ -104,7 +104,6 @@ abstract class DistageScalatestTestSuiteRunner[F[_]](
     args: Args,
     status: StatefulStatus,
     globalMode: Boolean,
-    isSbt: Boolean,
   ): Unit = {
     val debugLogger: TrivialLogger = TrivialLogger.make[DistageScalatestTestSuiteRunner[F]](DebugProperties.`izumi.distage.testkit.debug`.name)
 
@@ -137,7 +136,7 @@ abstract class DistageScalatestTestSuiteRunner[F[_]](
       }
     }
 
-    val testReporter = _mkTestReporter(isSbt)
+    val testReporter = _mkTestReporter()
 
     _doRunTests(debugLogger, asyncGlobalSuitesControl, testReporter, testsToRun)
   }
@@ -172,10 +171,16 @@ abstract class DistageScalatestTestSuiteRunner[F[_]](
     }
   }
 
-  protected def _mkTestReporter(isSbt: Boolean): TestReporter = {
+  protected def _mkTestReporter(): TestReporter = {
     val suiteHandler = DistageTestsRegistrySingleton.mkSuiteHandlerById()
     val scalatestReporter = new DistageScalatestReporter(suiteHandler)
-    if (isSbt) scalatestReporter else new SafeIntellijTestReporter(scalatestReporter)
+    // Wrap for BOTH the SBT and the Intellij paths. `ScalatestLinearizedTestReporter`
+    // is required for downstream ScalaTest reporters that pair-walk per-suite events
+    // (JUnitXmlReporter / XmlReporter / DashboardReporter — see the class scaladoc for
+    // exact line numbers) and benefits the Intellij reporter as well. Without this
+    // wrap, intra-suite parallelism (the testkit default,
+    // `parallelTests = Parallelism.Unlimited`) produces silent JUnit XML undercount.
+    new ScalatestLinearizedTestReporter(scalatestReporter)
   }
 
   override def tags: Map[String, Set[String]] = {

--- a/distage/distage-testkit-scalatest/src/main/scala/org/scalatest/distage/DistageScalatestTestSuiteRunner.scala
+++ b/distage/distage-testkit-scalatest/src/main/scala/org/scalatest/distage/DistageScalatestTestSuiteRunner.scala
@@ -4,9 +4,9 @@ import izumi.distage.modules.DefaultModule
 import izumi.distage.testkit.DebugProperties
 import izumi.distage.testkit.model.DistageTest
 import izumi.distage.testkit.runner.api.TestReporter
-import izumi.distage.testkit.services.scalatest.dstest.DistageTestsRegistrySingleton.RunningSuiteHandle
+import izumi.distage.testkit.services.scalatest.dstest.DistageTestsRegistry.RunningSuiteHandle
 import izumi.distage.testkit.services.scalatest.dstest.TestRunnerRuntime.AsyncGlobalSuitesControlHandle
-import izumi.distage.testkit.services.scalatest.dstest.{DistageTestsRegistrySingleton, ScalatestLinearizedTestReporter, TestRunnerRuntime}
+import izumi.distage.testkit.services.scalatest.dstest.{DistageTestsRegistry, DistageTestsRegistrySingleton, ScalatestLinearizedTestReporter, TestRunnerRuntime}
 import izumi.distage.testkit.spec.AbstractDistageSpec
 import izumi.fundamentals.platform.IzPlatform
 import izumi.fundamentals.platform.console.TrivialLogger
@@ -56,18 +56,18 @@ abstract class DistageScalatestTestSuiteRunner[F[_]](
   // create status early, so that runner can set it to `true` even before this test's
   // `run` method is called by scalatest, because all the suite's tests could have
   // already been executed by another suite before this `run` was called
-  private val singletonStatus: StatefulStatus = DistageTestsRegistrySingleton.registerInstantiatedSuite[F](suiteId, this)
+  private val singletonStatus: StatefulStatus = __internal_distageTestRegistry.registerInstantiatedSuite[F](suiteId, this)
 
   override def run(testName: Option[String], args: Args): Status = {
     val status = singletonStatus
 
-    DistageTestsRegistrySingleton.registerSuiteHandle(suiteId)(RunningSuiteHandle(args.tracker, args.reporter))
+    __internal_distageTestRegistry.registerSuiteHandle(suiteId)(RunningSuiteHandle(args.tracker, args.reporter))
 
     // Note: because https://github.com/scalatest/scalatest/pull/2410 has not been merged,
-    // we're forced to keep a separate registration mechanism for non-sbt runners (e.g. Intellij)
+    // we're forced to keep a separate registration mechanism for non-sbt org.scalatest.tools.Runner (used by e.g. Intellij)
     //
     // NON-sbt ScalatestRunner first instantiates ALL tests, THEN calls `.run` method,
-    // so for non-sbt runs we KNOW that all tests have already been registered
+    // so for non-sbt runs we KNOW that all tests have already been registered already
     val isSbt = args.reporter.getClass.getName.contains("org.scalatest.tools.Framework")
 
     val isJVM = !IzPlatform.isScalaJS
@@ -75,7 +75,7 @@ abstract class DistageScalatestTestSuiteRunner[F[_]](
 
     try {
       val testsToRun = if (globalMode) {
-        DistageTestsRegistrySingleton.collectAllTestkitTests(this, isSbt)
+        __internal_distageTestRegistry.collectAllTestkitTests(this, isSbt)
       } else {
         Some(registeredTests())
       }
@@ -131,7 +131,7 @@ abstract class DistageScalatestTestSuiteRunner[F[_]](
       }
       override def completeAllSuitesIfGlobal(): Unit = {
         if (globalMode) {
-          DistageTestsRegistrySingleton.completeAllStatuses()
+          __internal_distageTestRegistry.completeAllStatuses()
         }
       }
     }
@@ -172,7 +172,7 @@ abstract class DistageScalatestTestSuiteRunner[F[_]](
   }
 
   protected def _mkTestReporter(): TestReporter = {
-    val suiteHandler = DistageTestsRegistrySingleton.mkSuiteHandlerById()
+    val suiteHandler = __internal_distageTestRegistry.mkSuiteHandlerById()
     val scalatestReporter = new DistageScalatestReporter(suiteHandler)
     // Wrap for BOTH the SBT and the Intellij paths. `ScalatestLinearizedTestReporter`
     // is required for downstream ScalaTest reporters that pair-walk per-suite events
@@ -182,6 +182,9 @@ abstract class DistageScalatestTestSuiteRunner[F[_]](
     // `parallelTests = Parallelism.Unlimited`) produces silent JUnit XML undercount.
     new ScalatestLinearizedTestReporter(scalatestReporter)
   }
+
+  /** Must return the same instance on every call. */
+  protected def __internal_distageTestRegistry: DistageTestsRegistry = DistageTestsRegistrySingleton
 
   override def tags: Map[String, Set[String]] = {
     org.scalatest.Suite.autoTagClassAnnotations(Map.empty, this)

--- a/distage/distage-testkit-scalatest/src/main/scala/org/scalatest/distage/DistageScalatestTestSuiteRunner.scala
+++ b/distage/distage-testkit-scalatest/src/main/scala/org/scalatest/distage/DistageScalatestTestSuiteRunner.scala
@@ -56,12 +56,12 @@ abstract class DistageScalatestTestSuiteRunner[F[_]](
   // create status early, so that runner can set it to `true` even before this test's
   // `run` method is called by scalatest, because all the suite's tests could have
   // already been executed by another suite before this `run` was called
-  private val singletonStatus: StatefulStatus = __internal_distageTestRegistry.registerInstantiatedSuite[F](suiteId, this)
+  private val singletonStatus: StatefulStatus = _distageTestsRegistry.registerInstantiatedSuite[F](suiteId, this)
 
   override def run(testName: Option[String], args: Args): Status = {
     val status = singletonStatus
 
-    __internal_distageTestRegistry.registerSuiteHandle(suiteId)(RunningSuiteHandle(args.tracker, args.reporter))
+    _distageTestsRegistry.registerSuiteHandle(suiteId)(RunningSuiteHandle(args.tracker, args.reporter))
 
     // Note: because https://github.com/scalatest/scalatest/pull/2410 has not been merged,
     // we're forced to keep a separate registration mechanism for non-sbt org.scalatest.tools.Runner (used by e.g. Intellij)
@@ -75,7 +75,7 @@ abstract class DistageScalatestTestSuiteRunner[F[_]](
 
     try {
       val testsToRun = if (globalMode) {
-        __internal_distageTestRegistry.collectAllTestkitTests(this, isSbt)
+        _distageTestsRegistry.collectAllTestkitTests(this, isSbt)
       } else {
         Some(registeredTests())
       }
@@ -131,7 +131,7 @@ abstract class DistageScalatestTestSuiteRunner[F[_]](
       }
       override def completeAllSuitesIfGlobal(): Unit = {
         if (globalMode) {
-          __internal_distageTestRegistry.completeAllStatuses()
+          _distageTestsRegistry.completeAllStatuses()
         }
       }
     }
@@ -172,7 +172,7 @@ abstract class DistageScalatestTestSuiteRunner[F[_]](
   }
 
   protected def _mkTestReporter(): TestReporter = {
-    val suiteHandler = __internal_distageTestRegistry.mkSuiteHandlerById()
+    val suiteHandler = _distageTestsRegistry.mkSuiteHandlerById()
     val scalatestReporter = new DistageScalatestReporter(suiteHandler)
     // Wrap for BOTH the SBT and the Intellij paths. `ScalatestLinearizedTestReporter`
     // is required for downstream ScalaTest reporters that pair-walk per-suite events
@@ -184,7 +184,7 @@ abstract class DistageScalatestTestSuiteRunner[F[_]](
   }
 
   /** Must return the same instance on every call. */
-  protected def __internal_distageTestRegistry: DistageTestsRegistry = DistageTestsRegistrySingleton
+  protected def _distageTestsRegistry: DistageTestsRegistry = DistageTestsRegistrySingleton
 
   override def tags: Map[String, Set[String]] = {
     org.scalatest.Suite.autoTagClassAnnotations(Map.empty, this)

--- a/distage/distage-testkit-scalatest/src/test/scala/org/scalatest/tools/distagetest/JUnitXmlRegressionTest.scala
+++ b/distage/distage-testkit-scalatest/src/test/scala/org/scalatest/tools/distagetest/JUnitXmlRegressionTest.scala
@@ -64,21 +64,6 @@ import scala.xml.XML
   */
 final class JUnitXmlRegressionTest extends AnyWordSpec {
 
-  /** Per-test sleep duration. `Thread.sleep` is a strict lower bound: it can
-    * overshoot but never returns earlier, so the wall-clock delta observed
-    * across the sleep is always `>= testSleepMillis`. The corresponding
-    * lower bound on the JUnit XML `<testcase time>` field is therefore
-    * exactly `testSleepMillis / 1000.0`.
-    *
-    * `Instant.toEpochMilli` floors toward `-∞`; for a real wall-clock delta
-    * `Δ ms`, the integer ms-difference of two floored timestamps satisfies
-    * `ms_diff > Δ − 1`. So for `Δ >= 2000` we get `ms_diff >= 2000`, and
-    * `JUnitXmlReporter.xmlify` emits exactly `2.0` for `ms_diff = 2000`.
-    *
-    * Sleep length is otherwise arbitrary; 2 s is large enough to make the
-    * single-millisecond clock-tick noise immaterial and small enough not to
-    * dominate the test suite runtime.
-    */
   private val testSleepMillis: Long = 2000L
   private val minExpectedPerTestSeconds: Double = testSleepMillis / 1000.0
 

--- a/distage/distage-testkit-scalatest/src/test/scala/org/scalatest/tools/distagetest/JUnitXmlRegressionTest.scala
+++ b/distage/distage-testkit-scalatest/src/test/scala/org/scalatest/tools/distagetest/JUnitXmlRegressionTest.scala
@@ -1,0 +1,187 @@
+// This test lives in `org.scalatest.tools.distagetest` so it can instantiate
+// `org.scalatest.tools.JUnitXmlReporter`, which is `private[scalatest]`. The test
+// otherwise has no dependency on the package and adds nothing to it.
+package org.scalatest.tools.distagetest
+
+import izumi.distage.testkit.scalatest.SpecIdentity
+import izumi.distage.testkit.services.scalatest.dstest.DistageTestsRegistry
+import org.scalatest.{Args, Tracker}
+import org.scalatest.events.{Ordinal, SuiteCompleted, SuiteStarting}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.tools.JUnitXmlReporter
+import org.scalatest.wordspec.AnyWordSpec
+
+import izumi.fundamentals.platform.files.IzFiles
+
+import java.nio.file.{Files, Path}
+import scala.xml.XML
+
+/** Regression coverage for two distinct silent-failure modes of
+  * `distage-testkit-scalatest`'s integration with ScalaTest's XML reporters:
+  *
+  *   1. If the per-suite event linearizer
+  *      (`ScalatestLinearizedTestReporter`) is bypassed for any reporter
+  *      path while distage's intra-suite parallel test execution
+  *      (`parallelTests = Parallelism.Unlimited`, the default) is in
+  *      effect, the parallel `TestStarting → terminator` events for
+  *      different tests of the same suite interleave. ScalaTest's
+  *      `JUnitXmlReporter.processTest` then encounters a stray test
+  *      event and throws `RuntimeException("unexpected ...")`. Under
+  *      normal SBT/Intellij wiring that exception is swallowed by
+  *      `CatchReporter` and the suite's `TEST-*.xml` file is silently
+  *      never written.
+  *
+  *   2. If distage-testkit's reporter stops populating the explicit
+  *      `timeStamp` field of each ScalaTest `Event` (relying on the
+  *      `(new Date).getTime` case-class default), then for any wrapping
+  *      reporter that batches/serialises events, every event in a
+  *      flushed batch is allocated at the same wall-clock moment.
+  *      `JUnitXmlReporter` derives `<testcase time="...">` from
+  *      `terminator.timeStamp - testStarting.timeStamp`, which then
+  *      collapses to ~0ms regardless of how long the test actually
+  *      took.
+  *
+  * The test runs a small in-process distage-testkit suite with four
+  * parallel sleeping tests through a real `JUnitXmlReporter`, parses
+  * the resulting XML and asserts the minimum properties any correct
+  * implementation must satisfy:
+  *
+  *   - the per-suite `TEST-<suiteId>.xml` file exists and parses;
+  *   - it contains the four named tests we registered;
+  *   - each test's reported `time` is roughly the real sleep wall
+  *     time (with generous slack for CI jitter), not zero.
+  *
+  * Assertions are deliberately lower-bound only; extra tests or
+  * larger times in the XML do not constitute a failure.
+  *
+  * The anonymous inner suite uses a private
+  * [[DistageTestsRegistry]] (via the
+  * [[org.scalatest.distage.DistageScalatestTestSuiteRunner#__internal_distageTestRegistry]]
+  * injection point) so it is fully isolated from the process-wide
+  * [[izumi.distage.testkit.services.scalatest.dstest.DistageTestsRegistrySingleton]]. SBT/ScalaTest only auto-discovers
+  * top-level public suites, so the anonymous inner suite is invisible
+  * to test discovery.
+  */
+final class JUnitXmlRegressionTest extends AnyWordSpec {
+
+  /** Per-test sleep duration. `Thread.sleep` is a strict lower bound: it can
+    * overshoot but never returns earlier, so the wall-clock delta observed
+    * across the sleep is always `>= testSleepMillis`. The corresponding
+    * lower bound on the JUnit XML `<testcase time>` field is therefore
+    * exactly `testSleepMillis / 1000.0`.
+    *
+    * `Instant.toEpochMilli` floors toward `-∞`; for a real wall-clock delta
+    * `Δ ms`, the integer ms-difference of two floored timestamps satisfies
+    * `ms_diff > Δ − 1`. So for `Δ >= 2000` we get `ms_diff >= 2000`, and
+    * `JUnitXmlReporter.xmlify` emits exactly `2.0` for `ms_diff = 2000`.
+    *
+    * Sleep length is otherwise arbitrary; 2 s is large enough to make the
+    * single-millisecond clock-tick noise immaterial and small enough not to
+    * dominate the test suite runtime.
+    */
+  private val testSleepMillis: Long = 2000L
+  private val minExpectedPerTestSeconds: Double = testSleepMillis / 1000.0
+
+  /** WordSpec scope under which the parallel tests are nested. The full test name
+    * reported into JUnit XML is `"$parallelScope should $name"`.
+    */
+  private val parallelScope: String = "intra-suite parallel sleeps"
+
+  private val parallelLeafNames: Seq[String] = Seq(
+    "parallel sleep test 1",
+    "parallel sleep test 2",
+    "parallel sleep test 3",
+    "parallel sleep test 4",
+  )
+
+  private val expectedFullTestNames: Seq[String] = parallelLeafNames.map(n => s"$parallelScope should $n")
+
+  "intra-suite parallel tests must each be reported in JUnit XML with non-zero per-test time" in {
+    val tempDir: Path = Files.createTempDirectory("distage-junit-regression")
+    try {
+      val xmlReporter = new JUnitXmlReporter(tempDir.toAbsolutePath.toString)
+
+      val privateRegistry = new DistageTestsRegistry
+      val leafNames = parallelLeafNames
+      val scopeName = parallelScope
+      val perTestSleep = testSleepMillis
+
+      val suiteUnderTest: SpecIdentity = new SpecIdentity {
+        override protected def __internal_distageTestRegistry: DistageTestsRegistry = privateRegistry
+
+        scopeName should {
+          leafNames.foreach {
+            name =>
+              name in {
+                Thread.sleep(perTestSleep)
+                ()
+              }
+          }
+        }
+      }
+
+      val tracker = new Tracker(new Ordinal(0))
+      val suiteName = suiteUnderTest.suiteName
+      val suiteId = suiteUnderTest.suiteId
+      val suiteClassName = suiteUnderTest.getClass.getName
+
+      // ScalaTest's Framework emits SuiteStarting/SuiteCompleted around `suite.run`.
+      // Because this test invokes `run` directly, those bookend events must be emitted by hand —
+      // JUnitXmlReporter writes the per-suite XML file when it sees SuiteCompleted, and would
+      // fail to locate the matching SuiteStarting if we omitted it.
+      xmlReporter(
+        SuiteStarting(
+          ordinal = tracker.nextOrdinal(),
+          suiteName = suiteName,
+          suiteId = suiteId,
+          suiteClassName = Some(suiteClassName),
+        )
+      )
+
+      val status = suiteUnderTest.run(None, Args(reporter = xmlReporter, tracker = tracker))
+      val succeeded = status.succeeds()
+      assert(succeeded, "the in-process anonymous test suite must succeed before the XML is inspected")
+
+      xmlReporter(
+        SuiteCompleted(
+          ordinal = tracker.nextOrdinal(),
+          suiteName = suiteName,
+          suiteId = suiteId,
+          suiteClassName = Some(suiteClassName),
+        )
+      )
+
+      val xmlFile = tempDir.resolve(s"TEST-$suiteId.xml").toFile
+      assert(
+        xmlFile.exists(),
+        s"JUnit XML file was not produced at ${xmlFile.getAbsolutePath} — the per-suite TEST-*.xml file " +
+        "is silently absent when the linearizer is bypassed and intra-suite parallel events interleave",
+      )
+
+      val xml = XML.loadFile(xmlFile)
+      val reportedTestCount = (xml \ "@tests").text.toInt
+      assert(
+        reportedTestCount >= expectedFullTestNames.size,
+        s"JUnit XML claims $reportedTestCount tests, expected at least ${expectedFullTestNames.size} (test names: ${expectedFullTestNames.mkString(", ")})",
+      )
+
+      val testcases = (xml \ "testcase").map(tc => (tc \ "@name").text -> (tc \ "@time").text.toDouble).toMap
+      expectedFullTestNames.foreach {
+        name =>
+          val time = testcases.getOrElse(
+            name,
+            fail(s"expected <testcase name=\"$name\"> in JUnit XML, found: ${testcases.keys.mkString(", ")}"),
+          )
+          assert(
+            time >= minExpectedPerTestSeconds,
+            s"<testcase name=\"$name\" time=\"$time\"/> is below the minimum $minExpectedPerTestSeconds s — testkit must populate Event timestamps " +
+            "explicitly from its own Timing measurements; relying on the case-class `(new Date).getTime` default collapses " +
+            "per-test times to ~0 under the per-suite event linearizer.",
+          )
+      }
+    } finally {
+      if (Files.exists(tempDir)) IzFiles.erase(tempDir)
+    }
+  }
+
+}


### PR DESCRIPTION
<hr/>

ScalaTest's JUnitXmlReporter, XmlReporter, and DashboardReporter pair-walk per-suite events and throw on interleaved test events from parallelTests=Unlimited; CatchReporter swallows the throw, so the per-suite TEST-*.xml file is silently never written. The same reporters compute per-test time from event.timeStamp arithmetic rather than event.duration, so linearisation alone would collapse JUnit XML durations to ~0 — testkit must supply real timestamps on the events themselves.