### PR TITLE
distage-framework: Log crashes as JSON when JSON logging is enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,12 +16,12 @@ worktrees
 #project/plugins.sbt
 #project/build.properties
 
-
 secrets.tar
 build/project
 .DS_Store
 .metals
 **/metals.sbt
+.codegraph
 .bloop
 .bsp
 .scala-build

--- a/distage/distage-framework/.js/src/main/scala/izumi/distage/roles/launcher/LateLoggerFactory.scala
+++ b/distage/distage-framework/.js/src/main/scala/izumi/distage/roles/launcher/LateLoggerFactory.scala
@@ -1,6 +1,6 @@
 package izumi.distage.roles.launcher
 
-import distage.Lifecycle
+import distage.{Id, Lifecycle}
 import izumi.distage.roles.launcher.LoggerConfigLoader.DeclarativeLoggerConfig
 import izumi.fundamentals.platform.functional.Identity
 import izumi.logstage.api.logger.{LogQueue, LogRouter}
@@ -14,11 +14,14 @@ object LateLoggerFactory {
   class LateLoggerFactoryImpl(
     routerFactory: RouterFactory,
     buffer: LogQueue,
+    setupStaticLogRouter: Boolean @Id("distage.roles.logs.static-log-router"),
   ) extends LateLoggerFactory {
     def makeLateLogRouter(config: DeclarativeLoggerConfig): Lifecycle[Identity, LogRouter] = {
       Lifecycle.liftF[Identity, LogRouter] {
         val router = routerFactory.createRouter(config, buffer)
-        StaticLogRouter.instance.setup(router)
+        if (setupStaticLogRouter) {
+          StaticLogRouter.instance.setup(router)
+        }
         router
       }
     }

--- a/distage/distage-framework/.jvm/src/main/scala/izumi/distage/roles/launcher/LateLoggerFactory.scala
+++ b/distage/distage-framework/.jvm/src/main/scala/izumi/distage/roles/launcher/LateLoggerFactory.scala
@@ -1,6 +1,6 @@
 package izumi.distage.roles.launcher
 
-import distage.Lifecycle
+import distage.{Id, Lifecycle}
 import izumi.distage.roles.launcher.LoggerConfigLoader.DeclarativeLoggerConfig
 import izumi.fundamentals.platform.functional.Identity
 import izumi.logstage.adapter.jul.LogstageJulLogger
@@ -17,12 +17,15 @@ object LateLoggerFactory {
   class LateLoggerFactoryImpl(
     routerFactory: RouterFactory,
     buffer: LogQueue,
+    setupStaticLogRouter: Boolean @Id("distage.roles.logs.static-log-router"),
   ) extends LateLoggerFactory {
     def makeLateLogRouter(config: DeclarativeLoggerConfig): Lifecycle[Identity, LogRouter] = {
       for {
         router <- Lifecycle.liftF[Identity, LogRouter] {
           val router = routerFactory.createRouter(config, buffer)
-          StaticLogRouter.instance.setup(router)
+          if (setupStaticLogRouter) {
+            StaticLogRouter.instance.setup(router)
+          }
           router
         }
         _ <-

--- a/distage/distage-framework/.jvm/src/test/scala/izumi/distage/roles/test/RoleAppTest.scala
+++ b/distage/distage-framework/.jvm/src/test/scala/izumi/distage/roles/test/RoleAppTest.scala
@@ -22,8 +22,9 @@ import izumi.fundamentals.platform.functional.Identity
 import izumi.fundamentals.platform.os.{IzOs, OsType}
 import izumi.fundamentals.platform.resources.ArtifactVersion
 import izumi.fundamentals.platform.versions.Version
-import izumi.logstage.api.IzLogger
 import izumi.logstage.api.logger.LogSink
+import izumi.logstage.api.routing.StaticLogRouter
+import izumi.logstage.api.{IzLogger, Log}
 import org.scalatest.wordspec.AnyWordSpec
 
 import java.io.{File, OutputStream, PrintStream}
@@ -624,32 +625,49 @@ class RoleAppTest extends AnyWordSpec with WithProperties {
     }
 
     "TerminatingHandler reports error when exiting if an exception interrupts provisioning" in {
-      val oldErr = System.err
-      val errBuf = ByteBuffer.allocate(10 * 1024 * 1024)
-      val interceptErr = new PrintStream(
-        new OutputStream {
-          override def write(b: Int): Unit = {
-            oldErr.write(b)
-            try errBuf.put(b.toByte)
-            catch { case _: BufferOverflowException => () }
-            ()
-          }
-        },
-        true,
-      )
-      try {
-        System.setErr(interceptErr)
+      val errString = captureStderr {
         intercept[ProvisioningException] {
           Fixture3.TestRoleAppMain.main(Array("--ignore-all-reference-configs", ":fixture3"))
         }
-      } finally {
-        System.setErr(oldErr)
       }
-      errBuf.flip()
-      val errString = new String(errBuf.array(), errBuf.arrayOffset(), errBuf.limit(), StandardCharsets.UTF_8)
       assert(errString.contains("""Couldn't read configuration at path="basicConfig""""))
       // error appears only once
       assert(errString.indexOf("""Couldn't read configuration at path="basicConfig"""") == errString.lastIndexOf("""Couldn't read configuration at path="basicConfig""""))
+    }
+
+    "report a fatal provisioning failure through the application's late log router as a structured error entry" in {
+      // basicConfig is decoded during planning, after the late logger is built, so the crash is reported via the late router
+      val sink = new CapturingFixture3Sink
+      intercept[ProvisioningException] {
+        new CapturingFixture3Main(sink).main(Array("--ignore-all-reference-configs", ":fixture3"))
+      }
+      assertCrashLogged(sink.fetch(), "basicConfig")
+    }
+
+    "report a fatal failure occurring before the late logger through the early log router as a structured error entry" in {
+      // a missing explicit config fails config loading before the late logger exists, so the crash is reported via the early router
+      val sink = new CapturingFixture3Sink
+      intercept[ProvisioningException] {
+        new CapturingFixture3Main(sink).main(Array("-c", "/nonexistent-config-for-test-xyz.conf", ":fixture3"))
+      }
+      assertCrashLogged(sink.fetch(), "Cannot load configuration")
+    }
+
+    "gate global StaticLogRouter registration behind the static-log-router flag" in {
+      // default (flag on): a successful app run (re)registers its router in the process-global StaticLogRouter
+      val beforeDefault = StaticLogRouter.instance.get()
+      TestEntrypoint.main(Array("-ll", logLevel, ":" + ConfigTestRole.id))
+      assert(StaticLogRouter.instance.get() ne beforeDefault)
+
+      // flag off: the app must leave the global router untouched (isolated from process-global state)
+      withProperties(
+        DebugProperties.`izumi.distage.roles.logs.static-log-router`.name -> "false"
+      ) {
+        val before = StaticLogRouter.instance.get()
+        TestEntrypoint.main(Array("-ll", logLevel, ":" + ConfigTestRole.id))
+        assert(StaticLogRouter.instance.get() eq before)
+        ()
+      }
     }
 
     "LogIO2 binding is available in LauncherBIO for ZIO & MonixBIO" in {
@@ -663,6 +681,50 @@ class RoleAppTest extends AnyWordSpec with WithProperties {
 //        new StaticTestMainLogIO2[monix.bio.IO].main(Array("-ll", logLevel, "-c", checkTestGoodRes, ":" + StaticTestRole.id))
       }
     }
+  }
+
+  // Asserts the fatal failure was recorded as a structured error entry carrying the failure cause, rather than only
+  // reaching stderr as an unstructured stacktrace.
+  private def assertCrashLogged(entries: Seq[Log.Entry], causeSubstring: String): Unit = {
+    val crash = entries.find {
+      e =>
+        e.context.dynamic.level == Log.Level.Error &&
+        e.message.template.parts.mkString("").contains("Application failed to boot")
+    }
+    assert(crash.isDefined, s"expected a fatal-failure error entry; recorded levels=${entries.map(_.context.dynamic.level).toList}")
+    val cause = crash.flatMap(_.firstThrowable)
+    assert(
+      cause.exists(t => Option(t.getMessage).exists(_.contains(causeSubstring))),
+      s"crash entry must carry the failure cause containing '$causeSubstring'; got=${cause.map(_.getMessage)}",
+    )
+    ()
+  }
+
+  // Captures stderr for the duration of `body`, teeing to the real stderr. `System.setErr` is process-global, so this
+  // synchronizes on a JVM-wide lock: concurrently-running suites that capture stderr serialize instead of corrupting
+  // each other's redirection (ScalaTest runs suites in parallel by default).
+  private def captureStderr(body: => Any): String = RoleAppTest.stderrCaptureLock.synchronized {
+    val oldErr = System.err
+    val errBuf = ByteBuffer.allocate(10 * 1024 * 1024)
+    val interceptErr = new PrintStream(
+      new OutputStream {
+        override def write(b: Int): Unit = {
+          oldErr.write(b)
+          try errBuf.put(b.toByte)
+          catch { case _: BufferOverflowException => () }
+          ()
+        }
+      },
+      true,
+    )
+    try {
+      System.setErr(interceptErr)
+      val _ = body
+    } finally {
+      System.setErr(oldErr)
+    }
+    errBuf.flip()
+    new String(errBuf.array(), errBuf.arrayOffset(), errBuf.limit(), StandardCharsets.UTF_8)
   }
 
   private def cfg(role: String, version: ArtifactVersion): File = {
@@ -705,4 +767,9 @@ class RoleAppTest extends AnyWordSpec with WithProperties {
       }
     }
   }
+}
+
+object RoleAppTest {
+  // process-global lock guarding `System.setErr` redirection across concurrently-running suites
+  private val stderrCaptureLock = new AnyRef
 }

--- a/distage/distage-framework/src/main/scala/izumi/distage/framework/services/ModuleProvider.scala
+++ b/distage/distage-framework/src/main/scala/izumi/distage/framework/services/ModuleProvider.scala
@@ -72,6 +72,7 @@ object ModuleProvider {
     shutdownInitiator: AppShutdownInitiator,
     appArtifact: Option[IzArtifact] @Id("app.artifact"),
     roleAppLocator: Option[LocatorRef] @Id("roleapp"),
+    setupStaticLogRouter: Boolean @Id("distage.roles.logs.static-log-router"),
   ) extends ModuleProvider {
 
     def bootstrapModules(): Seq[BootstrapModule] = {
@@ -83,7 +84,7 @@ object ModuleProvider {
         make[Option[IzArtifact]].named("app.artifact").fromValue(appArtifact).exposed
       }
 
-      val loggerModule = new LogstageModule(logRouter, true)
+      val loggerModule = new LogstageModule(logRouter, setupStaticLogRouter)
 
       val platformModule = new BootstrapPlatformModule(options)
 

--- a/distage/distage-framework/src/main/scala/izumi/distage/roles/DebugProperties.scala
+++ b/distage/distage-framework/src/main/scala/izumi/distage/roles/DebugProperties.scala
@@ -35,6 +35,14 @@ object DebugProperties extends properties.DebugProperties {
   final val `izumi.distage.roles.logs.json` = BoolProperty("izumi.distage.roles.logs.json")
 
   /**
+    * Register the application's `LogRouter` in the process-global [[izumi.logstage.api.routing.StaticLogRouter]]
+    * (required for slf4j support).
+    *
+    * Default: `true`
+    */
+  final val `izumi.distage.roles.logs.static-log-router` = BoolProperty("izumi.distage.roles.logs.static-log-router")
+
+  /**
     * Include reference role configs as fallback configs if an explicit role config is passed on the command-line.
     *
     * If `false`, explicit role config fully replaces reference role configs instead of overriding them.

--- a/distage/distage-framework/src/main/scala/izumi/distage/roles/RoleAppBootLoggerModule.scala
+++ b/distage/distage-framework/src/main/scala/izumi/distage/roles/RoleAppBootLoggerModule.scala
@@ -1,34 +1,50 @@
 package izumi.distage.roles
 
 import izumi.distage.config.model.AppConfig
-import izumi.distage.model.definition.ModuleDef
+import izumi.distage.model.definition.{Id, ModuleDef}
 import izumi.distage.roles.launcher.*
 import izumi.logstage.api.logger.{LogQueue, LogRouter}
+import izumi.logstage.api.routing.StaticLogRouter
 import izumi.logstage.api.{IzLogger, Log}
 import logstage.ThreadingLogQueue
 
-class RoleAppBootLoggerModule() extends ModuleDef {
+class RoleAppBootLoggerModule(
+  crashLogRouterRef: Option[CrashLogRouterRef]
+) extends ModuleDef {
+  make[Option[CrashLogRouterRef]].fromValue(crashLogRouterRef)
+
   make[EarlyLoggerFactory].from[EarlyLoggerFactory.EarlyLoggerFactoryImpl]
-
-  make[LoggerConfigLoader].from[LoggerConfigLoader.LogConfigLoaderImpl]
-  make[RouterFactory].from[RouterFactory.RouterFactoryConsoleSinkImpl]
-  make[LogQueue].fromResource(ThreadingLogQueue.resource())
-
   make[Log.Level].named("early").fromValue(Log.Level.Info)
   make[IzLogger].named("early").from {
-    (factory: EarlyLoggerFactory, banner: StartupBanner) =>
+    (
+      factory: EarlyLoggerFactory,
+      banner: StartupBanner,
+      crashLogRouterRef: Option[CrashLogRouterRef],
+      setupStaticLogRouter: Boolean @Id("distage.roles.logs.static-log-router"),
+    ) =>
       val logger = factory.makeEarlyLogger()
+      crashLogRouterRef.foreach(_.set(logger.router))
+      if (setupStaticLogRouter) {
+        StaticLogRouter.instance.setup(logger.router)
+      }
       banner.showBanner(logger)
       logger
   }
 
+  make[LoggerConfigLoader].from[LoggerConfigLoader.LogConfigLoaderImpl]
+  make[RouterFactory].from[RouterFactory.RouterFactoryConsoleSinkImpl]
+  make[LogQueue].fromResource(ThreadingLogQueue.resource())
   make[LateLoggerFactory].from[LateLoggerFactory.LateLoggerFactoryImpl]
   make[LoggerConfigLoader.DeclarativeLoggerConfig].from {
     (loader: LoggerConfigLoader, config: AppConfig) =>
       loader.loadLoggingConfig(config)
   }
   make[LogRouter].fromResource {
-    (factory: LateLoggerFactory, config: LoggerConfigLoader.DeclarativeLoggerConfig) =>
-      factory.makeLateLogRouter(config)
+    (factory: LateLoggerFactory, config: LoggerConfigLoader.DeclarativeLoggerConfig, crashLogRouterRef: Option[CrashLogRouterRef]) =>
+      factory.makeLateLogRouter(config).map {
+        router =>
+          crashLogRouterRef.foreach(_.set(router))
+          router
+      }
   }
 }

--- a/distage/distage-framework/src/main/scala/izumi/distage/roles/RoleAppBootModule.scala
+++ b/distage/distage-framework/src/main/scala/izumi/distage/roles/RoleAppBootModule.scala
@@ -51,8 +51,9 @@ class RoleAppBootModule[F[_]: TagK: DefaultModule](
   bootstrapPluginConfig: PluginConfig,
   appArtifact: IzArtifact,
   unusedValidAxisChoices: Set[Axis.AxisChoice],
+  crashLogRouterRef: Option[CrashLogRouterRef],
 ) extends ModuleDef {
-  include(new RoleAppBootPlatformModule())
+  include(new RoleAppBootPlatformModule(crashLogRouterRef))
 
   addImplicit[TagK[F]]
   addImplicit[DefaultModule[F]]
@@ -103,6 +104,7 @@ class RoleAppBootModule[F[_]: TagK: DefaultModule](
   make[Activation].named("additional").fromValue(Activation.empty)
 
   make[Boolean].named("distage.roles.logs.json").from(DebugProperties.`izumi.distage.roles.logs.json`.boolValue(default = false))
+  make[Boolean].named("distage.roles.logs.static-log-router").from(DebugProperties.`izumi.distage.roles.logs.static-log-router`.boolValue(default = true))
   make[Boolean].named("distage.roles.ignore-mismatched-effect").from(DebugProperties.`izumi.distage.roles.ignore-mismatched-effect`.boolValue(default = false))
   make[Boolean].named("distage.roles.activation.ignore-unknown").from(DebugProperties.`izumi.distage.roles.activation.ignore-unknown`.boolValue(default = false))
   make[Boolean].named("distage.roles.activation.warn-unset").from(DebugProperties.`izumi.distage.roles.activation.warn-unset`.boolValue(default = true))

--- a/distage/distage-framework/src/main/scala/izumi/distage/roles/RoleAppBootPlatformModule.scala
+++ b/distage/distage-framework/src/main/scala/izumi/distage/roles/RoleAppBootPlatformModule.scala
@@ -3,11 +3,13 @@ package izumi.distage.roles
 import izumi.distage.config.model.AppConfig
 import izumi.distage.framework.services.ConfigLoader
 import izumi.distage.model.definition.ModuleDef
-import izumi.distage.roles.launcher.RoleProvider
+import izumi.distage.roles.launcher.{CrashLogRouterRef, RoleProvider}
 
-class RoleAppBootPlatformModule() extends ModuleDef {
+class RoleAppBootPlatformModule(
+  crashLogRouterRef: Option[CrashLogRouterRef]
+) extends ModuleDef {
   include(new RoleAppBootConfigModule())
-  include(new RoleAppBootLoggerModule())
+  include(new RoleAppBootLoggerModule(crashLogRouterRef))
 
   make[RoleProvider].from[RoleProvider.NonReflectiveImpl]
   make[AppConfig].from {

--- a/distage/distage-framework/src/main/scala/izumi/distage/roles/RoleAppMain.scala
+++ b/distage/distage-framework/src/main/scala/izumi/distage/roles/RoleAppMain.scala
@@ -9,7 +9,7 @@ import izumi.distage.modules.{DefaultModule, DefaultModule2}
 import izumi.distage.plugins.PluginConfig
 import izumi.distage.roles.RoleAppMain.ArgV
 import izumi.distage.roles.launcher.AppResourceProvider.AppResource
-import izumi.distage.roles.launcher.{AppFailureHandler, AppShutdownStrategy}
+import izumi.distage.roles.launcher.{AppFailureHandler, AppShutdownStrategy, CrashLogRouterRef}
 import izumi.functional.lifecycle.Lifecycle
 import izumi.functional.quasi.QuasiIO
 import izumi.fundamentals.platform.IzPlatform
@@ -17,9 +17,12 @@ import izumi.fundamentals.platform.cli.model.schema.ParserDef
 import izumi.fundamentals.platform.cli.model.{RequiredRoles, RoleArgs}
 import izumi.fundamentals.platform.functional.Identity
 import izumi.fundamentals.platform.resources.IzArtifactMaterializer
+import izumi.logstage.api.IzLogger
+import izumi.logstage.api.logger.LogRouter
 import izumi.logstage.distage.LogIO2Module
 import izumi.reflect.{TagK, TagKK}
 
+import java.util.concurrent.atomic.AtomicReference
 import scala.annotation.unused
 
 /**
@@ -84,13 +87,18 @@ abstract class RoleAppMain[F[_]](
 
   def main(args: Array[String]): RoleAppMainPlatformSpecific.MainEffect[Unit] = {
     val argv = ArgV(args)
+    val crashLogRouterRef = new CrashLogRouterRef(new AtomicReference(Option.empty[LogRouter]))
     try {
-      Injector.NoProxies[Identity]().produceRun(roleAppBootModule(argv)) {
+      Injector.NoProxies[Identity]().produceRun(roleAppBootModule(argv, RequiredRoles(requiredRoles(argv)), Some(crashLogRouterRef))) {
         (appResource: AppResource[F]) =>
           appResource.resource.use(_.run())
       }
     } catch {
       case t: Throwable =>
+        crashLogRouterRef.get.foreach {
+          router =>
+            IzLogger(router).error(s"Application failed to boot, exiting: ${t -> "error"}")
+        }
         earlyFailureHandler(argv).onError(t)
         RoleAppMainPlatformSpecific.failedMain(t)
     }
@@ -155,24 +163,24 @@ abstract class RoleAppMain[F[_]](
     roleAppBootModule(ArgV.empty)
   }
 
-  def roleAppBootModule(argv: ArgV): Module = {
-    val mainModule = roleAppBootModule(argv, RequiredRoles(requiredRoles(argv)))
-    val overrideModule = roleAppBootOverrides(argv)
-    mainModule overriddenBy overrideModule
+  final def roleAppBootModule(argv: ArgV): Module = {
+    roleAppBootModule(argv, RequiredRoles(requiredRoles(argv)), None)
   }
 
   /** @see [[izumi.distage.roles.RoleAppBootModule]] for initial values */
-  def roleAppBootModule(argv: ArgV, additionalRoles: RequiredRoles): Module = {
-    new RoleAppBootModule[F](
+  def roleAppBootModule(argv: ArgV, additionalRoles: RequiredRoles, crashLogRouterRef: Option[CrashLogRouterRef]): Module = {
+    val mainModule = new RoleAppBootModule[F](
       shutdownStrategy = shutdownStrategy,
       pluginConfig = pluginConfig,
       bootstrapPluginConfig = bootstrapPluginConfig,
       appArtifact = artifact.get,
-      unusedValidAxisChoices,
+      unusedValidAxisChoices = unusedValidAxisChoices,
+      crashLogRouterRef = crashLogRouterRef,
     ) ++ new RoleAppBootArgsModule(
       args = argv,
       requiredRoles = additionalRoles,
     )
+    mainModule overriddenBy roleAppBootOverrides(argv)
   }
 
   protected def earlyFailureHandler(@unused args: ArgV): AppFailureHandler = {

--- a/distage/distage-framework/src/main/scala/izumi/distage/roles/launcher/CrashLogRouterRef.scala
+++ b/distage/distage-framework/src/main/scala/izumi/distage/roles/launcher/CrashLogRouterRef.scala
@@ -1,0 +1,15 @@
+package izumi.distage.roles.launcher
+
+import izumi.logstage.api.logger.LogRouter
+
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+  * Per-application holder of the most-recently-initialized application `LogRouter`, used by
+  * [[izumi.distage.roles.RoleAppMain.main]] to report a fatal failure through the configured (format-resolved)
+  * router after the boot graph has been torn down.
+  */
+final class CrashLogRouterRef(ref: AtomicReference[Option[LogRouter]]) {
+  def set(router: LogRouter): Unit = ref.set(Some(router))
+  def get: Option[LogRouter] = ref.get()
+}

--- a/distage/distage-framework/src/test/scala/izumi/distage/roles/test/fixtures/CapturingFixture3Main.scala
+++ b/distage/distage-framework/src/test/scala/izumi/distage/roles/test/fixtures/CapturingFixture3Main.scala
@@ -1,0 +1,38 @@
+package izumi.distage.roles.test.fixtures
+
+import izumi.distage.model.definition.{Module, ModuleDef}
+import izumi.distage.plugins.PluginConfig
+import izumi.distage.roles.RoleAppMain
+import izumi.distage.roles.launcher.LoggerConfigLoader.DeclarativeLoggerConfig
+import izumi.distage.roles.launcher.{AppFailureHandler, EarlyLoggerFactory, RouterFactory}
+import izumi.logstage.api.logger.{LogQueue, LogSink}
+import izumi.logstage.api.routing.ConfigurableLogRouter
+import izumi.logstage.api.{IzLogger, Log}
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import scala.jdk.CollectionConverters.*
+
+// In-memory accumulating sink (cf. izumi.logstage.api.TestSink) — records entries so a fatal failure can be matched
+// against recorded structured output instead of a global stdout capture.
+final class CapturingFixture3Sink extends LogSink {
+  private val entries = new ConcurrentLinkedQueue[Log.Entry]()
+  override def flush(e: Log.Entry): Unit = { entries.add(e); () }
+  def fetch(): Seq[Log.Entry] = entries.asScala.toSeq
+}
+
+// Fixture3 launcher that routes both the early and late loggers to the given sink via roleAppBootOverrides.
+final class CapturingFixture3Main(sink: LogSink) extends RoleAppMain.LauncherIdentity {
+  override protected def pluginConfig: PluginConfig = PluginConfig.cached("com.github.pshirshov.test3.plugins")
+  override protected def bootstrapPluginConfig: PluginConfig = PluginConfig.cached("com.github.pshirshov.test3.bootstrap")
+  override protected def earlyFailureHandler(args: RoleAppMain.ArgV): AppFailureHandler =
+    new AppFailureHandler.TerminatingHandler(sysExit = _ => ())
+  override protected def roleAppBootOverrides(argv: RoleAppMain.ArgV): Module = new ModuleDef {
+    make[EarlyLoggerFactory].fromValue(new EarlyLoggerFactory {
+      override def makeEarlyLogger(): IzLogger = IzLogger(sink = sink)
+    })
+    make[RouterFactory].fromValue(new RouterFactory {
+      override def createRouter(config: DeclarativeLoggerConfig, buffer: LogQueue): ConfigurableLogRouter =
+        ConfigurableLogRouter(config.rootLevel, Seq(sink), buffer)
+    })
+  }
+}

--- a/distage/distage-testkit-core/.js/src/main/scala/izumi/distage/testkit/runner/impl/services/BootstrapFactory.scala
+++ b/distage/distage-testkit-core/.js/src/main/scala/izumi/distage/testkit/runner/impl/services/BootstrapFactory.scala
@@ -5,6 +5,7 @@ import izumi.distage.framework.config.PlanningOptions
 import izumi.distage.framework.model.ActivationInfo
 import izumi.distage.framework.services.{ConfigLoader, ModuleProvider}
 import izumi.distage.model.definition.Activation
+import izumi.distage.roles.DebugProperties
 import izumi.distage.roles.launcher.AppShutdownInitiator
 import izumi.distage.roles.model.meta.RolesInfo
 import izumi.fundamentals.platform.cli.model.RoleAppArgs
@@ -56,6 +57,7 @@ object BootstrapFactory {
         shutdownInitiator = AppShutdownInitiator.empty,
         roleAppLocator = None,
         appArtifact = None,
+        setupStaticLogRouter = DebugProperties.`izumi.distage.roles.logs.static-log-router`.boolValue(true),
       )
     }
   }

--- a/distage/distage-testkit-core/.jvm/src/main/scala/izumi/distage/testkit/runner/impl/services/BootstrapFactory.scala
+++ b/distage/distage-testkit-core/.jvm/src/main/scala/izumi/distage/testkit/runner/impl/services/BootstrapFactory.scala
@@ -7,6 +7,7 @@ import izumi.distage.framework.model.ActivationInfo
 import izumi.distage.framework.services.ConfigMerger.ConfigMergerImpl
 import izumi.distage.framework.services.{ConfigFilteringStrategy, ConfigLoader, ConfigLoaderArgs, ConfigLocationProvider, ModuleProvider}
 import izumi.distage.model.definition.Activation
+import izumi.distage.roles.DebugProperties
 import izumi.distage.roles.launcher.AppShutdownInitiator
 import izumi.distage.roles.model.meta.RolesInfo
 import izumi.fundamentals.platform.cli.model.RoleAppArgs
@@ -73,6 +74,7 @@ object BootstrapFactory {
         shutdownInitiator = AppShutdownInitiator.empty,
         roleAppLocator = None,
         appArtifact = None,
+        setupStaticLogRouter = DebugProperties.`izumi.distage.roles.logs.static-log-router`.boolValue(true),
       )
     }
   }


### PR DESCRIPTION
Use object graph produced LogRouter to report crashes

Also make StaticLogRouter installation configurable